### PR TITLE
feat(github-pr-triage): support fork workflows and hard CI check gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ procedural, actionable instructions to AI assistants for specific domains or tas
 <!-- SKILLS_LIST_START -->
 To install any skill individually:
 ```bash
-npx skills add kevmoo/kevmoo_skills --skill <skill-name>
+npx skills add kevmoo/github_pr_triage_team --skill <skill-name>
 ```
 
 | Skill | Description | Key Features |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ procedural, actionable instructions to AI assistants for specific domains or tas
 <!-- SKILLS_LIST_START -->
 To install any skill individually:
 ```bash
-npx skills add kevmoo/github_pr_triage_team --skill <skill-name>
+npx skills add kevmoo/kevmoo_skills --skill <skill-name>
 ```
 
 | Skill | Description | Key Features |

--- a/skills/github-pr-triage/SKILL.md
+++ b/skills/github-pr-triage/SKILL.md
@@ -98,13 +98,20 @@ key_features:
      - Inform the user and call `ask_question` to ask their preference:
        * Option 1: `(Recommended) Proceed with triaging open comments now`
        * Option 2: `Wait for active CI status checks to complete first`
-     - *(Note: This interactive prompt is bypassed when operating within an
-       outer orchestrator skill like `pr-loop`, which handles background timers
-       automatically)*.
+     - **MANDATORY HARD BLOCK**: When CI is pending, you MUST halt execution after
+       calling `ask_question`. Do NOT proceed to Step 5 (Generate a Triage Report)
+       or create the `pr_triage_report.md` artifact until the user has answered,
+       because final CI results might change the triage plan and action items.
+     - *(Note: This interactive prompt and hard block are bypassed when
+       operating within an outer orchestrator skill like `pr-loop`, which handles
+       background timers automatically)*.
    - Analyze the stack traces, compile errors, or analyzer failures to
      understand why any failed checks failed.
 
 5. **Generate a Triage Report (Artifact)**:
+   - **Prereq (Hard Gate)**: If CI status checks are active/pending, you MUST
+     NOT generate this report until the user has answered the `ask_question`
+     prompt from Step 4.
    - Create a markdown artifact named `pr_triage_report.md` in the artifacts
      directory (using `write_to_file` with `RequestFeedback: true` in
      `ArtifactMetadata` to render an interactive 'Proceed' button). (Note: This
@@ -204,6 +211,11 @@ dart <path-to-github-pr-triage-skill>/bin/triage.dart resolve <thread_graphql_id
 
 
 ## Constraints
+- **Hard CI Gate**: If CI checks are running or pending, you MUST halt execution
+  after calling `ask_question` in Step 4 and DO NOT proceed to Step 5 or
+  generate `pr_triage_report.md` until the user responds, as pending CI
+  results may alter the final triage plan. (Note: Bypassed ONLY IF operating
+  within an outer orchestrator skill like `pr-loop`).
 - **CRITICAL**: You MUST NOT modify files or make any code edits to address PR
   comments or CI failures before generating a `pr_triage_report.md` artifact
   and obtaining explicit user approval on the plan. (Note: This constraint is

--- a/skills/github-pr-triage/lib/github_cli.dart
+++ b/skills/github-pr-triage/lib/github_cli.dart
@@ -19,6 +19,14 @@ class PrContext {
   });
 }
 
+/// Function signature for running external process commands.
+typedef CommandRunner =
+    Future<String> Function(
+      String command,
+      List<String> args, {
+      String? workingDirectory,
+    });
+
 /// Runs an external process command and returns its standard output.
 ///
 /// Throws a [ProcessException] if the command exits with a non-zero exit code.
@@ -49,6 +57,7 @@ Future<String> runCommand(
 Future<PrContext> resolvePrContext(
   List<String> args, {
   required Never Function(String message) onFail,
+  CommandRunner runCommand = runCommand,
 }) async {
   String? prInput;
   String? targetDir;
@@ -181,7 +190,12 @@ Future<PrContext> resolvePrContext(
     final sameOwner = localOwner.toLowerCase() == owner.toLowerCase();
     if (!sameOwner || !sameRepoName) {
       if (!sameRepoName) {
-        final matchesRemote = await _hasGitRemote(workingDir, owner, repo);
+        final matchesRemote = await _hasGitRemote(
+          workingDir,
+          owner,
+          repo,
+          runCommand: runCommand,
+        );
         if (!matchesRemote) {
           onFail(
             'The target directory "$workingDir" is for repository "$localOwner/$localRepo", '
@@ -200,7 +214,12 @@ Future<PrContext> resolvePrContext(
   );
 }
 
-Future<bool> _hasGitRemote(String workingDir, String owner, String repo) async {
+Future<bool> _hasGitRemote(
+  String workingDir,
+  String owner,
+  String repo, {
+  CommandRunner runCommand = runCommand,
+}) async {
   try {
     final output = await runCommand('git', [
       'remote',
@@ -278,6 +297,7 @@ Future<PrSyncStatus> fetchPrSyncStatus(
   PrContext context, {
   String? remoteBranch,
   String? remoteHeadSha,
+  CommandRunner runCommand = runCommand,
 }) async {
   var rBranch = remoteBranch;
   var rHeadSha = remoteHeadSha;
@@ -455,7 +475,10 @@ Future<PrSyncStatus> fetchPrSyncStatus(
 }
 
 /// Fetches status check runs for the specified [PrContext].
-Future<List<PrCheckRun>> fetchPrChecks(PrContext context) async {
+Future<List<PrCheckRun>> fetchPrChecks(
+  PrContext context, {
+  CommandRunner runCommand = runCommand,
+}) async {
   final repoArgs = ['-R', '${context.owner}/${context.repo}'];
   try {
     final checksOutput = await runCommand('gh', [
@@ -524,7 +547,11 @@ String? parseCheckRunIdFromLink(String link) {
 /// check run annotations via `/check-runs/{check_run_id}/annotations` to
 /// avoid failures when sibling workflow jobs are still in progress.
 /// Falls back to `gh run view --log-failed` if job-level API calls fail.
-Future<String> fetchFailedCheckLog(PrContext context, PrCheckRun check) async {
+Future<String> fetchFailedCheckLog(
+  PrContext context,
+  PrCheckRun check, {
+  CommandRunner runCommand = runCommand,
+}) async {
   final link = check.link;
   final runId = parseRunIdFromLink(link);
   final checkRunId = parseCheckRunIdFromLink(link);
@@ -633,7 +660,10 @@ Future<String> fetchFailedCheckLog(PrContext context, PrCheckRun check) async {
 }
 
 /// Fetches comments, reviews, and review threads for the specified [PrContext] using GraphQL.
-Future<PrGraphData> fetchPrGraphQLData(PrContext context) async {
+Future<PrGraphData> fetchPrGraphQLData(
+  PrContext context, {
+  CommandRunner runCommand = runCommand,
+}) async {
   const query = r'''
   query($owner: String!, $repo: String!, $pr: Int!) {
     repository(owner: $owner, name: $repo) {
@@ -734,6 +764,7 @@ Future<void> _replyToComment(
   PrContext context, {
   required String commentId,
   required String body,
+  CommandRunner runCommand = runCommand,
 }) async {
   if (!_digitsOnly.hasMatch(commentId)) {
     throw ArgumentError('Comment ID must be a numeric database ID.');
@@ -756,6 +787,7 @@ Future<void> _replyToComment(
 Future<void> _resolveReviewThread(
   PrContext context, {
   required String threadId,
+  CommandRunner runCommand = runCommand,
 }) async {
   if (threadId.trim().isEmpty) {
     throw ArgumentError('Thread ID cannot be empty.');
@@ -791,6 +823,7 @@ Future<void> replyAndResolveThread(
   required String threadId,
   String? commentId,
   String? body,
+  CommandRunner runCommand = runCommand,
 }) async {
   final hasCommentId = commentId != null && commentId.trim().isNotEmpty;
   final hasBody = body != null && body.trim().isNotEmpty;
@@ -800,9 +833,18 @@ Future<void> replyAndResolveThread(
     );
   }
   if (hasCommentId && hasBody) {
-    await _replyToComment(context, commentId: commentId, body: body);
+    await _replyToComment(
+      context,
+      commentId: commentId,
+      body: body,
+      runCommand: runCommand,
+    );
   }
-  await _resolveReviewThread(context, threadId: threadId);
+  await _resolveReviewThread(
+    context,
+    threadId: threadId,
+    runCommand: runCommand,
+  );
 }
 
 PrCheckRun _parsePrCheckRun(Map json) {

--- a/skills/github-pr-triage/lib/github_cli.dart
+++ b/skills/github-pr-triage/lib/github_cli.dart
@@ -177,12 +177,18 @@ Future<PrContext> resolvePrContext(
       localRepo != null &&
       owner != null &&
       repo != null) {
-    if (localOwner.toLowerCase() != owner.toLowerCase() ||
-        localRepo.toLowerCase() != repo.toLowerCase()) {
-      onFail(
-        'The target directory "$workingDir" is for repository "$localOwner/$localRepo", '
-        'but the specified PR is for repository "$owner/$repo".',
-      );
+    final sameRepoName = localRepo.toLowerCase() == repo.toLowerCase();
+    final sameOwner = localOwner.toLowerCase() == owner.toLowerCase();
+    if (!sameOwner || !sameRepoName) {
+      if (!sameRepoName) {
+        final matchesRemote = await _hasGitRemote(workingDir, owner, repo);
+        if (!matchesRemote) {
+          onFail(
+            'The target directory "$workingDir" is for repository "$localOwner/$localRepo", '
+            'but the specified PR is for repository "$owner/$repo".',
+          );
+        }
+      }
     }
   }
 
@@ -192,6 +198,25 @@ Future<PrContext> resolvePrContext(
     owner: resolvedOwner,
     repo: resolvedRepo,
   );
+}
+
+Future<bool> _hasGitRemote(String workingDir, String owner, String repo) async {
+  try {
+    final output = await runCommand('git', [
+      'remote',
+      '-v',
+    ], workingDirectory: workingDir);
+    final pattern = RegExp(
+      '(?:[/:])${RegExp.escape(owner)}/${RegExp.escape(repo)}(?:\\.git|/|[\\s]|\$)',
+      caseSensitive: false,
+    );
+    for (final line in output.split('\n')) {
+      if (pattern.hasMatch(line)) {
+        return true;
+      }
+    }
+  } catch (_) {}
+  return false;
 }
 
 /// Represents a status check run on a PR.

--- a/tool/bin/readme.dart
+++ b/tool/bin/readme.dart
@@ -161,15 +161,31 @@ Directory? _findRepoRoot(Directory startDir) {
 
 String? parseRepoSlugFromUrl(String rawUrl) {
   var url = rawUrl.trim();
-  if (url.endsWith('.git')) {
-    url = url.substring(0, url.length - 4);
+  if (!url.contains('://') && url.contains('@') && url.contains(':')) {
+    url = 'ssh://${url.replaceFirst(':', '/')}';
   }
-  final regExp = RegExp(r'(?:github\.com[/:]|git@github\.com:)([^/]+/[^/]+)');
-  final match = regExp.firstMatch(url);
-  if (match != null) {
-    return match.group(1);
+
+  final uri = Uri.tryParse(url);
+  if (uri == null || uri.host.toLowerCase() != 'github.com') {
+    return null;
   }
-  return null;
+
+  final segments = uri.pathSegments.where((s) => s.isNotEmpty).toList();
+  if (segments.length < 2) {
+    return null;
+  }
+
+  final owner = segments[0];
+  var repo = segments[1];
+  if (repo.endsWith('.git')) {
+    repo = repo.substring(0, repo.length - 4);
+  }
+
+  if (owner.isEmpty || repo.isEmpty) {
+    return null;
+  }
+
+  return '$owner/$repo';
 }
 
 String _resolveRepoSlug(Directory repoRoot) {

--- a/tool/bin/readme.dart
+++ b/tool/bin/readme.dart
@@ -159,6 +159,19 @@ Directory? _findRepoRoot(Directory startDir) {
   return null;
 }
 
+String? parseRepoSlugFromUrl(String rawUrl) {
+  var url = rawUrl.trim();
+  if (url.endsWith('.git')) {
+    url = url.substring(0, url.length - 4);
+  }
+  final regExp = RegExp(r'(?:github\.com[/:]|git@github\.com:)([^/]+/[^/]+)');
+  final match = regExp.firstMatch(url);
+  if (match != null) {
+    return match.group(1);
+  }
+  return null;
+}
+
 String _resolveRepoSlug(Directory repoRoot) {
   final envRepo = Platform.environment['GITHUB_REPOSITORY'];
   if (envRepo != null && envRepo.isNotEmpty) {
@@ -171,13 +184,9 @@ String _resolveRepoSlug(Directory repoRoot) {
       'remote.origin.url',
     ], workingDirectory: repoRoot.path);
     if (result.exitCode == 0) {
-      final url = result.stdout.toString().trim();
-      final regExp = RegExp(
-        r'(?:github\.com[/:]|git@github\.com:)([^/]+/[^/.]+)(?:\.git)?',
-      );
-      final match = regExp.firstMatch(url);
-      if (match != null) {
-        return match.group(1)!;
+      final slug = parseRepoSlugFromUrl(result.stdout.toString());
+      if (slug != null && slug.isNotEmpty) {
+        return slug;
       }
     }
   } catch (_) {}

--- a/tool/bin/readme.dart
+++ b/tool/bin/readme.dart
@@ -29,9 +29,7 @@ void main(List<String> arguments) async {
     exit(1);
   }
 
-  final repoName = p.basename(repoRoot.path);
-  final repoSlug =
-      Platform.environment['GITHUB_REPOSITORY'] ?? 'kevmoo/$repoName';
+  final repoSlug = _resolveRepoSlug(repoRoot);
 
   final skillsDir = Directory(p.join(repoRoot.path, 'skills'));
   if (!skillsDir.existsSync()) {
@@ -159,6 +157,31 @@ Directory? _findRepoRoot(Directory startDir) {
     dir = parent;
   }
   return null;
+}
+
+String _resolveRepoSlug(Directory repoRoot) {
+  final envRepo = Platform.environment['GITHUB_REPOSITORY'];
+  if (envRepo != null && envRepo.isNotEmpty) {
+    return envRepo;
+  }
+  try {
+    final result = Process.runSync('git', [
+      'config',
+      '--get',
+      'remote.origin.url',
+    ], workingDirectory: repoRoot.path);
+    if (result.exitCode == 0) {
+      final url = result.stdout.toString().trim();
+      final regExp = RegExp(
+        r'(?:github\.com[/:]|git@github\.com:)([^/]+/[^/.]+)(?:\.git)?',
+      );
+      final match = regExp.firstMatch(url);
+      if (match != null) {
+        return match.group(1)!;
+      }
+    }
+  } catch (_) {}
+  return 'kevmoo/${p.basename(repoRoot.path)}';
 }
 
 Map<dynamic, dynamic> _parseFrontMatter(String content) {

--- a/tool/test/readme_test.dart
+++ b/tool/test/readme_test.dart
@@ -32,6 +32,27 @@ void main() {
       );
     });
 
+    test('extracts slug from URL with trailing slash', () {
+      expect(
+        readme.parseRepoSlugFromUrl('https://github.com/owner/repo/'),
+        equals('owner/repo'),
+      );
+    });
+
+    test('extracts slug from full pull request subpath URL', () {
+      expect(
+        readme.parseRepoSlugFromUrl('https://github.com/owner/repo/pull/39'),
+        equals('owner/repo'),
+      );
+    });
+
+    test('extracts slug from ssh:// URL with .git suffix', () {
+      expect(
+        readme.parseRepoSlugFromUrl('ssh://git@github.com/owner/repo.git'),
+        equals('owner/repo'),
+      );
+    });
+
     test('returns null for non-github URLs', () {
       expect(
         readme.parseRepoSlugFromUrl('https://gitlab.com/owner/repo.git'),

--- a/tool/test/readme_test.dart
+++ b/tool/test/readme_test.dart
@@ -1,7 +1,45 @@
 import 'dart:io';
 import 'package:test/test.dart';
+import '../bin/readme.dart' as readme;
 
 void main() {
+  group('parseRepoSlugFromUrl unit tests', () {
+    test('extracts slug from https URL with .git suffix', () {
+      expect(
+        readme.parseRepoSlugFromUrl(
+          'https://github.com/kevmoo/angular.dart.git',
+        ),
+        equals('kevmoo/angular.dart'),
+      );
+    });
+
+    test(
+      'extracts slug from SSH URL with .git suffix and dots in repo name',
+      () {
+        expect(
+          readme.parseRepoSlugFromUrl(
+            'git@github.com:kevmoo/built_value.dart.git',
+          ),
+          equals('kevmoo/built_value.dart'),
+        );
+      },
+    );
+
+    test('extracts slug when no .git suffix exists', () {
+      expect(
+        readme.parseRepoSlugFromUrl('https://github.com/owner/repo'),
+        equals('owner/repo'),
+      );
+    });
+
+    test('returns null for non-github URLs', () {
+      expect(
+        readme.parseRepoSlugFromUrl('https://gitlab.com/owner/repo.git'),
+        isNull,
+      );
+    });
+  });
+
   test('validate README.md is up-to-date with the latest skills', () async {
     final scriptPath = Directory.current.path.endsWith('tool')
         ? 'bin/readme.dart'

--- a/tool/test/sync_status_test.dart
+++ b/tool/test/sync_status_test.dart
@@ -372,4 +372,109 @@ void main() {
       },
     );
   });
+
+  group('resolvePrContext unit tests', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('resolve_pr_test_');
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test(
+      'allows localOwner != owner when localRepo matches repo (fork workflow)',
+      () async {
+        await runCommand('git', ['init'], workingDirectory: tempDir.path);
+        await runCommand('git', [
+          'remote',
+          'add',
+          'origin',
+          'https://github.com/kevmoo/kevmoo_skills.git',
+        ], workingDirectory: tempDir.path);
+
+        final context = await resolvePrContext([
+          '--dir',
+          tempDir.path,
+          '--pr',
+          'https://github.com/forkcontributor/kevmoo_skills/pull/10',
+        ], onFail: (message) => fail('Should not fail: $message'));
+
+        expect(context.owner, equals('forkcontributor'));
+        expect(context.repo, equals('kevmoo_skills'));
+        expect(context.prNumber, equals('10'));
+      },
+    );
+
+    test(
+      'allows localRepo != repo when owner/repo matches configured git remote',
+      () async {
+        await runCommand('git', ['init'], workingDirectory: tempDir.path);
+        await runCommand('git', [
+          'remote',
+          'add',
+          'origin',
+          'https://github.com/kevmoo/kevmoo_skills.git',
+        ], workingDirectory: tempDir.path);
+        await runCommand('git', [
+          'remote',
+          'add',
+          'upstream',
+          'https://github.com/upstreamowner/some_other_repo.git',
+        ], workingDirectory: tempDir.path);
+
+        final context = await resolvePrContext([
+          '--dir',
+          tempDir.path,
+          '--pr',
+          'https://github.com/upstreamowner/some_other_repo/pull/25',
+        ], onFail: (message) => fail('Should not fail: $message'));
+
+        expect(context.owner, equals('upstreamowner'));
+        expect(context.repo, equals('some_other_repo'));
+        expect(context.prNumber, equals('25'));
+      },
+    );
+
+    test(
+      'rejects when localRepo != repo and owner/repo is not in git remotes',
+      () async {
+        await runCommand('git', ['init'], workingDirectory: tempDir.path);
+        await runCommand('git', [
+          'remote',
+          'add',
+          'origin',
+          'https://github.com/kevmoo/kevmoo_skills.git',
+        ], workingDirectory: tempDir.path);
+
+        String? failMsg;
+        try {
+          await resolvePrContext(
+            [
+              '--dir',
+              tempDir.path,
+              '--pr',
+              'https://github.com/otherowner/unrelated_repo/pull/50',
+            ],
+            onFail: (message) {
+              failMsg = message;
+              throw StateError(message);
+            },
+          );
+        } catch (_) {}
+
+        expect(
+          failMsg,
+          contains(
+            'The target directory "${tempDir.path}" is for repository "kevmoo/kevmoo_skills", '
+            'but the specified PR is for repository "otherowner/unrelated_repo".',
+          ),
+        );
+      },
+    );
+  });
 }

--- a/tool/test/sync_status_test.dart
+++ b/tool/test/sync_status_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
@@ -386,6 +387,23 @@ void main() {
       }
     });
 
+    Future<String> mockRunCommand(
+      String command,
+      List<String> args, {
+      String? workingDirectory,
+    }) async {
+      if (command == 'gh' &&
+          args.length >= 2 &&
+          args[0] == 'repo' &&
+          args[1] == 'view') {
+        return jsonEncode({
+          'owner': {'login': 'kevmoo'},
+          'name': 'kevmoo_skills',
+        });
+      }
+      return runCommand(command, args, workingDirectory: workingDirectory);
+    }
+
     test(
       'allows localOwner != owner when localRepo matches repo (fork workflow)',
       () async {
@@ -397,12 +415,16 @@ void main() {
           'https://github.com/kevmoo/kevmoo_skills.git',
         ], workingDirectory: tempDir.path);
 
-        final context = await resolvePrContext([
-          '--dir',
-          tempDir.path,
-          '--pr',
-          'https://github.com/forkcontributor/kevmoo_skills/pull/10',
-        ], onFail: (message) => fail('Should not fail: $message'));
+        final context = await resolvePrContext(
+          [
+            '--dir',
+            tempDir.path,
+            '--pr',
+            'https://github.com/forkcontributor/kevmoo_skills/pull/10',
+          ],
+          onFail: (message) => fail('Should not fail: $message'),
+          runCommand: mockRunCommand,
+        );
 
         expect(context.owner, equals('forkcontributor'));
         expect(context.repo, equals('kevmoo_skills'));
@@ -427,12 +449,16 @@ void main() {
           'https://github.com/upstreamowner/some_other_repo.git',
         ], workingDirectory: tempDir.path);
 
-        final context = await resolvePrContext([
-          '--dir',
-          tempDir.path,
-          '--pr',
-          'https://github.com/upstreamowner/some_other_repo/pull/25',
-        ], onFail: (message) => fail('Should not fail: $message'));
+        final context = await resolvePrContext(
+          [
+            '--dir',
+            tempDir.path,
+            '--pr',
+            'https://github.com/upstreamowner/some_other_repo/pull/25',
+          ],
+          onFail: (message) => fail('Should not fail: $message'),
+          runCommand: mockRunCommand,
+        );
 
         expect(context.owner, equals('upstreamowner'));
         expect(context.repo, equals('some_other_repo'));
@@ -464,6 +490,7 @@ void main() {
               failMsg = message;
               throw StateError(message);
             },
+            runCommand: mockRunCommand,
           );
         } catch (_) {}
 


### PR DESCRIPTION
Update `resolvePrContext` to support fork workflows and make the pending CI check a mandatory hard block during triage.

- Allow `localOwner != owner` when repository names match (`localRepo == repo`) or when `owner/repo` matches any configured remote (`git remote -v`).
- Enforce a mandatory hard gate in `github-pr-triage` Step 4/Step 5 when CI status is pending so agents do not skip user prompts.
- Add unit tests verifying `resolvePrContext` fork verification scenarios.
- Synchronize `README.md` skills table.

Fixes #36
Fixes #37
