### PR TITLE
feat(triage,pr-loop): instruct agents to never guess PR/branch and exit on ambiguity

### DIFF
--- a/skills/github-pr-triage/SKILL.md
+++ b/skills/github-pr-triage/SKILL.md
@@ -35,6 +35,13 @@ description: |-
 
 ## How to use this skill (The Workflow)
 
+- **NEVER GUESS Target PR or Branch**: If the target PR number or branch is not
+  explicitly provided by the user, and the current git workspace state is on a
+  trunk branch (`main`/`master`), in detached HEAD state, or matches multiple
+  open PRs, **DO NOT GUESS**. The agent MUST pause execution and explicitly ask
+  the user (using `ask_question` or chat) to clarify which PR or branch to
+  target before taking action.
+
 1. **Run the Triage Script**:
    Execute the `triage.dart` helper script using the `run_command` tool.
    Use the `--dir` (or `-C`) option to specify the path to the target

--- a/skills/github-pr-triage/bin/triage.dart
+++ b/skills/github-pr-triage/bin/triage.dart
@@ -115,14 +115,28 @@ void main(List<String> args) async {
         '--json',
         'number,url',
       ], workingDirectory: workingDir);
-      final listJson = jsonDecode(listOutput) as List<dynamic>;
+      final decodedList = jsonDecode(listOutput);
+      final listJson = decodedList is List<dynamic> ? decodedList : const [];
       if (listJson.isEmpty) {
         stderr.writeln(
-          'No open PR found for branch "$branch". Please specify a PR number or URL.',
+          'Error: Ambiguous context. No open PR found for branch "$branch". '
+          'Do not guess. Please explicitly ask the user for a PR number or URL.',
         );
         exit(1);
       }
-      prNumber = listJson[0]['number'].toString();
+      if (listJson.length > 1) {
+        stderr.writeln(
+          'Error: Ambiguous context. Multiple open PRs found for branch "$branch". '
+          'Do not guess. Please explicitly ask the user which PR number or URL to target.',
+        );
+        exit(1);
+      }
+      final firstPr = listJson[0];
+      if (firstPr is! Map || firstPr['number'] == null) {
+        stderr.writeln('Error: Unexpected PR data format from "gh pr list".');
+        exit(1);
+      }
+      prNumber = firstPr['number'].toString();
     }
 
     // 3. Resolve owner and repo for context.

--- a/skills/pr-loop/SKILL.md
+++ b/skills/pr-loop/SKILL.md
@@ -20,6 +20,11 @@ automated AI code review bot (such as `gemini-code-assist`,
 
 ## 🔓 Upfront VCS Authorization & Safeguards
 
+- **NEVER GUESS Target PR or Branch**: Agents MUST NEVER guess the target
+  branch or pull request. If the active local branch or PR is ambiguous,
+  unclear, or not explicitly confirmed by the user, the agent MUST pause and
+  explicitly ask the user for clarification before initiating the loop or
+  executing any git pushes or gh commands.
 - **Request Blanket Upfront Consent**: When initiating `pr-loop`, the agent MUST
   first confirm the target feature branch and remote with the user in its
   opening message, requesting blanket consent for autonomous commits and pushes


### PR DESCRIPTION
Resolves #15 by adding explicit ambiguity checks and rules prohibiting branch/PR guessing.