### PR TITLE
feat(triage): consolidate PR triage and loop guardrails (#28, #31, #32, #33)

### DIFF
--- a/skills/github-pr-triage/SKILL.md
+++ b/skills/github-pr-triage/SKILL.md
@@ -27,6 +27,16 @@ key_features:
   AI bot like Gemini Code Assist or a human engineer — is infallible. AI review
   bots frequently hallucinate syntax limitations, suggest outdated patterns, or
   misunderstand broader repository architecture.
+- **Treat Severity Badges as Unverified External Claims**: Bot-generated severity
+  tags (such as `![critical]` or `![security-high]`) are unverified external claims,
+  NOT confirmed system diagnostics or compiler errors. Never blindly trust badges.
+- **Mandatory Pre-Edit Empirical Verification Gate**:
+  Before editing code for any reviewer comment claiming a syntax error, compilation
+  failure, or type issue, the agent MUST run static analysis (`dart analyze`) on
+  the **unmodified existing codebase** first.
+  - If `dart analyze` returns **0 issues**, the reviewer's claim is empirically false.
+    The item MUST be classified as `👎 Disagree (Hallucinated Syntax/Compile Error)` and
+    NO code changes may be made for that item.
 - **You have the execution advantage**: External reviewers inspect static code,
   whereas you can execute live compilers, static analyzers (`dart analyze`),
   and test suites (`dart test`). Always empirically test claims before accepting
@@ -126,7 +136,9 @@ key_features:
            it, but it's low priority)
          * `👎 Disagree` (Incorrect or counter-productive suggestion; we should
            explain why and propose no action)
-       - **Rationale**: Your technical explanation of why you agree,
+        - **Empirical Verification**: Output of `dart analyze` or `dart test` run on
+          the unmodified codebase before accepting any fix or classifying a claim.
+        - **Rationale**: Your technical explanation of why you agree,
          disagree, or recommend a specific direction.
      - **Planned Action**:
        - The target file name(s) and specific line ranges.

--- a/skills/github-pr-triage/bin/triage.dart
+++ b/skills/github-pr-triage/bin/triage.dart
@@ -176,29 +176,13 @@ void main(List<String> args) async {
     // 7. Fetch logs for failed check runs (if they are GitHub Actions).
     final checkLogs = <String, String>{};
     for (final check in failedChecks) {
-      final link = check.link;
       final checkName = check.name;
-      final match = RegExp(r'/actions/runs/(\d+)').firstMatch(link);
-      if (match != null) {
-        final runId = match.group(1)!;
-        stdout.writeln(
-          'Fetching failed logs for check "$checkName" (Run ID: $runId)...',
-        );
-        try {
-          final logOutput = await runCommand('gh', [
-            ...repoArgs,
-            'run',
-            'view',
-            runId,
-            '--log-failed',
-          ], workingDirectory: workingDir);
-          checkLogs[checkName] = _truncateLog(logOutput);
-        } catch (e) {
-          checkLogs[checkName] = 'Failed to fetch logs: $e';
-        }
-      } else {
-        checkLogs[checkName] =
-            'Non-GitHub Actions run. Inspect details at: $link';
+      stdout.writeln('Fetching failed logs for check "$checkName"...');
+      try {
+        final logOutput = await fetchFailedCheckLog(context, check);
+        checkLogs[checkName] = _truncateLog(logOutput);
+      } catch (e) {
+        checkLogs[checkName] = 'Failed to fetch logs: $e';
       }
     }
 

--- a/skills/github-pr-triage/lib/github_cli.dart
+++ b/skills/github-pr-triage/lib/github_cli.dart
@@ -450,6 +450,46 @@ Future<List<PrCheckRun>> fetchPrChecks(PrContext context) async {
   }
 }
 
+/// Extracts the workflow run ID from a GitHub Actions URL (e.g. `.../actions/runs/12345`).
+String? parseRunIdFromLink(String link) {
+  final segments = Uri.tryParse(link)?.pathSegments ?? const [];
+  final idx = segments.indexOf('runs');
+  if (idx > 0 && segments[idx - 1] == 'actions' && idx + 1 < segments.length) {
+    final candidate = segments[idx + 1];
+    if (RegExp(r'^\d+$').hasMatch(candidate)) return candidate;
+  }
+  return null;
+}
+
+/// Extracts the check run ID from a GitHub check run or job URL.
+String? parseCheckRunIdFromLink(String link) {
+  final segments = Uri.tryParse(link)?.pathSegments ?? const [];
+  if (segments.isEmpty) return null;
+
+  final last = segments.last;
+  if (!RegExp(r'^\d+$').hasMatch(last)) return null;
+
+  final length = segments.length;
+  if (length >= 2 && segments[length - 2] == 'check-runs') {
+    return last;
+  }
+
+  if (length >= 3 &&
+      (segments[length - 2] == 'job' || segments[length - 2] == 'jobs') &&
+      segments.contains('actions') &&
+      segments.contains('runs')) {
+    return last;
+  }
+
+  if (length >= 2 &&
+      segments[length - 2] == 'runs' &&
+      !segments.contains('actions')) {
+    return last;
+  }
+
+  return null;
+}
+
 /// Fetches logs and annotations for a failed status check.
 ///
 /// Attempts to fetch job-level logs via `/actions/jobs/{job_id}/logs` and
@@ -458,19 +498,13 @@ Future<List<PrCheckRun>> fetchPrChecks(PrContext context) async {
 /// Falls back to `gh run view --log-failed` if job-level API calls fail.
 Future<String> fetchFailedCheckLog(PrContext context, PrCheckRun check) async {
   final link = check.link;
-  final runIdMatch = RegExp(r'/actions/runs/(\d+)').firstMatch(link);
-  final checkRunIdMatch =
-      RegExp(r'/check-runs/(\d+)').firstMatch(link) ??
-      RegExp(r'/actions/runs/\d+/jobs?/(\d+)').firstMatch(link) ??
-      (link.contains('/actions/runs/')
-          ? null
-          : RegExp(r'/runs/(\d+)').firstMatch(link));
+  final runId = parseRunIdFromLink(link);
+  final checkRunId = parseCheckRunIdFromLink(link);
   final repoArgs = ['-R', '${context.owner}/${context.repo}'];
 
   final annotations = <String>[];
 
-  if (checkRunIdMatch != null) {
-    final checkRunId = checkRunIdMatch.group(1)!;
+  if (checkRunId != null) {
     try {
       final annOutput = await runCommand('gh', [
         ...repoArgs,
@@ -496,8 +530,7 @@ Future<String> fetchFailedCheckLog(PrContext context, PrCheckRun check) async {
     }
   }
 
-  if (runIdMatch != null) {
-    final runId = runIdMatch.group(1)!;
+  if (runId != null) {
     try {
       final jobsOutput = await runCommand('gh', [
         ...repoArgs,

--- a/skills/github-pr-triage/lib/github_cli.dart
+++ b/skills/github-pr-triage/lib/github_cli.dart
@@ -461,6 +461,7 @@ Future<String> fetchFailedCheckLog(PrContext context, PrCheckRun check) async {
   final runIdMatch = RegExp(r'/actions/runs/(\d+)').firstMatch(link);
   final checkRunIdMatch =
       RegExp(r'/check-runs/(\d+)').firstMatch(link) ??
+      RegExp(r'/actions/runs/\d+/jobs?/(\d+)').firstMatch(link) ??
       (link.contains('/actions/runs/')
           ? null
           : RegExp(r'/runs/(\d+)').firstMatch(link));

--- a/skills/github-pr-triage/lib/github_cli.dart
+++ b/skills/github-pr-triage/lib/github_cli.dart
@@ -453,7 +453,8 @@ Future<List<PrCheckRun>> fetchPrChecks(PrContext context) async {
 
 /// Extracts the workflow run ID from a GitHub Actions URL (e.g. `.../actions/runs/12345`).
 String? parseRunIdFromLink(String link) {
-  final segments = Uri.tryParse(link)?.pathSegments ?? const [];
+  final rawSegments = Uri.tryParse(link)?.pathSegments ?? const [];
+  final segments = rawSegments.where((s) => s.isNotEmpty).toList();
   final idx = segments.indexOf('runs');
   if (idx > 0 && segments[idx - 1] == 'actions' && idx + 1 < segments.length) {
     final candidate = segments[idx + 1];
@@ -464,7 +465,8 @@ String? parseRunIdFromLink(String link) {
 
 /// Extracts the check run ID from a GitHub check run or job URL.
 String? parseCheckRunIdFromLink(String link) {
-  final segments = Uri.tryParse(link)?.pathSegments ?? const [];
+  final rawSegments = Uri.tryParse(link)?.pathSegments ?? const [];
+  final segments = rawSegments.where((s) => s.isNotEmpty).toList();
   if (segments.isEmpty) return null;
 
   final last = segments.last;

--- a/skills/github-pr-triage/lib/github_cli.dart
+++ b/skills/github-pr-triage/lib/github_cli.dart
@@ -459,7 +459,9 @@ Future<List<PrCheckRun>> fetchPrChecks(PrContext context) async {
 Future<String> fetchFailedCheckLog(PrContext context, PrCheckRun check) async {
   final link = check.link;
   final runIdMatch = RegExp(r'/actions/runs/(\d+)').firstMatch(link);
-  final checkRunIdMatch = RegExp(r'/check-runs/(\d+)').firstMatch(link);
+  final checkRunIdMatch = RegExp(
+    r'/(?:check-runs|runs)/(\d+)',
+  ).firstMatch(link);
   final repoArgs = ['-R', '${context.owner}/${context.repo}'];
 
   final annotations = <String>[];

--- a/skills/github-pr-triage/lib/github_cli.dart
+++ b/skills/github-pr-triage/lib/github_cli.dart
@@ -459,9 +459,11 @@ Future<List<PrCheckRun>> fetchPrChecks(PrContext context) async {
 Future<String> fetchFailedCheckLog(PrContext context, PrCheckRun check) async {
   final link = check.link;
   final runIdMatch = RegExp(r'/actions/runs/(\d+)').firstMatch(link);
-  final checkRunIdMatch = RegExp(
-    r'/(?:check-runs|runs)/(\d+)',
-  ).firstMatch(link);
+  final checkRunIdMatch =
+      RegExp(r'/check-runs/(\d+)').firstMatch(link) ??
+      (link.contains('/actions/runs/')
+          ? null
+          : RegExp(r'/runs/(\d+)').firstMatch(link));
   final repoArgs = ['-R', '${context.owner}/${context.repo}'];
 
   final annotations = <String>[];

--- a/skills/github-pr-triage/lib/github_cli.dart
+++ b/skills/github-pr-triage/lib/github_cli.dart
@@ -1,6 +1,9 @@
 import 'dart:convert';
 import 'dart:io';
 
+final _digitsOnly = RegExp(r'^\d+$');
+final _prUrlRegExp = RegExp(r'github\.com/([^/]+)/([^/]+)/pull/(\d+)');
+
 /// Encapsulates context for a target Pull Request and workspace directory.
 class PrContext {
   final String workingDir;
@@ -83,14 +86,12 @@ Future<PrContext> resolvePrContext(
   String? repo;
 
   if (prInput != null) {
-    final prUrlMatch = RegExp(
-      r'github\.com/([^/]+)/([^/]+)/pull/(\d+)',
-    ).firstMatch(prInput);
+    final prUrlMatch = _prUrlRegExp.firstMatch(prInput);
     if (prUrlMatch != null) {
       owner = prUrlMatch.group(1);
       repo = prUrlMatch.group(2);
       prNumber = prUrlMatch.group(3);
-    } else if (RegExp(r'^\d+$').hasMatch(prInput)) {
+    } else if (_digitsOnly.hasMatch(prInput)) {
       prNumber = prInput;
     } else {
       onFail(
@@ -456,7 +457,7 @@ String? parseRunIdFromLink(String link) {
   final idx = segments.indexOf('runs');
   if (idx > 0 && segments[idx - 1] == 'actions' && idx + 1 < segments.length) {
     final candidate = segments[idx + 1];
-    if (RegExp(r'^\d+$').hasMatch(candidate)) return candidate;
+    if (_digitsOnly.hasMatch(candidate)) return candidate;
   }
   return null;
 }
@@ -467,7 +468,7 @@ String? parseCheckRunIdFromLink(String link) {
   if (segments.isEmpty) return null;
 
   final last = segments.last;
-  if (!RegExp(r'^\d+$').hasMatch(last)) return null;
+  if (!_digitsOnly.hasMatch(last)) return null;
 
   final length = segments.length;
   if (length >= 2 && segments[length - 2] == 'check-runs') {
@@ -707,7 +708,7 @@ Future<void> replyToComment(
   required String commentId,
   required String body,
 }) async {
-  if (!RegExp(r'^\d+$').hasMatch(commentId)) {
+  if (!_digitsOnly.hasMatch(commentId)) {
     throw ArgumentError('Comment ID must be a numeric database ID.');
   }
   if (body.trim().isEmpty) {

--- a/skills/github-pr-triage/lib/github_cli.dart
+++ b/skills/github-pr-triage/lib/github_cli.dart
@@ -450,6 +450,122 @@ Future<List<PrCheckRun>> fetchPrChecks(PrContext context) async {
   }
 }
 
+/// Fetches logs and annotations for a failed status check.
+///
+/// Attempts to fetch job-level logs via `/actions/jobs/{job_id}/logs` and
+/// check run annotations via `/check-runs/{check_run_id}/annotations` to
+/// avoid failures when sibling workflow jobs are still in progress.
+/// Falls back to `gh run view --log-failed` if job-level API calls fail.
+Future<String> fetchFailedCheckLog(PrContext context, PrCheckRun check) async {
+  final link = check.link;
+  final runIdMatch = RegExp(r'/actions/runs/(\d+)').firstMatch(link);
+  final checkRunIdMatch = RegExp(r'/check-runs/(\d+)').firstMatch(link);
+  final repoArgs = ['-R', '${context.owner}/${context.repo}'];
+
+  final annotations = <String>[];
+
+  if (checkRunIdMatch != null) {
+    final checkRunId = checkRunIdMatch.group(1)!;
+    try {
+      final annOutput = await runCommand('gh', [
+        ...repoArgs,
+        'api',
+        'repos/${context.owner}/${context.repo}/check-runs/$checkRunId/annotations',
+      ], workingDirectory: context.workingDir);
+      final annList = jsonDecode(annOutput) as List<dynamic>;
+      for (final ann in annList.whereType<Map>()) {
+        final path = ann['path']?.toString() ?? '';
+        final startLine = ann['start_line'];
+        final message = ann['message']?.toString() ?? '';
+        final level = ann['annotation_level']?.toString() ?? '';
+        final title = ann['title']?.toString() ?? '';
+        if (message.isNotEmpty) {
+          annotations.add(
+            'Annotation [$level] ${path.isNotEmpty ? "$path:$startLine " : ""}'
+            '${title.isNotEmpty ? "($title): " : ""}$message',
+          );
+        }
+      }
+    } catch (_) {
+      // Annotations fetch is best-effort.
+    }
+  }
+
+  if (runIdMatch != null) {
+    final runId = runIdMatch.group(1)!;
+    try {
+      final jobsOutput = await runCommand('gh', [
+        ...repoArgs,
+        'api',
+        'repos/${context.owner}/${context.repo}/actions/runs/$runId/jobs',
+      ], workingDirectory: context.workingDir);
+      final jobsJson = jsonDecode(jobsOutput) as Map<String, dynamic>;
+      final jobsList = (jobsJson['jobs'] as List<dynamic>? ?? [])
+          .whereType<Map>()
+          .toList();
+      final failedJobs = jobsList.where((j) {
+        final conc = j['conclusion']?.toString();
+        return conc == 'failure' ||
+            conc == 'timed_out' ||
+            conc == 'action_required';
+      }).toList();
+
+      if (failedJobs.isNotEmpty) {
+        final logBuffers = <String>[];
+        for (final job in failedJobs) {
+          final jobId = job['id']?.toString();
+          final jobName = job['name']?.toString() ?? 'Job';
+          if (jobId != null && jobId.isNotEmpty) {
+            try {
+              final jobLog = await runCommand('gh', [
+                ...repoArgs,
+                'api',
+                'repos/${context.owner}/${context.repo}/actions/jobs/$jobId/logs',
+              ], workingDirectory: context.workingDir);
+              if (jobLog.trim().isNotEmpty) {
+                logBuffers.add('--- Job: $jobName (ID: $jobId) ---\n$jobLog');
+              }
+            } catch (_) {}
+          }
+        }
+
+        if (logBuffers.isNotEmpty) {
+          final combinedLog = logBuffers.join('\n\n');
+          if (annotations.isNotEmpty) {
+            return 'Check Annotations:\n${annotations.join("\n")}\n\n$combinedLog';
+          }
+          return combinedLog;
+        }
+      }
+    } catch (_) {}
+
+    try {
+      final fallbackLog = await runCommand('gh', [
+        ...repoArgs,
+        'run',
+        'view',
+        runId,
+        '--log-failed',
+      ], workingDirectory: context.workingDir);
+      if (annotations.isNotEmpty) {
+        return 'Check Annotations:\n${annotations.join("\n")}\n\n$fallbackLog';
+      }
+      return fallbackLog;
+    } catch (e) {
+      if (annotations.isNotEmpty) {
+        return 'Check Annotations:\n${annotations.join("\n")}\n\nFailed to fetch logs: $e';
+      }
+      return 'Failed to fetch logs: $e';
+    }
+  }
+
+  if (annotations.isNotEmpty) {
+    return 'Check Annotations:\n${annotations.join("\n")}\n\nNon-GitHub Actions run. Inspect details at: $link';
+  }
+
+  return 'Non-GitHub Actions run. Inspect details at: $link';
+}
+
 /// Fetches comments, reviews, and review threads for the specified [PrContext] using GraphQL.
 Future<PrGraphData> fetchPrGraphQLData(PrContext context) async {
   const query = r'''

--- a/skills/github-pr-triage/lib/github_cli.dart
+++ b/skills/github-pr-triage/lib/github_cli.dart
@@ -703,7 +703,7 @@ Future<PrGraphData> fetchPrGraphQLData(PrContext context) async {
 }
 
 /// Posts a reply to a PR review comment using its numeric [commentId].
-Future<void> replyToComment(
+Future<void> _replyToComment(
   PrContext context, {
   required String commentId,
   required String body,
@@ -726,7 +726,7 @@ Future<void> replyToComment(
 }
 
 /// Resolves a review thread via GraphQL using its [threadId] (e.g. `PRRT_...`).
-Future<void> resolveReviewThread(
+Future<void> _resolveReviewThread(
   PrContext context, {
   required String threadId,
 }) async {
@@ -773,9 +773,9 @@ Future<void> replyAndResolveThread(
     );
   }
   if (hasCommentId && hasBody) {
-    await replyToComment(context, commentId: commentId, body: body);
+    await _replyToComment(context, commentId: commentId, body: body);
   }
-  await resolveReviewThread(context, threadId: threadId);
+  await _resolveReviewThread(context, threadId: threadId);
 }
 
 PrCheckRun _parsePrCheckRun(Map json) {

--- a/skills/pr-loop/SKILL.md
+++ b/skills/pr-loop/SKILL.md
@@ -84,7 +84,11 @@ which are bypassed in favor of autonomous execution):
     --body "<walkthrough_summary>" --base main --head <head_branch>
   ```
 
-### 2. [START] Schedule Polling Timer
+### 2. [START] Immediate Status Check & Polling Timer
+* **Immediate Initial Check**: Before scheduling a background timer, execute an
+  immediate check of PR status (`dart <path-to-pr-loop-skill>/bin/pr_status.dart --dir .` or `gh pr view`).
+  * If actionable review comments or failed CI checks already exist, **bypass the initial timer** and proceed directly to Step 3/4.
+  * If review feedback or CI checks are still in progress, proceed to schedule the background wakeup timer.
 * Call the `schedule` tool to set a background wakeup timer:
   * **Initial Push**: Set `DurationSeconds=180` (3 minutes) to allow initial bot
     ingestion.
@@ -111,6 +115,12 @@ which are bypassed in favor of autonomous execution):
   3. No review pass is currently in progress (i.e., no new review request has
      been submitted since the last bot review).
   4. The local git branch commit SHA is fully in sync with the remote PR head commit (`is_synced: true`).
+
+  > [!IMPORTANT]
+  > **NO LOCAL OVERRIDES / RATIONALIZATIONS**:
+  > Passing local tests (`dart analyze`, `dart test`) are NEVER a substitute for remote CI status.
+  > If `pr_status.dart` returns `"can_terminate": false`, the agent MUST NOT exit the loop
+  > or declare victory early under any circumstances, regardless of local test results.
 * **Action on In-Progress Activity**: If `pr_status.dart` returns
   `"can_terminate": false` because CI checks are in-progress or a review pass is
   currently in progress, **schedule another 90s timer** and **go idle**. DO
@@ -181,10 +191,13 @@ which are bypassed in favor of autonomous execution):
   `resolveReviewThread` mutation for that thread BEFORE setting the background
   wakeup timer.
 
-### 6. Trigger Subsequent Review Pass
-* **CRITICAL OPERATIONAL REMINDER**: `gemini-code-assist` automatically ingests
-  the *first* PR push. However, for **every subsequent push**, you MUST
-  explicitly prompt the bot again by posting a comment on the main PR thread:
+### 6. Trigger Subsequent Review Pass (Or Terminate Zero-Change Loop)
+* **Zero-Code-Change Loop Termination Rule**:
+  If **0 code changes** were made in an iteration because all review comments were evaluated via the empirical verification gate (`dart analyze` returned 0 issues) and classified as `👎 Disagree`:
+  * **DO NOT** comment `/gemini review` on the PR. Re-triggering the review bot on the exact same commit causes an infinite review loop.
+  * **DO** post empirical disagreement replies on all review threads, resolve all threads via GraphQL (`triage.dart resolve`), and **terminate the loop immediately** with a final status summary.
+* **Subsequent Push Review Trigger**:
+  If code changes or new test files **were** committed and pushed to `origin`, you MUST explicitly prompt the bot again by posting a comment on the main PR thread:
   ```bash
   gh pr comment <pr_number> --body "/gemini review"
   ```

--- a/tool/test/job_logs_test.dart
+++ b/tool/test/job_logs_test.dart
@@ -37,5 +37,16 @@ void main() {
       expect(result, contains('Non-GitHub Actions run'));
       expect(result, contains('https://example.com/build/123'));
     });
+
+    test('checkRunIdMatch matches both /check-runs/ and /runs/', () {
+      final regex = RegExp(r'/(?:check-runs|runs)/(\d+)');
+      final match1 = regex.firstMatch(
+        'https://github.com/foo/bar/check-runs/12345',
+      );
+      final match2 = regex.firstMatch('https://github.com/foo/bar/runs/67890');
+
+      expect(match1?.group(1), equals('12345'));
+      expect(match2?.group(1), equals('67890'));
+    });
   });
 }

--- a/tool/test/job_logs_test.dart
+++ b/tool/test/job_logs_test.dart
@@ -38,15 +38,27 @@ void main() {
       expect(result, contains('https://example.com/build/123'));
     });
 
-    test('checkRunIdMatch matches both /check-runs/ and /runs/', () {
-      final regex = RegExp(r'/(?:check-runs|runs)/(\d+)');
-      final match1 = regex.firstMatch(
-        'https://github.com/foo/bar/check-runs/12345',
-      );
-      final match2 = regex.firstMatch('https://github.com/foo/bar/runs/67890');
+    test(
+      'checkRunIdMatch matches both /check-runs/ and /runs/ but excludes /actions/runs/',
+      () {
+        RegExpMatch? parseCheckRunId(String link) =>
+            RegExp(r'/check-runs/(\d+)').firstMatch(link) ??
+            (link.contains('/actions/runs/')
+                ? null
+                : RegExp(r'/runs/(\d+)').firstMatch(link));
 
-      expect(match1?.group(1), equals('12345'));
-      expect(match2?.group(1), equals('67890'));
-    });
+        final match1 = parseCheckRunId(
+          'https://github.com/foo/bar/check-runs/12345',
+        );
+        final match2 = parseCheckRunId('https://github.com/foo/bar/runs/67890');
+        final match3 = parseCheckRunId(
+          'https://github.com/foo/bar/actions/runs/67890',
+        );
+
+        expect(match1?.group(1), equals('12345'));
+        expect(match2?.group(1), equals('67890'));
+        expect(match3, isNull);
+      },
+    );
   });
 }

--- a/tool/test/job_logs_test.dart
+++ b/tool/test/job_logs_test.dart
@@ -47,6 +47,12 @@ void main() {
       );
       expect(
         parseRunIdFromLink(
+          'https://github.com/owner/repo/actions/runs/123456789/',
+        ),
+        equals('123456789'),
+      );
+      expect(
+        parseRunIdFromLink(
           'https://github.com/owner/repo/actions/runs/123456789/job/987654321',
         ),
         equals('123456789'),
@@ -64,7 +70,17 @@ void main() {
           equals('12345'),
         );
         expect(
+          parseCheckRunIdFromLink(
+            'https://github.com/foo/bar/check-runs/12345/',
+          ),
+          equals('12345'),
+        );
+        expect(
           parseCheckRunIdFromLink('https://github.com/foo/bar/runs/67890'),
+          equals('67890'),
+        );
+        expect(
+          parseCheckRunIdFromLink('https://github.com/foo/bar/runs/67890/'),
           equals('67890'),
         );
         expect(
@@ -76,6 +92,12 @@ void main() {
         expect(
           parseCheckRunIdFromLink(
             'https://github.com/foo/bar/actions/runs/12345/job/67890',
+          ),
+          equals('67890'),
+        );
+        expect(
+          parseCheckRunIdFromLink(
+            'https://github.com/foo/bar/actions/runs/12345/job/67890/',
           ),
           equals('67890'),
         );

--- a/tool/test/job_logs_test.dart
+++ b/tool/test/job_logs_test.dart
@@ -1,0 +1,41 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import '../../skills/github-pr-triage/lib/github_cli.dart';
+
+void main() {
+  group('fetchFailedCheckLog unit tests', () {
+    late Directory tempDir;
+    late PrContext context;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('job_logs_test_');
+      context = PrContext(
+        workingDir: tempDir.path,
+        prNumber: '999',
+        owner: 'test-owner',
+        repo: 'test-repo',
+      );
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('returns non-GHA notice when link is not GitHub Actions', () async {
+      final check = (
+        name: 'Custom Check',
+        state: 'FAILURE',
+        bucket: 'fail',
+        link: 'https://example.com/build/123',
+        workflow: 'Custom',
+      );
+
+      final result = await fetchFailedCheckLog(context, check);
+      expect(result, contains('Non-GitHub Actions run'));
+      expect(result, contains('https://example.com/build/123'));
+    });
+  });
+}

--- a/tool/test/job_logs_test.dart
+++ b/tool/test/job_logs_test.dart
@@ -38,35 +38,53 @@ void main() {
       expect(result, contains('https://example.com/build/123'));
     });
 
+    test('parseRunIdFromLink extracts run ID from GitHub Actions URLs', () {
+      expect(
+        parseRunIdFromLink(
+          'https://github.com/owner/repo/actions/runs/123456789',
+        ),
+        equals('123456789'),
+      );
+      expect(
+        parseRunIdFromLink(
+          'https://github.com/owner/repo/actions/runs/123456789/job/987654321',
+        ),
+        equals('123456789'),
+      );
+      expect(parseRunIdFromLink('https://example.com/build/123456789'), isNull);
+    });
+
     test(
-      'checkRunIdMatch matches /check-runs/, /runs/, and job-level URLs but excludes plain /actions/runs/',
+      'parseCheckRunIdFromLink extracts check run IDs and job IDs correctly',
       () {
-        RegExpMatch? parseCheckRunId(String link) =>
-            RegExp(r'/check-runs/(\d+)').firstMatch(link) ??
-            RegExp(r'/actions/runs/\d+/jobs?/(\d+)').firstMatch(link) ??
-            (link.contains('/actions/runs/')
-                ? null
-                : RegExp(r'/runs/(\d+)').firstMatch(link));
-
-        final match1 = parseCheckRunId(
-          'https://github.com/foo/bar/check-runs/12345',
+        expect(
+          parseCheckRunIdFromLink(
+            'https://github.com/foo/bar/check-runs/12345',
+          ),
+          equals('12345'),
         );
-        final match2 = parseCheckRunId('https://github.com/foo/bar/runs/67890');
-        final match3 = parseCheckRunId(
-          'https://github.com/foo/bar/actions/runs/67890',
+        expect(
+          parseCheckRunIdFromLink('https://github.com/foo/bar/runs/67890'),
+          equals('67890'),
         );
-        final match4 = parseCheckRunId(
-          'https://github.com/foo/bar/actions/runs/12345/job/67890',
+        expect(
+          parseCheckRunIdFromLink(
+            'https://github.com/foo/bar/actions/runs/67890',
+          ),
+          isNull,
         );
-        final match5 = parseCheckRunId(
-          'https://github.com/foo/bar/actions/runs/12345/jobs/67890',
+        expect(
+          parseCheckRunIdFromLink(
+            'https://github.com/foo/bar/actions/runs/12345/job/67890',
+          ),
+          equals('67890'),
         );
-
-        expect(match1?.group(1), equals('12345'));
-        expect(match2?.group(1), equals('67890'));
-        expect(match3, isNull);
-        expect(match4?.group(1), equals('67890'));
-        expect(match5?.group(1), equals('67890'));
+        expect(
+          parseCheckRunIdFromLink(
+            'https://github.com/foo/bar/actions/runs/12345/jobs/67890',
+          ),
+          equals('67890'),
+        );
       },
     );
   });

--- a/tool/test/job_logs_test.dart
+++ b/tool/test/job_logs_test.dart
@@ -39,10 +39,11 @@ void main() {
     });
 
     test(
-      'checkRunIdMatch matches both /check-runs/ and /runs/ but excludes /actions/runs/',
+      'checkRunIdMatch matches /check-runs/, /runs/, and job-level URLs but excludes plain /actions/runs/',
       () {
         RegExpMatch? parseCheckRunId(String link) =>
             RegExp(r'/check-runs/(\d+)').firstMatch(link) ??
+            RegExp(r'/actions/runs/\d+/jobs?/(\d+)').firstMatch(link) ??
             (link.contains('/actions/runs/')
                 ? null
                 : RegExp(r'/runs/(\d+)').firstMatch(link));
@@ -54,10 +55,18 @@ void main() {
         final match3 = parseCheckRunId(
           'https://github.com/foo/bar/actions/runs/67890',
         );
+        final match4 = parseCheckRunId(
+          'https://github.com/foo/bar/actions/runs/12345/job/67890',
+        );
+        final match5 = parseCheckRunId(
+          'https://github.com/foo/bar/actions/runs/12345/jobs/67890',
+        );
 
         expect(match1?.group(1), equals('12345'));
         expect(match2?.group(1), equals('67890'));
         expect(match3, isNull);
+        expect(match4?.group(1), equals('67890'));
+        expect(match5?.group(1), equals('67890'));
       },
     );
   });


### PR DESCRIPTION
Consolidated PR for PR-Triage and PR-Loop skill enhancements.

### Summary of Changes:
- **Issue #28**: Added explicit anti-rationalization guardrails in `pr-loop/SKILL.md` prohibiting early termination when `pr_status.dart` returns `can_terminate: false`.
- **Issue #31**: Upgraded `github_cli.dart` and `triage.dart` to fetch logs via job-level endpoints (`/actions/jobs/{job_id}/logs`) and check run annotations (`/check-runs/{check_run_id}/annotations`).
- **Issue #32**: Updated `pr-loop/SKILL.md` to perform an immediate check of PR review comments/status before scheduling polling timers.
- **Issue #33 & Comment #1**: Enforced mandatory pre-edit `dart analyze` empirical verification gate and zero-code-change loop termination rules in `github-pr-triage/SKILL.md` and `pr-loop/SKILL.md`.
- **Unit Tests**: Added `tool/test/job_logs_test.dart` verifying `fetchFailedCheckLog`.

Fixes #28
Fixes #31
Fixes #32
Fixes #33