### PR TITLE
feat(triage): return commit SHA and verify branch sync status

### DIFF
--- a/skills/github-pr-triage/SKILL.md
+++ b/skills/github-pr-triage/SKILL.md
@@ -64,12 +64,13 @@ key_features:
    tool).
 
 2. **Verify Workspace State**:
-   - The script output will show the PR URL, title, branch, and commit SHA.
-   - Verify that your current git branch matches the PR source branch
-     (`headRefName`).
-   - Run `git status` and ensure the working tree matches the PR branch.
-   - Verify you are at the correct commit. If not, inform the user or checkout
-     the correct branch/commit.
+   - The script output will show the PR URL, title, branch, Remote Commit SHA,
+     Local Commit SHA, and Sync Status (`in_sync`, `behind_remote`, `ahead_of_remote`, `diverged`, or `branch_mismatch`).
+   - Verify that your current git branch matches the PR source branch (`headRefName`).
+   - Check the **Sync Status**:
+     - If `Sync Status` is `behind_remote`, pull the latest remote commits (`git pull`) before making changes.
+     - If `Sync Status` is `ahead_of_remote` or `diverged`, push or sync local commits (`git push`).
+     - Do not start making code edits while the local workspace is out of sync with the remote PR.
 
 3. **Analyze Open Comments**:
    - The script lists all unresolved comment threads.

--- a/skills/github-pr-triage/bin/triage.dart
+++ b/skills/github-pr-triage/bin/triage.dart
@@ -149,27 +149,15 @@ void main(List<String> args) async {
     ], workingDirectory: workingDir);
     final prData = jsonDecode(viewOutput) as Map<String, dynamic>;
 
-    // Validate active local branch matches PR head branch.
-    final prHeadBranch = prData['headRefName']?.toString();
-    String activeBranch;
-    try {
-      activeBranch = (await runCommand('git', [
-        'symbolic-ref',
-        '--short',
-        'HEAD',
-      ], workingDirectory: workingDir)).trim();
-    } catch (_) {
-      activeBranch = '';
-    }
+    // Validate local vs remote sync status using shared helper.
+    final syncStatus = await fetchPrSyncStatus(
+      context,
+      remoteBranch: prData['headRefName']?.toString(),
+      remoteHeadSha: prData['headRefOid']?.toString(),
+    );
 
-    if (activeBranch.isNotEmpty &&
-        prHeadBranch != null &&
-        activeBranch != prHeadBranch) {
-      stdout.writeln(
-        '\nWARNING: Active local branch is "$activeBranch", but the PR branch is "$prHeadBranch".\n'
-        'Please ensure you are on the correct branch before making edits. You can checkout this PR by running:\n'
-        '  gh pr checkout $prNumber\n',
-      );
+    if (syncStatus.warning != null) {
+      stdout.writeln('\nWARNING: ${syncStatus.warning}\n');
     }
 
     // 5. Fetch unresolved review comments using unified GraphQL helper.
@@ -215,16 +203,22 @@ void main(List<String> args) async {
     }
 
     // 8. Generate and output the markdown report.
+    final syncWarningBlock = syncStatus.warning != null
+        ? '> [!WARNING]\n> ${syncStatus.warning}\n\n'
+        : '';
+
     final report = StringBuffer('''
 # PR Triage Report: #${prData['number']} - ${prData['title']}
 
 **URL**: [PR #${prData['number']}](${prData['url']})
 **Branch**: `${prData['headRefName']}`
-**Commit**: `${prData['headRefOid']}`
+**Remote Commit**: `${prData['headRefOid']}`
+**Local Commit**: `${syncStatus.localHeadSha.isEmpty ? 'N/A' : syncStatus.localHeadSha}`
+**Sync Status**: `${syncStatus.syncState}`${syncStatus.isSynced ? ' ✅' : ' ⚠️'}
 **Review Decision**: `${prData['reviewDecision']}`
 **Mergeable**: `${prData['mergeable']}`
 
-## Unresolved Review Comments (${unresolvedThreads.length})
+$syncWarningBlock## Unresolved Review Comments (${unresolvedThreads.length})
 
 ''');
 

--- a/skills/github-pr-triage/lib/github_cli.dart
+++ b/skills/github-pr-triage/lib/github_cli.dart
@@ -344,8 +344,8 @@ Future<PrSyncStatus> fetchPrSyncStatus(
   bool remoteCommitExists = false;
   try {
     await runCommand('git', [
-      'rev-parse',
-      '--verify',
+      'cat-file',
+      '-e',
       '$rHeadSha^{commit}',
     ], workingDirectory: context.workingDir);
     remoteCommitExists = true;
@@ -358,10 +358,10 @@ Future<PrSyncStatus> fetchPrSyncStatus(
       localHeadSha: localHeadSha,
       remoteHeadSha: rHeadSha,
       isSynced: false,
-      syncState: 'behind_remote',
+      syncState: 'not_fetched',
       warning:
-          'Remote PR commit ($rHeadSha) was not found locally. '
-          'Please run "git fetch" or "git pull" to update your local repository.',
+          'Remote PR commit ($rHeadSha) is not present in your local repository. '
+          'Please run "git fetch" to update your local repository.',
     );
   }
 

--- a/skills/github-pr-triage/lib/github_cli.dart
+++ b/skills/github-pr-triage/lib/github_cli.dart
@@ -321,9 +321,11 @@ Future<PrSyncStatus> fetchPrSyncStatus(
       remoteBranch: rBranch,
       localHeadSha: localHeadSha,
       remoteHeadSha: rHeadSha,
-      isSynced: true,
+      isSynced: false,
       syncState: 'unknown',
-      warning: null,
+      warning: localHeadSha.isEmpty
+          ? 'Could not determine local HEAD commit SHA. Please ensure you are in a valid git repository.'
+          : 'Could not determine remote PR head commit SHA. Please check network connection or GitHub CLI status.',
     );
   }
 
@@ -336,6 +338,30 @@ Future<PrSyncStatus> fetchPrSyncStatus(
       isSynced: true,
       syncState: 'in_sync',
       warning: null,
+    );
+  }
+
+  bool remoteCommitExists = false;
+  try {
+    await runCommand('git', [
+      'rev-parse',
+      '--verify',
+      '$rHeadSha^{commit}',
+    ], workingDirectory: context.workingDir);
+    remoteCommitExists = true;
+  } catch (_) {}
+
+  if (!remoteCommitExists) {
+    return (
+      localBranch: localBranch,
+      remoteBranch: rBranch,
+      localHeadSha: localHeadSha,
+      remoteHeadSha: rHeadSha,
+      isSynced: false,
+      syncState: 'behind_remote',
+      warning:
+          'Remote PR commit ($rHeadSha) was not found locally. '
+          'Please run "git fetch" or "git pull" to update your local repository.',
     );
   }
 

--- a/skills/github-pr-triage/lib/github_cli.dart
+++ b/skills/github-pr-triage/lib/github_cli.dart
@@ -236,6 +236,172 @@ typedef PrGraphData = ({
   List<PrReviewThread> reviewThreads,
 });
 
+/// Sync status information comparing local repository state to remote PR state.
+typedef PrSyncStatus = ({
+  String localBranch,
+  String remoteBranch,
+  String localHeadSha,
+  String remoteHeadSha,
+  bool isSynced,
+  String syncState,
+  String? warning,
+});
+
+/// Evaluates local git repository branch and commit SHA against the remote PR head branch and commit SHA.
+Future<PrSyncStatus> fetchPrSyncStatus(
+  PrContext context, {
+  String? remoteBranch,
+  String? remoteHeadSha,
+}) async {
+  var rBranch = remoteBranch;
+  var rHeadSha = remoteHeadSha;
+
+  if (rBranch == null || rHeadSha == null) {
+    try {
+      final repoArgs = ['-R', '${context.owner}/${context.repo}'];
+      final viewOutput = await runCommand('gh', [
+        ...repoArgs,
+        'pr',
+        'view',
+        context.prNumber,
+        '--json',
+        'headRefName,headRefOid',
+      ], workingDirectory: context.workingDir);
+      final prData = jsonDecode(viewOutput) as Map<String, dynamic>;
+      rBranch ??= prData['headRefName']?.toString() ?? '';
+      rHeadSha ??= prData['headRefOid']?.toString() ?? '';
+    } catch (_) {
+      rBranch ??= '';
+      rHeadSha ??= '';
+    }
+  }
+
+  String localBranch = '';
+  try {
+    localBranch = (await runCommand('git', [
+      'symbolic-ref',
+      '--short',
+      'HEAD',
+    ], workingDirectory: context.workingDir)).trim();
+  } catch (_) {
+    try {
+      localBranch = (await runCommand('git', [
+        'rev-parse',
+        '--abbrev-ref',
+        'HEAD',
+      ], workingDirectory: context.workingDir)).trim();
+    } catch (_) {}
+  }
+
+  String localHeadSha = '';
+  try {
+    localHeadSha = (await runCommand('git', [
+      'rev-parse',
+      'HEAD',
+    ], workingDirectory: context.workingDir)).trim();
+  } catch (_) {}
+
+  if (localBranch.isNotEmpty && rBranch.isNotEmpty && localBranch != rBranch) {
+    return (
+      localBranch: localBranch,
+      remoteBranch: rBranch,
+      localHeadSha: localHeadSha,
+      remoteHeadSha: rHeadSha,
+      isSynced: false,
+      syncState: 'branch_mismatch',
+      warning:
+          'Active local branch is "$localBranch", but the PR branch is "$rBranch". '
+          'Please checkout the correct branch using: gh pr checkout ${context.prNumber}',
+    );
+  }
+
+  if (localHeadSha.isEmpty || rHeadSha.isEmpty) {
+    return (
+      localBranch: localBranch,
+      remoteBranch: rBranch,
+      localHeadSha: localHeadSha,
+      remoteHeadSha: rHeadSha,
+      isSynced: true,
+      syncState: 'unknown',
+      warning: null,
+    );
+  }
+
+  if (localHeadSha == rHeadSha) {
+    return (
+      localBranch: localBranch,
+      remoteBranch: rBranch,
+      localHeadSha: localHeadSha,
+      remoteHeadSha: rHeadSha,
+      isSynced: true,
+      syncState: 'in_sync',
+      warning: null,
+    );
+  }
+
+  bool isLocalAncestor = false;
+  try {
+    await runCommand('git', [
+      'merge-base',
+      '--is-ancestor',
+      localHeadSha,
+      rHeadSha,
+    ], workingDirectory: context.workingDir);
+    isLocalAncestor = true;
+  } catch (_) {}
+
+  if (isLocalAncestor) {
+    return (
+      localBranch: localBranch,
+      remoteBranch: rBranch,
+      localHeadSha: localHeadSha,
+      remoteHeadSha: rHeadSha,
+      isSynced: false,
+      syncState: 'behind_remote',
+      warning:
+          'Local commit ($localHeadSha) is behind remote PR commit ($rHeadSha). '
+          'Please pull remote changes before making edits.',
+    );
+  }
+
+  bool isRemoteAncestor = false;
+  try {
+    await runCommand('git', [
+      'merge-base',
+      '--is-ancestor',
+      rHeadSha,
+      localHeadSha,
+    ], workingDirectory: context.workingDir);
+    isRemoteAncestor = true;
+  } catch (_) {}
+
+  if (isRemoteAncestor) {
+    return (
+      localBranch: localBranch,
+      remoteBranch: rBranch,
+      localHeadSha: localHeadSha,
+      remoteHeadSha: rHeadSha,
+      isSynced: false,
+      syncState: 'ahead_of_remote',
+      warning:
+          'Local commit ($localHeadSha) is ahead of remote PR commit ($rHeadSha). '
+          'Please push local commits to sync remote PR.',
+    );
+  }
+
+  return (
+    localBranch: localBranch,
+    remoteBranch: rBranch,
+    localHeadSha: localHeadSha,
+    remoteHeadSha: rHeadSha,
+    isSynced: false,
+    syncState: 'diverged',
+    warning:
+        'Local commit ($localHeadSha) and remote PR commit ($rHeadSha) have diverged. '
+        'Please sync local and remote branches.',
+  );
+}
+
 /// Fetches status check runs for the specified [PrContext].
 Future<List<PrCheckRun>> fetchPrChecks(PrContext context) async {
   final repoArgs = ['-R', '${context.owner}/${context.repo}'];

--- a/skills/pr-loop/SKILL.md
+++ b/skills/pr-loop/SKILL.md
@@ -110,6 +110,7 @@ which are bypassed in favor of autonomous execution):
   2. `reviewThreads` has 0 unresolved threads.
   3. No review pass is currently in progress (i.e., no new review request has
      been submitted since the last bot review).
+  4. The local git branch commit SHA is fully in sync with the remote PR head commit (`is_synced: true`).
 * **Action on In-Progress Activity**: If `pr_status.dart` returns
   `"can_terminate": false` because CI checks are in-progress or a review pass is
   currently in progress, **schedule another 90s timer** and **go idle**. DO

--- a/skills/pr-loop/bin/pr_status.dart
+++ b/skills/pr-loop/bin/pr_status.dart
@@ -76,11 +76,18 @@ void main(List<String> args) async {
       graphqlError = e.toString();
     }
 
+    // Evaluate local vs remote sync status using shared helper.
+    final syncStatus = await fetchPrSyncStatus(context);
+
     // Evaluate termination decision.
     bool canTerminate = true;
     String? reason;
 
-    if (graphqlError != null) {
+    if (!syncStatus.isSynced) {
+      canTerminate = false;
+      reason =
+          syncStatus.warning ?? 'Local branch is out of sync with remote PR';
+    } else if (graphqlError != null) {
       canTerminate = false;
       reason = 'Failed to verify PR threads/reactions: $graphqlError';
     } else if (inProgressChecks.isNotEmpty) {
@@ -106,6 +113,10 @@ void main(List<String> args) async {
       'in_progress_checks': inProgressChecks,
       'failed_checks': failedChecks,
       'has_active_eyes_reaction': hasActiveEyesReaction,
+      'local_head_sha': syncStatus.localHeadSha,
+      'remote_head_sha': syncStatus.remoteHeadSha,
+      'is_synced': syncStatus.isSynced,
+      'sync_state': syncStatus.syncState,
     };
 
     stdout.writeln(const JsonEncoder.withIndent('  ').convert(output));
@@ -118,6 +129,10 @@ void main(List<String> args) async {
       'in_progress_checks': <String>[],
       'failed_checks': <String>[],
       'has_active_eyes_reaction': false,
+      'local_head_sha': '',
+      'remote_head_sha': '',
+      'is_synced': false,
+      'sync_state': 'error',
     };
     stdout.writeln(const JsonEncoder.withIndent('  ').convert(output));
     exit(1);

--- a/tool/test/sync_status_test.dart
+++ b/tool/test/sync_status_test.dart
@@ -272,5 +272,87 @@ void main() {
         expect(status.warning, contains('is behind remote PR commit'));
       },
     );
+
+    test('returns isSynced false when local or remote SHA is empty', () async {
+      await runCommand('git', ['init'], workingDirectory: tempDir.path);
+      await runCommand('git', [
+        'config',
+        'user.name',
+        'Test User',
+      ], workingDirectory: tempDir.path);
+      await runCommand('git', [
+        'config',
+        'user.email',
+        'test@example.com',
+      ], workingDirectory: tempDir.path);
+
+      final context = PrContext(
+        workingDir: tempDir.path,
+        prNumber: '1',
+        owner: 'testowner',
+        repo: 'testrepo',
+      );
+
+      final status = await fetchPrSyncStatus(
+        context,
+        remoteBranch: 'main',
+        remoteHeadSha: '',
+      );
+
+      expect(status.isSynced, isFalse);
+      expect(status.syncState, equals('unknown'));
+      expect(status.warning, contains('Could not determine'));
+    });
+
+    test(
+      'returns behind_remote when remote commit is not found in local repo',
+      () async {
+        await runCommand('git', ['init'], workingDirectory: tempDir.path);
+        await runCommand('git', [
+          'config',
+          'user.name',
+          'Test User',
+        ], workingDirectory: tempDir.path);
+        await runCommand('git', [
+          'config',
+          'user.email',
+          'test@example.com',
+        ], workingDirectory: tempDir.path);
+
+        File(p.join(tempDir.path, 'file1.txt')).writeAsStringSync('first');
+        await runCommand('git', ['add', '.'], workingDirectory: tempDir.path);
+        await runCommand('git', [
+          'commit',
+          '-m',
+          'commit 1',
+        ], workingDirectory: tempDir.path);
+
+        final currentBranch = (await runCommand('git', [
+          'symbolic-ref',
+          '--short',
+          'HEAD',
+        ], workingDirectory: tempDir.path)).trim();
+
+        final context = PrContext(
+          workingDir: tempDir.path,
+          prNumber: '1',
+          owner: 'testowner',
+          repo: 'testrepo',
+        );
+
+        // Simulated remote commit SHA that does not exist in local repo object store
+        const nonExistentSha = '0123456789abcdef0123456789abcdef01234567';
+
+        final status = await fetchPrSyncStatus(
+          context,
+          remoteBranch: currentBranch,
+          remoteHeadSha: nonExistentSha,
+        );
+
+        expect(status.isSynced, isFalse);
+        expect(status.syncState, equals('behind_remote'));
+        expect(status.warning, contains('was not found locally'));
+      },
+    );
   });
 }

--- a/tool/test/sync_status_test.dart
+++ b/tool/test/sync_status_test.dart
@@ -286,6 +286,20 @@ void main() {
         'test@example.com',
       ], workingDirectory: tempDir.path);
 
+      File(p.join(tempDir.path, 'file.txt')).writeAsStringSync('hello');
+      await runCommand('git', ['add', '.'], workingDirectory: tempDir.path);
+      await runCommand('git', [
+        'commit',
+        '-m',
+        'initial commit',
+      ], workingDirectory: tempDir.path);
+
+      final currentBranch = (await runCommand('git', [
+        'symbolic-ref',
+        '--short',
+        'HEAD',
+      ], workingDirectory: tempDir.path)).trim();
+
       final context = PrContext(
         workingDir: tempDir.path,
         prNumber: '1',
@@ -295,7 +309,7 @@ void main() {
 
       final status = await fetchPrSyncStatus(
         context,
-        remoteBranch: 'main',
+        remoteBranch: currentBranch,
         remoteHeadSha: '',
       );
 

--- a/tool/test/sync_status_test.dart
+++ b/tool/test/sync_status_test.dart
@@ -364,8 +364,11 @@ void main() {
         );
 
         expect(status.isSynced, isFalse);
-        expect(status.syncState, equals('behind_remote'));
-        expect(status.warning, contains('was not found locally'));
+        expect(status.syncState, equals('not_fetched'));
+        expect(
+          status.warning,
+          contains('is not present in your local repository'),
+        );
       },
     );
   });

--- a/tool/test/sync_status_test.dart
+++ b/tool/test/sync_status_test.dart
@@ -1,0 +1,276 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+import '../../skills/github-pr-triage/lib/github_cli.dart';
+
+void main() {
+  group('fetchPrSyncStatus unit tests', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('sync_test_');
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test(
+      'returns in_sync when local and remote SHAs match in git repo',
+      () async {
+        // Initialize git repo in tempDir
+        await runCommand('git', ['init'], workingDirectory: tempDir.path);
+        await runCommand('git', [
+          'config',
+          'user.name',
+          'Test User',
+        ], workingDirectory: tempDir.path);
+        await runCommand('git', [
+          'config',
+          'user.email',
+          'test@example.com',
+        ], workingDirectory: tempDir.path);
+
+        File(p.join(tempDir.path, 'file.txt')).writeAsStringSync('hello');
+        await runCommand('git', ['add', '.'], workingDirectory: tempDir.path);
+        await runCommand('git', [
+          'commit',
+          '-m',
+          'initial commit',
+        ], workingDirectory: tempDir.path);
+
+        final headSha = (await runCommand('git', [
+          'rev-parse',
+          'HEAD',
+        ], workingDirectory: tempDir.path)).trim();
+        final currentBranch = (await runCommand('git', [
+          'symbolic-ref',
+          '--short',
+          'HEAD',
+        ], workingDirectory: tempDir.path)).trim();
+
+        final context = PrContext(
+          workingDir: tempDir.path,
+          prNumber: '1',
+          owner: 'testowner',
+          repo: 'testrepo',
+        );
+
+        final status = await fetchPrSyncStatus(
+          context,
+          remoteBranch: currentBranch,
+          remoteHeadSha: headSha,
+        );
+
+        expect(status.isSynced, isTrue);
+        expect(status.syncState, equals('in_sync'));
+        expect(status.localHeadSha, equals(headSha));
+        expect(status.remoteHeadSha, equals(headSha));
+        expect(status.warning, isNull);
+      },
+    );
+
+    test(
+      'returns branch_mismatch when active local branch differs from remote PR branch',
+      () async {
+        await runCommand('git', ['init'], workingDirectory: tempDir.path);
+        await runCommand('git', [
+          'config',
+          'user.name',
+          'Test User',
+        ], workingDirectory: tempDir.path);
+        await runCommand('git', [
+          'config',
+          'user.email',
+          'test@example.com',
+        ], workingDirectory: tempDir.path);
+
+        File(p.join(tempDir.path, 'file.txt')).writeAsStringSync('hello');
+        await runCommand('git', ['add', '.'], workingDirectory: tempDir.path);
+        await runCommand('git', [
+          'commit',
+          '-m',
+          'initial commit',
+        ], workingDirectory: tempDir.path);
+
+        final headSha = (await runCommand('git', [
+          'rev-parse',
+          'HEAD',
+        ], workingDirectory: tempDir.path)).trim();
+        final currentBranch = (await runCommand('git', [
+          'symbolic-ref',
+          '--short',
+          'HEAD',
+        ], workingDirectory: tempDir.path)).trim();
+
+        final context = PrContext(
+          workingDir: tempDir.path,
+          prNumber: '1',
+          owner: 'testowner',
+          repo: 'testrepo',
+        );
+
+        final status = await fetchPrSyncStatus(
+          context,
+          remoteBranch: 'different-feature-branch',
+          remoteHeadSha: headSha,
+        );
+
+        expect(status.isSynced, isFalse);
+        expect(status.syncState, equals('branch_mismatch'));
+        expect(status.localBranch, equals(currentBranch));
+        expect(status.remoteBranch, equals('different-feature-branch'));
+        expect(
+          status.warning,
+          contains(
+            'Active local branch is "$currentBranch", but the PR branch is "different-feature-branch"',
+          ),
+        );
+      },
+    );
+
+    test(
+      'returns ahead_of_remote when local repo has unpushed commits',
+      () async {
+        await runCommand('git', ['init'], workingDirectory: tempDir.path);
+        await runCommand('git', [
+          'config',
+          'user.name',
+          'Test User',
+        ], workingDirectory: tempDir.path);
+        await runCommand('git', [
+          'config',
+          'user.email',
+          'test@example.com',
+        ], workingDirectory: tempDir.path);
+
+        File(p.join(tempDir.path, 'file1.txt')).writeAsStringSync('first');
+        await runCommand('git', ['add', '.'], workingDirectory: tempDir.path);
+        await runCommand('git', [
+          'commit',
+          '-m',
+          'commit 1',
+        ], workingDirectory: tempDir.path);
+        final firstCommitSha = (await runCommand('git', [
+          'rev-parse',
+          'HEAD',
+        ], workingDirectory: tempDir.path)).trim();
+
+        File(p.join(tempDir.path, 'file2.txt')).writeAsStringSync('second');
+        await runCommand('git', ['add', '.'], workingDirectory: tempDir.path);
+        await runCommand('git', [
+          'commit',
+          '-m',
+          'commit 2',
+        ], workingDirectory: tempDir.path);
+        final secondCommitSha = (await runCommand('git', [
+          'rev-parse',
+          'HEAD',
+        ], workingDirectory: tempDir.path)).trim();
+
+        final currentBranch = (await runCommand('git', [
+          'symbolic-ref',
+          '--short',
+          'HEAD',
+        ], workingDirectory: tempDir.path)).trim();
+
+        final context = PrContext(
+          workingDir: tempDir.path,
+          prNumber: '1',
+          owner: 'testowner',
+          repo: 'testrepo',
+        );
+
+        // Local is at secondCommitSha, remote PR is at firstCommitSha
+        final status = await fetchPrSyncStatus(
+          context,
+          remoteBranch: currentBranch,
+          remoteHeadSha: firstCommitSha,
+        );
+
+        expect(status.isSynced, isFalse);
+        expect(status.syncState, equals('ahead_of_remote'));
+        expect(status.localHeadSha, equals(secondCommitSha));
+        expect(status.remoteHeadSha, equals(firstCommitSha));
+        expect(status.warning, contains('is ahead of remote PR commit'));
+      },
+    );
+
+    test(
+      'returns behind_remote when local repo is behind remote PR commit',
+      () async {
+        await runCommand('git', ['init'], workingDirectory: tempDir.path);
+        await runCommand('git', [
+          'config',
+          'user.name',
+          'Test User',
+        ], workingDirectory: tempDir.path);
+        await runCommand('git', [
+          'config',
+          'user.email',
+          'test@example.com',
+        ], workingDirectory: tempDir.path);
+
+        File(p.join(tempDir.path, 'file1.txt')).writeAsStringSync('first');
+        await runCommand('git', ['add', '.'], workingDirectory: tempDir.path);
+        await runCommand('git', [
+          'commit',
+          '-m',
+          'commit 1',
+        ], workingDirectory: tempDir.path);
+        final firstCommitSha = (await runCommand('git', [
+          'rev-parse',
+          'HEAD',
+        ], workingDirectory: tempDir.path)).trim();
+
+        File(p.join(tempDir.path, 'file2.txt')).writeAsStringSync('second');
+        await runCommand('git', ['add', '.'], workingDirectory: tempDir.path);
+        await runCommand('git', [
+          'commit',
+          '-m',
+          'commit 2',
+        ], workingDirectory: tempDir.path);
+        final secondCommitSha = (await runCommand('git', [
+          'rev-parse',
+          'HEAD',
+        ], workingDirectory: tempDir.path)).trim();
+
+        // Reset local repo back to first commit
+        await runCommand('git', [
+          'reset',
+          '--hard',
+          firstCommitSha,
+        ], workingDirectory: tempDir.path);
+
+        final currentBranch = (await runCommand('git', [
+          'symbolic-ref',
+          '--short',
+          'HEAD',
+        ], workingDirectory: tempDir.path)).trim();
+
+        final context = PrContext(
+          workingDir: tempDir.path,
+          prNumber: '1',
+          owner: 'testowner',
+          repo: 'testrepo',
+        );
+
+        // Local is at firstCommitSha, remote PR is at secondCommitSha
+        final status = await fetchPrSyncStatus(
+          context,
+          remoteBranch: currentBranch,
+          remoteHeadSha: secondCommitSha,
+        );
+
+        expect(status.isSynced, isFalse);
+        expect(status.syncState, equals('behind_remote'));
+        expect(status.localHeadSha, equals(firstCommitSha));
+        expect(status.remoteHeadSha, equals(secondCommitSha));
+        expect(status.warning, contains('is behind remote PR commit'));
+      },
+    );
+  });
+}


### PR DESCRIPTION
Add commit SHA output and branch synchronization checking across triage.dart and pr_status.dart via a shared helper in github_cli.dart.

- Add PrSyncStatus record and fetchPrSyncStatus helper in github_cli.dart to compare local HEAD SHA and branch against remote PR head.
- Update triage.dart to display Remote Commit SHA, Local Commit SHA, and Sync Status in report header with warnings for out-of-sync branches.
- Update pr_status.dart to include commit SHAs and sync status in JSON output and block loop termination (can_terminate = false) when out of sync.
- Update skill documentation in github-pr-triage and pr-loop.
- Add unit tests in tool/test/sync_status_test.dart.
