### PR TITLE
feat(github-pr-triage): add resolve subcommand for review comments

### DIFF
--- a/skills/github-pr-triage/SKILL.md
+++ b/skills/github-pr-triage/SKILL.md
@@ -177,26 +177,18 @@ key_features:
 
 ## Replying and Resolving Comments
 
-For every addressed review thread, you MUST execute both steps in sequence (thread resolution is explicit, mandatory, and un-skippable):
+For every addressed review thread, you MUST execute thread resolution (thread resolution is explicit, mandatory, and un-skippable).
 
-1. **Step 1 (Reply)**: Post REST reply comment using numeric comment
-   `databaseId`:
-   ```bash
-   gh api repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_database_id>/replies -f body="<your reply>"
-   ```
-2. **Step 2 (Resolve - MANDATORY)**: Immediately resolve thread via GraphQL
-   mutation using thread ID (`PRRT_...`):
-   ```bash
-   gh api graphql -f query='
-     mutation($threadId: ID!) {
-       resolveReviewThread(input: {threadId: $threadId}) {
-         thread {
-           isResolved
-         }
-       }
-     }
-   ' -F threadId='<thread_graphql_id>'
-   ```
+Use the `resolve` subcommand in `triage.dart` to programmatically reply to comments and resolve threads without shell-escaping issues:
+
+```bash
+# Reply to a comment and resolve its thread:
+dart <path-to-github-pr-triage-skill>/bin/triage.dart resolve <thread_graphql_id> <comment_database_id> "<your reply body>"
+
+# Or resolve a thread without posting a reply:
+dart <path-to-github-pr-triage-skill>/bin/triage.dart resolve <thread_graphql_id>
+```
+
 
 ## Constraints
 - **CRITICAL**: You MUST NOT modify files or make any code edits to address PR

--- a/skills/github-pr-triage/bin/triage.dart
+++ b/skills/github-pr-triage/bin/triage.dart
@@ -52,8 +52,24 @@ void main(List<String> args) async {
     if (resolveIndex != -1) {
       contextArgs.addAll(remainingArgs.sublist(0, resolveIndex));
       final subArgs = remainingArgs.sublist(resolveIndex + 1);
+      final resolvePositional = <String>[];
 
-      if (subArgs.length != 1 && subArgs.length != 3) {
+      for (var i = 0; i < subArgs.length; i++) {
+        final arg = subArgs[i];
+        if (arg == '--pr' || arg == '-p' || arg == '--dir' || arg == '-C') {
+          if (i + 1 < subArgs.length) {
+            contextArgs.add(arg);
+            contextArgs.add(subArgs[++i]);
+          } else {
+            stderr.writeln('Error: Missing value for option "$arg"');
+            exit(1);
+          }
+        } else {
+          resolvePositional.add(arg);
+        }
+      }
+
+      if (resolvePositional.length != 1 && resolvePositional.length != 3) {
         stderr.writeln(
           'Error: Invalid arguments for resolve subcommand.\n'
           'Usage:\n'
@@ -62,9 +78,13 @@ void main(List<String> args) async {
         );
         exit(1);
       }
-      final threadId = subArgs[0];
-      final commentId = subArgs.length == 3 ? subArgs[1] : null;
-      final bodyText = subArgs.length == 3 ? subArgs[2] : null;
+      final threadId = resolvePositional[0];
+      final commentId = resolvePositional.length == 3
+          ? resolvePositional[1]
+          : null;
+      final bodyText = resolvePositional.length == 3
+          ? resolvePositional[2]
+          : null;
 
       if (commentId != null && !RegExp(r'^\d+$').hasMatch(commentId)) {
         stderr.writeln('Error: <comment_id> must be a numeric database ID.');

--- a/skills/github-pr-triage/bin/triage.dart
+++ b/skills/github-pr-triage/bin/triage.dart
@@ -31,6 +31,47 @@ import '../lib/github_cli.dart';
 /// 8. **Report Generation**: Consolidates the results into a markdown format printed to stdout.
 void main(List<String> args) async {
   try {
+    if (args.isNotEmpty && args.first == 'resolve') {
+      final subArgs = args.sublist(1);
+      if (subArgs.length != 1 && subArgs.length != 3) {
+        stderr.writeln(
+          'Error: Invalid arguments for resolve subcommand.\n'
+          'Usage:\n'
+          '  dart triage.dart resolve <thread_id>\n'
+          '  dart triage.dart resolve <thread_id> <comment_id> "<body_text>"',
+        );
+        exit(1);
+      }
+      final threadId = subArgs[0];
+      final commentId = subArgs.length == 3 ? subArgs[1] : null;
+      final bodyText = subArgs.length == 3 ? subArgs[2] : null;
+
+      final context = await resolvePrContext(
+        const [],
+        onFail: (msg) {
+          stderr.writeln('Error: $msg');
+          exit(1);
+        },
+      );
+
+      if (commentId != null && bodyText != null) {
+        stdout.writeln(
+          'Replying to comment $commentId and resolving thread $threadId...',
+        );
+      } else {
+        stdout.writeln('Resolving thread $threadId...');
+      }
+
+      await replyAndResolveThread(
+        context,
+        threadId: threadId,
+        commentId: commentId,
+        body: bodyText,
+      );
+      stdout.writeln('Successfully resolved thread $threadId.');
+      return;
+    }
+
     final context = await resolvePrContext(
       args,
       onFail: (msg) {
@@ -38,6 +79,7 @@ void main(List<String> args) async {
         exit(1);
       },
     );
+
     final workingDir = context.workingDir;
     final prNumber = context.prNumber;
     final owner = context.owner;

--- a/skills/github-pr-triage/bin/triage.dart
+++ b/skills/github-pr-triage/bin/triage.dart
@@ -48,8 +48,11 @@ void main(List<String> args) async {
       }
     }
 
-    if (remainingArgs.isNotEmpty && remainingArgs.first == 'resolve') {
-      final subArgs = remainingArgs.sublist(1);
+    final resolveIndex = remainingArgs.indexOf('resolve');
+    if (resolveIndex != -1) {
+      contextArgs.addAll(remainingArgs.sublist(0, resolveIndex));
+      final subArgs = remainingArgs.sublist(resolveIndex + 1);
+
       if (subArgs.length != 1 && subArgs.length != 3) {
         stderr.writeln(
           'Error: Invalid arguments for resolve subcommand.\n'

--- a/skills/github-pr-triage/bin/triage.dart
+++ b/skills/github-pr-triage/bin/triage.dart
@@ -63,6 +63,15 @@ void main(List<String> args) async {
       final commentId = subArgs.length == 3 ? subArgs[1] : null;
       final bodyText = subArgs.length == 3 ? subArgs[2] : null;
 
+      if (commentId != null && !RegExp(r'^\d+$').hasMatch(commentId)) {
+        stderr.writeln('Error: <comment_id> must be a numeric database ID.');
+        exit(1);
+      }
+      if (bodyText != null && bodyText.trim().isEmpty) {
+        stderr.writeln('Error: <body_text> cannot be empty.');
+        exit(1);
+      }
+
       final context = await resolvePrContext(
         contextArgs,
         onFail: (msg) {

--- a/skills/github-pr-triage/bin/triage.dart
+++ b/skills/github-pr-triage/bin/triage.dart
@@ -31,8 +31,25 @@ import '../lib/github_cli.dart';
 /// 8. **Report Generation**: Consolidates the results into a markdown format printed to stdout.
 void main(List<String> args) async {
   try {
-    if (args.isNotEmpty && args.first == 'resolve') {
-      final subArgs = args.sublist(1);
+    final contextArgs = <String>[];
+    final remainingArgs = <String>[];
+    for (var i = 0; i < args.length; i++) {
+      final arg = args[i];
+      if (arg == '--pr' || arg == '-p' || arg == '--dir' || arg == '-C') {
+        if (i + 1 < args.length) {
+          contextArgs.add(arg);
+          contextArgs.add(args[++i]);
+        } else {
+          stderr.writeln('Error: Missing value for option "$arg"');
+          exit(1);
+        }
+      } else {
+        remainingArgs.add(arg);
+      }
+    }
+
+    if (remainingArgs.isNotEmpty && remainingArgs.first == 'resolve') {
+      final subArgs = remainingArgs.sublist(1);
       if (subArgs.length != 1 && subArgs.length != 3) {
         stderr.writeln(
           'Error: Invalid arguments for resolve subcommand.\n'
@@ -47,7 +64,7 @@ void main(List<String> args) async {
       final bodyText = subArgs.length == 3 ? subArgs[2] : null;
 
       final context = await resolvePrContext(
-        const [],
+        contextArgs,
         onFail: (msg) {
           stderr.writeln('Error: $msg');
           exit(1);

--- a/skills/github-pr-triage/lib/github_cli.dart
+++ b/skills/github-pr-triage/lib/github_cli.dart
@@ -355,6 +355,65 @@ Future<PrGraphData> fetchPrGraphQLData(PrContext context) async {
   return (comments: comments, reviews: reviews, reviewThreads: threads);
 }
 
+/// Posts a reply to a PR review comment using its numeric [commentId].
+Future<void> replyToComment(
+  PrContext context, {
+  required String commentId,
+  required String body,
+}) async {
+  final endpoint =
+      'repos/${context.owner}/${context.repo}/pulls/${context.prNumber}/comments/$commentId/replies';
+  await runCommand('gh', [
+    'api',
+    endpoint,
+    '-f',
+    'body=$body',
+  ], workingDirectory: context.workingDir);
+}
+
+/// Resolves a review thread via GraphQL using its [threadId] (e.g. `PRRT_...`).
+Future<void> resolveReviewThread(
+  PrContext context, {
+  required String threadId,
+}) async {
+  const mutation = r'''
+  mutation($threadId: ID!) {
+    resolveReviewThread(input: {threadId: $threadId}) {
+      thread {
+        isResolved
+      }
+    }
+  }
+  ''';
+
+  final response = await runCommand('gh', [
+    'api',
+    'graphql',
+    '-f',
+    'query=$mutation',
+    '-F',
+    'threadId=$threadId',
+  ], workingDirectory: context.workingDir);
+
+  final parsed = jsonDecode(response) as Map<String, dynamic>;
+  if (parsed['errors'] != null) {
+    throw Exception('GraphQL errors resolving thread: ${parsed['errors']}');
+  }
+}
+
+/// Replies to a comment (if [commentId] and [body] are provided) and resolves the [threadId].
+Future<void> replyAndResolveThread(
+  PrContext context, {
+  required String threadId,
+  String? commentId,
+  String? body,
+}) async {
+  if (commentId != null && body != null && body.isNotEmpty) {
+    await replyToComment(context, commentId: commentId, body: body);
+  }
+  await resolveReviewThread(context, threadId: threadId);
+}
+
 PrCheckRun _parsePrCheckRun(Map json) {
   return (
     name: json['name']?.toString() ?? 'Unknown Check',

--- a/skills/github-pr-triage/lib/github_cli.dart
+++ b/skills/github-pr-triage/lib/github_cli.dart
@@ -361,6 +361,12 @@ Future<void> replyToComment(
   required String commentId,
   required String body,
 }) async {
+  if (commentId.trim().isEmpty) {
+    throw ArgumentError('Comment ID cannot be empty.');
+  }
+  if (body.trim().isEmpty) {
+    throw ArgumentError('Comment body cannot be empty.');
+  }
   final endpoint =
       'repos/${context.owner}/${context.repo}/pulls/${context.prNumber}/comments/$commentId/replies';
   await runCommand('gh', [
@@ -376,6 +382,9 @@ Future<void> resolveReviewThread(
   PrContext context, {
   required String threadId,
 }) async {
+  if (threadId.trim().isEmpty) {
+    throw ArgumentError('Thread ID cannot be empty.');
+  }
   const mutation = r'''
   mutation($threadId: ID!) {
     resolveReviewThread(input: {threadId: $threadId}) {
@@ -408,7 +417,10 @@ Future<void> replyAndResolveThread(
   String? commentId,
   String? body,
 }) async {
-  if (commentId != null && body != null && body.trim().isNotEmpty) {
+  if (commentId != null &&
+      commentId.trim().isNotEmpty &&
+      body != null &&
+      body.trim().isNotEmpty) {
     await replyToComment(context, commentId: commentId, body: body);
   }
   await resolveReviewThread(context, threadId: threadId);

--- a/skills/github-pr-triage/lib/github_cli.dart
+++ b/skills/github-pr-triage/lib/github_cli.dart
@@ -417,10 +417,14 @@ Future<void> replyAndResolveThread(
   String? commentId,
   String? body,
 }) async {
-  if (commentId != null &&
-      commentId.trim().isNotEmpty &&
-      body != null &&
-      body.trim().isNotEmpty) {
+  final hasCommentId = commentId != null && commentId.trim().isNotEmpty;
+  final hasBody = body != null && body.trim().isNotEmpty;
+  if (hasCommentId != hasBody) {
+    throw ArgumentError(
+      'Both commentId and body must be provided and non-empty, or both must be null/empty.',
+    );
+  }
+  if (hasCommentId && hasBody) {
     await replyToComment(context, commentId: commentId, body: body);
   }
   await resolveReviewThread(context, threadId: threadId);

--- a/skills/github-pr-triage/lib/github_cli.dart
+++ b/skills/github-pr-triage/lib/github_cli.dart
@@ -401,7 +401,7 @@ Future<void> resolveReviewThread(
     'graphql',
     '-f',
     'query=$mutation',
-    '-F',
+    '-f',
     'threadId=$threadId',
   ], workingDirectory: context.workingDir);
 

--- a/skills/github-pr-triage/lib/github_cli.dart
+++ b/skills/github-pr-triage/lib/github_cli.dart
@@ -361,12 +361,13 @@ Future<void> replyToComment(
   required String commentId,
   required String body,
 }) async {
-  if (commentId.trim().isEmpty) {
-    throw ArgumentError('Comment ID cannot be empty.');
+  if (!RegExp(r'^\d+$').hasMatch(commentId)) {
+    throw ArgumentError('Comment ID must be a numeric database ID.');
   }
   if (body.trim().isEmpty) {
     throw ArgumentError('Comment body cannot be empty.');
   }
+
   final endpoint =
       'repos/${context.owner}/${context.repo}/pulls/${context.prNumber}/comments/$commentId/replies';
   await runCommand('gh', [

--- a/skills/github-pr-triage/lib/github_cli.dart
+++ b/skills/github-pr-triage/lib/github_cli.dart
@@ -408,7 +408,7 @@ Future<void> replyAndResolveThread(
   String? commentId,
   String? body,
 }) async {
-  if (commentId != null && body != null && body.isNotEmpty) {
+  if (commentId != null && body != null && body.trim().isNotEmpty) {
     await replyToComment(context, commentId: commentId, body: body);
   }
   await resolveReviewThread(context, threadId: threadId);

--- a/skills/pr-loop/SKILL.md
+++ b/skills/pr-loop/SKILL.md
@@ -166,25 +166,13 @@ which are bypassed in favor of autonomous execution):
   ```
   *(Note: If no code changes were made, e.g. all comments were disagreed with,
   skip committing and pushing).*
-* **Two-Step Reply & Resolve Protocol (MANDATORY)**:
-  For every addressed review thread, you MUST execute both steps in order
-  (thread resolution is explicit, mandatory, and un-skippable):
-  1. **Post Reply Comment**: Call the REST API reply endpoint using the numeric
-     comment `databaseId`:
-     ```bash
-     gh api repos/<owner>/<repo>/pulls/<pr_number>/comments/<comment_id>/replies -f body="<your concise explanation>"
-     ```
-  2. **Resolve Thread**: Call the GraphQL mutation using the thread `id`
-     (`PRRT_...`):
-     ```bash
-     gh api graphql -f query='
-       mutation {
-         resolveReviewThread(input: {threadId: "<thread_id>"}) {
-           thread { isResolved }
-         }
-       }
-     '
-     ```
+* **Reply & Resolve Protocol (MANDATORY)**:
+  For every addressed review thread, you MUST execute thread resolution (thread resolution is explicit, mandatory, and un-skippable).
+  Use the `resolve` subcommand in `triage.dart`:
+  ```bash
+  dart <path-to-github-pr-triage-skill>/bin/triage.dart resolve <thread_id> <comment_id> "<your concise explanation>"
+  ```
+
 * **Pre-Timer Verification Gate (MANDATORY)**:
   Before calling `schedule` or going idle, query GraphQL (or run `pr_status.dart`)
   to verify that all addressed review threads report `isResolved: true`. If any

--- a/tool/test/triage_resolve_test.dart
+++ b/tool/test/triage_resolve_test.dart
@@ -71,4 +71,44 @@ void main() {
       await process.shouldExit(1);
     },
   );
+
+  test(
+    'triage.dart resolve with non-numeric comment_id outputs error and exits with code 1',
+    () async {
+      final process = await TestProcess.start(Platform.resolvedExecutable, [
+        triageScript,
+        'resolve',
+        'thread_123',
+        'not_a_number',
+        'some reply',
+      ]);
+
+      await expectLater(
+        process.stderr,
+        emitsThrough(
+          contains('Error: <comment_id> must be a numeric database ID.'),
+        ),
+      );
+      await process.shouldExit(1);
+    },
+  );
+
+  test(
+    'triage.dart resolve with empty body_text outputs error and exits with code 1',
+    () async {
+      final process = await TestProcess.start(Platform.resolvedExecutable, [
+        triageScript,
+        'resolve',
+        'thread_123',
+        '456',
+        '   ',
+      ]);
+
+      await expectLater(
+        process.stderr,
+        emitsThrough(contains('Error: <body_text> cannot be empty.')),
+      );
+      await process.shouldExit(1);
+    },
+  );
 }

--- a/tool/test/triage_resolve_test.dart
+++ b/tool/test/triage_resolve_test.dart
@@ -50,4 +50,25 @@ void main() {
       await process.shouldExit(1);
     },
   );
+
+  test(
+    'triage.dart resolve with invalid target directory outputs error and exits with code 1',
+    () async {
+      final process = await TestProcess.start(Platform.resolvedExecutable, [
+        triageScript,
+        'resolve',
+        'thread_123',
+        '--dir',
+        '/non_existent_path_xyz',
+      ]);
+
+      await expectLater(
+        process.stderr,
+        emitsThrough(
+          contains('Target directory "/non_existent_path_xyz" does not exist.'),
+        ),
+      );
+      await process.shouldExit(1);
+    },
+  );
 }

--- a/tool/test/triage_resolve_test.dart
+++ b/tool/test/triage_resolve_test.dart
@@ -54,6 +54,7 @@ void main() {
   test(
     'triage.dart resolve with invalid target directory outputs error and exits with code 1',
     () async {
+      final expectedPath = Directory('/non_existent_path_xyz').absolute.path;
       final process = await TestProcess.start(Platform.resolvedExecutable, [
         triageScript,
         'resolve',
@@ -65,7 +66,7 @@ void main() {
       await expectLater(
         process.stderr,
         emitsThrough(
-          contains('Target directory "/non_existent_path_xyz" does not exist.'),
+          contains('Target directory "$expectedPath" does not exist.'),
         ),
       );
       await process.shouldExit(1);

--- a/tool/test/triage_resolve_test.dart
+++ b/tool/test/triage_resolve_test.dart
@@ -6,7 +6,7 @@ import 'package:test_process/test_process.dart';
 
 void main() {
   final triageScript = p.join(
-    Directory.current.path.endsWith('tool') ? '..' : '.',
+    p.basename(Directory.current.path) == 'tool' ? '..' : '.',
     'skills',
     'github-pr-triage',
     'bin',

--- a/tool/test/triage_resolve_test.dart
+++ b/tool/test/triage_resolve_test.dart
@@ -1,0 +1,53 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import 'package:test_process/test_process.dart';
+
+void main() {
+  final triageScript = p.join(
+    Directory.current.path.endsWith('tool') ? '..' : '.',
+    'skills',
+    'github-pr-triage',
+    'bin',
+    'triage.dart',
+  );
+
+  test(
+    'triage.dart resolve with no args outputs usage and exits with code 1',
+    () async {
+      final process = await TestProcess.start(Platform.resolvedExecutable, [
+        triageScript,
+        'resolve',
+      ]);
+
+      await expectLater(
+        process.stderr,
+        emitsThrough(
+          contains('Error: Invalid arguments for resolve subcommand.'),
+        ),
+      );
+      await process.shouldExit(1);
+    },
+  );
+
+  test(
+    'triage.dart resolve with 2 args outputs usage and exits with code 1',
+    () async {
+      final process = await TestProcess.start(Platform.resolvedExecutable, [
+        triageScript,
+        'resolve',
+        'thread_123',
+        'comment_456',
+      ]);
+
+      await expectLater(
+        process.stderr,
+        emitsThrough(
+          contains('Error: Invalid arguments for resolve subcommand.'),
+        ),
+      );
+      await process.shouldExit(1);
+    },
+  );
+}


### PR DESCRIPTION
Add a helper subcommand `resolve` to `triage.dart` to programmatically reply to PR review comments and resolve GraphQL review threads without shell-escaping issues.

- Add helper functions to `github_cli.dart` (`replyToComment`, `resolveReviewThread`, `replyAndResolveThread`).
- Add `resolve` subcommand handling in `triage.dart`.
- Update `SKILL.md` documentation in `github-pr-triage` and `pr-loop`.
- Add unit tests in `tool/test/triage_resolve_test.dart`.

Fixes #26
