### PR TITLE
feat(skills): add just_brainstorm, what_if, and quick_question skills

### DIFF
--- a/skills/just_brainstorm/SKILL.md
+++ b/skills/just_brainstorm/SKILL.md
@@ -39,8 +39,8 @@ Examples of trigger phrases:
 
 ### 2. Mandatory Artifact Generation
 - The output of this skill **MUST be saved as an artifact** (`.md` file in the
-  conversation artifacts directory) so the user can easily review, share, and
-  comment on specific sections.
+  conversation artifacts directory using the `write_to_file` tool) so the user
+  can easily review, share, and comment on specific sections.
 - Format the artifact clearly with headers, options tables, and pros/cons
   breakdowns.
 

--- a/skills/just_brainstorm/SKILL.md
+++ b/skills/just_brainstorm/SKILL.md
@@ -19,9 +19,10 @@ Examples of trigger phrases:
 
 ## Critical Rule: Zero Code Changes Allowed
 
-- **NO FILE EDITS OR CREATION**: Under no circumstances should you edit
+- **NO CODEBASE FILE EDITS OR CREATION**: Under no circumstances should you edit
   existing project files, write new implementation code, or modify repository
-  state.
+  state. (Note: Writing the mandatory design artifact using `write_to_file` as
+  described in the workflow below is the only permitted file creation).
 - **READ-ONLY INSPECTION IS ALLOWED**: You are fully authorized and encouraged
   to inspect the codebase using read-only tools (`grep_search`, `view_file`,
   `list_dir`) to understand the current architecture and ground your

--- a/skills/just_brainstorm/SKILL.md
+++ b/skills/just_brainstorm/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: just_brainstorm
+description: |-
+  Brainstorm architectural designs, explore potential solutions, and weigh
+  implementation tradeoffs collaboratively without making code changes.
+---
+
+## When to use this skill
+
+Activate this skill when the user asks to brainstorm, explore design ideas,
+discuss potential solutions, or outline architecture before committing to
+execution.
+
+Examples of trigger phrases:
+- "Let me brainstorm..."
+- "Just brainstorming here..."
+- "What are some ways we could solve..."
+- "Help me design..."
+
+## Critical Rule: Zero Code Changes Allowed
+
+- **NO FILE EDITS OR CREATION**: Under no circumstances should you edit
+  existing project files, write new implementation code, or modify repository
+  state.
+- **READ-ONLY INSPECTION IS ALLOWED**: You are fully authorized and encouraged
+  to inspect the codebase using read-only tools (`grep_search`, `view_file`,
+  `list_dir`) to understand the current architecture and ground your
+  brainstorming in reality.
+- **DO NOT ASSUME IMPLEMENTATION IS DESIRED**: Never jump from brainstorming
+  directly into writing code unless explicitly commanded in a separate
+  follow-up turn.
+
+## Procedural Workflow
+
+### 1. Interactive Alignment (`ask_question`)
+- You are **strongly encouraged** to use the `ask_question` tool early to
+  request clarification, surface design choices, and align on goals or
+  constraints before drafting extensive proposals.
+
+### 2. Mandatory Artifact Generation
+- The output of this skill **MUST be saved as an artifact** (`.md` file in the
+  conversation artifacts directory) so the user can easily review, share, and
+  comment on specific sections.
+- Format the artifact clearly with headers, options tables, and pros/cons
+  breakdowns.
+
+### 3. Structure Your Proposals
+- Present 2–4 distinct architectural or conceptual options (e.g., simple vs.
+  scalable, synchronous vs. asynchronous).
+- Highlight tradeoffs, impact on existing code, and relative complexity for each
+  option.
+- Summarize discussion points for the user to consider.
+
+### 4. Offer Obvious Next Steps
+- Conclude by suggesting relevant, actionable next steps based on the context.
+- Examples of suggested next steps (pick 1–3 that fit best or tailor your own):
+  - Create a GitHub issue to track the design/decision.
+  - Explore one of the proposed options deeper.
+  - Create an implementation plan based on the preferred option.
+  - Begin implementing the preferred plan.
+- You are not required to include all suggestions—tailor them to what makes the
+  most sense for the current discussion.

--- a/skills/quick_question/SKILL.md
+++ b/skills/quick_question/SKILL.md
@@ -40,9 +40,9 @@ Examples of trigger phrases:
     context?"*
 
 ### 2. Direct Chat Output (NO Artifacts)
-- **Put the answer in the answer box**: Do NOT create artifacts (`.md` files in
-  the conversation artifacts directory) for quick questions. Deliver the
-  response inline directly to the user.
+- **Direct Chat Response**: Do NOT create artifacts (`.md` files in the
+  conversation artifacts directory) for quick questions. Deliver the response
+  inline directly to the user.
 
 ### 3. Conciseness & Structure
 - **Brief TL;DR**: Always lead with a very brief TL;DR or direct answer.

--- a/skills/quick_question/SKILL.md
+++ b/skills/quick_question/SKILL.md
@@ -41,8 +41,8 @@ Examples of trigger phrases:
 
 ### 2. Direct Chat Output (NO Artifacts)
 - **Put the answer in the answer box**: Do NOT create artifacts (`.md` files in
-  the brain directory) for quick questions. Deliver the response inline
-  directly to the user.
+  the conversation artifacts directory) for quick questions. Deliver the
+  response inline directly to the user.
 
 ### 3. Conciseness & Structure
 - **Brief TL;DR**: Always lead with a very brief TL;DR or direct answer.

--- a/skills/quick_question/SKILL.md
+++ b/skills/quick_question/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: quick_question
+description: |-
+  Provide ultra-concise, direct technical answers and rapid clarifications
+  without heavy overhead, deep research loops, or artifact generation. (Triggers
+  on "quick question" or "qq")
+---
+
+## When to use this skill
+
+Activate this skill when the user asks a straightforward technical question,
+requests a quick clarification, asks for a TL;DR explanation, or uses the short
+prefix `qq`.
+
+Examples of trigger phrases:
+- "qq..." / "qq: ..."
+- "Quick question..."
+- "TL;DR on..."
+- "Just real quick..."
+
+## Critical Rule: Accuracy Over Speculation & Zero Code Changes
+
+- **ACCURACY IS THE TOP PRIORITY**: The most important goal when using this
+  skill is offering ACCURATE guidance. Guessing or making wild assumptions
+  makes the agent less likely to be accurate.
+- **NO FILE EDITS OR CREATION**: Zero file changes are expected or allowed. Do
+  not edit files or alter repository state.
+- **DO NOT ASSUME ACTION IS DESIRED**: Answer the question directly. Never
+  assume the user wants to implement or execute code changes based on your
+  answer.
+
+## Procedural & Formatting Rules
+
+### 1. Handling Unclear Requests (Be Up-Front)
+- If the user's question is vague or unclear, be completely up-front about it
+  inline in your response rather than making blind guesses.
+- Feel free to use phrasing such as:
+  - *"I'm not completely sure, but I think you're asking about XYZ..."*
+  - *"I don't really understand what you mean. Can you offer a bit more
+    context?"*
+
+### 2. Direct Chat Output (NO Artifacts)
+- **Put the answer in the answer box**: Do NOT create artifacts (`.md` files in
+  the brain directory) for quick questions. Deliver the response inline
+  directly to the user.
+
+### 3. Conciseness & Structure
+- **Brief TL;DR**: Always lead with a very brief TL;DR or direct answer.
+- **Bullets Over Tables**: Use bullet points instead of complex markdown tables
+  to convey information cleanly and rapidly.
+- **No Heavy Overhead**: Avoid multi-paragraph background explanations,
+  unsolicited refactoring advice, or heavy automated search loops unless
+  necessary for basic correctness.
+
+### 4. Tool Avoidance (`ask_question`)
+- **AVOID `ask_question` tool calls**: Do not invoke the interactive modal tool.
+  Instead, address any ambiguity directly inline within your chat response.
+
+### 5. Optional Next Steps
+- Feel free to suggest **0 to 3 obvious next steps** at the end of your response
+  if they are genuinely useful, but keep them brief and non-intrusive.

--- a/skills/what_if/SKILL.md
+++ b/skills/what_if/SKILL.md
@@ -43,6 +43,9 @@ Examples of trigger phrases:
   well-defined, proceed directly to analysis without prompting the user.
 
 ### 2. Scenario Walking & Analysis
+- **Direct Chat Output**: Deliver the analysis inline directly to the user in
+  your chat response. Do NOT create artifacts unless the analysis is
+  exceptionally long or explicitly requested.
 - Outline the step-by-step impact if the change were actually executed.
 - Identify potential breaking changes, migration friction, and ripple effects
   across dependent packages or modules.

--- a/skills/what_if/SKILL.md
+++ b/skills/what_if/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: what_if
+description: |-
+  Perform "what-if" scenario analysis and impact evaluations for proposed
+  codebase changes, migrations, or architectural shifts.
+---
+
+## When to use this skill
+
+Activate this skill when the user asks a what-if question or requests a thought
+experiment about potential codebase modifications, deprecations, dependency
+upgrades, or migrations.
+
+Examples of trigger phrases:
+- "What if..." / "What-if..."
+- "What would break if we..."
+- "How hard would it be to migrate to..."
+- "What happens if we deprecate..."
+
+## Critical Rule: Zero Code Changes Allowed
+
+- **NO FILE EDITS OR CREATION**: You are explicitly forbidden from modifying
+  project files, committing changes, or altering repository state.
+- **DO NOT ASSUME CHANGE IS WANTED**: Treat the scenario strictly as an
+  analytical evaluation. Never start making changes under the assumption that
+  the user wants to implement the what-if scenario.
+
+## Empirical Data Gathering (Read-Only)
+
+- **Back Up Answers with Real Project Statistics**: You are strongly encouraged
+  to actively inspect the codebase using read-only tools (`grep_search`,
+  `view_file`, `list_dir`) to provide empirical metrics.
+- Calculate exact counts and scope where possible (e.g., *"This package is
+  imported across 34 files and 12 separate modules"* or *"Updating this method
+  signature impacts 8 call sites in 3 packages"*).
+
+## Procedural Workflow & Interaction Rules
+
+### 1. `ask_question` Tool Guidelines
+- **Conditional Usage Only**: Use the `ask_question` tool **ONLY if the user's
+  intent or scope is unclear or vague**.
+- **DO NOT USE if Clear**: If the user's what-if question is clear and
+  well-defined, proceed directly to analysis without prompting the user.
+
+### 2. Scenario Walking & Analysis
+- Outline the step-by-step impact if the change were actually executed.
+- Identify potential breaking changes, migration friction, and ripple effects
+  across dependent packages or modules.
+- Provide a summary verdict estimating overall complexity, risks, and
+  feasibility based on your read-only inspection.


### PR DESCRIPTION
This PR introduces three new agent skills designed for non-destructive exploration, analytical evaluation, and rapid clarification:

1. **`just_brainstorm`**: Interactive architectural design and option exploration. Outputs proposals to a dedicated artifact and offers tailored next steps.
2. **`what_if`**: "What-if" scenario evaluation backed by real project statistics via read-only tools.
3. **`quick_question`** (Shorthand: `qq`): Direct, concise inline answers prioritizing accuracy over speculation.

All skills strictly enforce zero code/file modifications in the codebase.