### PR TITLE
fix(pr-loop): mandate explicit thread resolution and pre-timer verification gate

### DIFF
--- a/skills/github-pr-triage/SKILL.md
+++ b/skills/github-pr-triage/SKILL.md
@@ -177,24 +177,26 @@ key_features:
 
 ## Replying and Resolving Comments
 
-Use these API patterns to reply to review comments and resolve threads:
+For every addressed review thread, you MUST execute both steps in sequence (thread resolution is explicit, mandatory, and un-skippable):
 
-- **Reply to comment**:
-  ```bash
-  gh api repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_database_id>/replies -f body="<your reply>"
-  ```
-- **Resolve thread**:
-  ```bash
-  gh api graphql -f query='
-    mutation($threadId: ID!) {
-      resolveReviewThread(input: {threadId: $threadId}) {
-        thread {
-          isResolved
-        }
-      }
-    }
-  ' -F threadId='<thread_graphql_id>'
-  ```
+1. **Step 1 (Reply)**: Post REST reply comment using numeric comment
+   `databaseId`:
+   ```bash
+   gh api repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_database_id>/replies -f body="<your reply>"
+   ```
+2. **Step 2 (Resolve - MANDATORY)**: Immediately resolve thread via GraphQL
+   mutation using thread ID (`PRRT_...`):
+   ```bash
+   gh api graphql -f query='
+     mutation($threadId: ID!) {
+       resolveReviewThread(input: {threadId: $threadId}) {
+         thread {
+           isResolved
+         }
+       }
+     }
+   ' -F threadId='<thread_graphql_id>'
+   ```
 
 ## Constraints
 - **CRITICAL**: You MUST NOT modify files or make any code edits to address PR

--- a/skills/pr-loop/SKILL.md
+++ b/skills/pr-loop/SKILL.md
@@ -167,7 +167,8 @@ which are bypassed in favor of autonomous execution):
   *(Note: If no code changes were made, e.g. all comments were disagreed with,
   skip committing and pushing).*
 * **Two-Step Reply & Resolve Protocol (MANDATORY)**:
-  For every addressed review thread, you MUST execute both steps in order:
+  For every addressed review thread, you MUST execute both steps in order
+  (thread resolution is explicit, mandatory, and un-skippable):
   1. **Post Reply Comment**: Call the REST API reply endpoint using the numeric
      comment `databaseId`:
      ```bash
@@ -184,6 +185,12 @@ which are bypassed in favor of autonomous execution):
        }
      '
      ```
+* **Pre-Timer Verification Gate (MANDATORY)**:
+  Before calling `schedule` or going idle, query GraphQL (or run `pr_status.dart`)
+  to verify that all addressed review threads report `isResolved: true`. If any
+  addressed thread reports `isResolved: false`, immediately execute the
+  `resolveReviewThread` mutation for that thread BEFORE setting the background
+  wakeup timer.
 
 ### 6. Trigger Subsequent Review Pass
 * **CRITICAL OPERATIONAL REMINDER**: `gemini-code-assist` automatically ingests
@@ -192,8 +199,9 @@ which are bypassed in favor of autonomous execution):
   ```bash
   gh pr comment <pr_number> --body "/gemini review"
   ```
-* Once `/gemini review` is posted, loop back immediately to **Step 2 [START]**
-  to schedule your 120s timer and go idle!
+* Once `/gemini review` is posted and all threads are verified as resolved, loop
+  back immediately to **Step 2 [START]** to schedule your 120s timer and go
+  idle!
 
 ---
 


### PR DESCRIPTION
Fixes #24 by mandating two-step thread resolution (REST reply comment + GraphQL resolveReviewThread mutation) and adding a pre-timer verification gate in github-pr-triage and pr-loop skills.