### PR TITLE
feat(github-pr-triage): output thread and comment IDs directly

### DIFF
--- a/skills/github-pr-triage/SKILL.md
+++ b/skills/github-pr-triage/SKILL.md
@@ -45,6 +45,7 @@ description: |-
    - The report MUST group associated comments and CI failures into cohesive action items (you may cluster multiple related comments or failures together if they address the same problem).
    - For each action item/group, include:
      - **Summary of Feedback/Failure**: A concise summary of the reviewer comment(s) or CI failure(s), including direct markdown links back to the comments/checks on GitHub. When linking to comments, use a descriptive link that includes both the comment number and the GitHub username of the reviewer (e.g. `[Comment #1 by @reviewer_username](url)`).
+     - **Thread & Comment Identifiers (For Comments)**: Explicitly preserve the `Thread ID` (e.g. `PRRT_...`) and `Comment ID` (e.g. `3438780787`) from the comment header in `raw_triage_output.md` under each action item so Step 8 (`gh api`) has immediate access to both parameters without extra API lookups.
      - **Agent Assessment (For Comments)**:
        - **Agreement Level**: A short indicator of your agreement using one of these categories:
          * `🔥 Urgent` (Critical fix for a crash, bug, or CI blocker; we should fix immediately)

--- a/skills/github-pr-triage/bin/triage.dart
+++ b/skills/github-pr-triage/bin/triage.dart
@@ -337,7 +337,8 @@ void main(List<String> args) async {
 
         final threadId = thread['id']?.toString() ?? 'Unknown Thread';
         final firstComment = commentsList.first;
-        final commentDbId = firstComment['databaseId']?.toString() ?? '';
+        final commentDbId =
+            firstComment['databaseId']?.toString() ?? 'Unknown Comment';
         final path = firstComment['path'] ?? 'Unknown File';
         final line =
             firstComment['line'] ?? firstComment['originalLine'] ?? 'N/A';

--- a/skills/github-pr-triage/bin/triage.dart
+++ b/skills/github-pr-triage/bin/triage.dart
@@ -213,9 +213,11 @@ void main(List<String> args) async {
         pullRequest(number: $pr) {
           reviewThreads(first: 100) {
             nodes {
+              id
               isResolved
               comments(first: 100) {
                 nodes {
+                  databaseId
                   author { login }
                   body
                   path
@@ -333,7 +335,9 @@ void main(List<String> args) async {
             thread['comments']?['nodes'] as List<dynamic>? ?? [];
         if (commentsList.isEmpty) continue;
 
+        final threadId = thread['id']?.toString() ?? 'Unknown Thread';
         final firstComment = commentsList.first;
+        final commentDbId = firstComment['databaseId']?.toString() ?? '';
         final path = firstComment['path'] ?? 'Unknown File';
         final line =
             firstComment['line'] ?? firstComment['originalLine'] ?? 'N/A';
@@ -351,7 +355,7 @@ void main(List<String> args) async {
             .join('\n\n');
 
         report.write('''
-### Comment #${i + 1}: `$path` (Line $line)
+### Comment #${i + 1} (Thread `$threadId`, Comment `$commentDbId`): `$path` (Line $line)
 Link: $url
 
 $commentsMarkdown


### PR DESCRIPTION
### Summary
Updates `github-pr-triage` to enable deterministic GraphQL thread resolutions and replies with zero extra API roundtrips.

### Changes
- **triage.dart**: Requests `id` inside `reviewThreads` and `databaseId` inside `comments`, formatting them directly into markdown comment headers.
- **SKILL.md**: Instructs agents in Step 5 (`pr_triage_report.md` generation) to preserve both identifiers so Step 8 (`gh api`) has immediate access to them.