### PR TITLE
refactor(skills): optimize tool usage and improve harness compatibility

### DIFF
--- a/skills/clarify-confirm-continue/SKILL.md
+++ b/skills/clarify-confirm-continue/SKILL.md
@@ -55,7 +55,7 @@ Immediately following the summary in the same turn, invoke the `ask_question` to
 
 ### Phase 4: Handling Gate Selection
 - **If "Yes, proceed"**: Transition immediately to task execution.
-- **If "Open in artifact"**: Use `write_to_file` to save the structured summary and execution plan as a markdown artifact (`.md` file) in the session's artifact directory. Stop calling tools and wait for the user's line-by-line review and comments.
+- **If "Open in artifact"**: Use your file-writing tools to save the structured summary and execution plan as a markdown artifact (`.md` file) in the workspace. Configure the file to request interactive approval/feedback (e.g., set `RequestFeedback: true` in Jetski's `ArtifactMetadata` to render a 'Proceed' button). If the harness does not support interactive gates, instruct the user in chat to review the file and reply 'Proceed' when they are ready. Stop calling tools and wait for the user's review and comments.
 - **If "No, adjust in chat"**: Ask what needs adjustment or loop back to Phase 1.
 
 ## Critical Rule: Zero Execution Before Approval & Global Rules

--- a/skills/clarify-confirm-continue/SKILL.md
+++ b/skills/clarify-confirm-continue/SKILL.md
@@ -55,7 +55,7 @@ Immediately following the summary in the same turn, invoke the `ask_question` to
 
 ### Phase 4: Handling Gate Selection
 - **If "Yes, proceed"**: Transition immediately to task execution.
-- **If "Open in artifact"**: Use your file-writing tools to save the structured summary and execution plan as a markdown artifact (`.md` file) in the workspace. Configure the file to request interactive approval/feedback (e.g., set `RequestFeedback: true` in Antigravity's `ArtifactMetadata` to render a 'Proceed' button). If the harness does not support interactive gates, instruct the user in chat to review the file and reply 'Proceed' when they are ready. Stop calling tools and wait for the user's review and comments.
+- **If "Open in artifact"**: Use your file-writing tools to save the structured summary and execution plan as a markdown artifact (`.md` file) in the session's artifact directory. Configure the file to request interactive approval/feedback (e.g., set `RequestFeedback: true` in Antigravity's `ArtifactMetadata` to render a 'Proceed' button). If the harness does not support interactive gates, instruct the user in chat to review the file and reply 'Proceed' when they are ready. Stop calling tools and wait for the user's review and comments.
 - **If "No, adjust in chat"**: Ask what needs adjustment or loop back to Phase 1.
 
 ## Critical Rule: Zero Execution Before Approval & Global Rules

--- a/skills/clarify-confirm-continue/SKILL.md
+++ b/skills/clarify-confirm-continue/SKILL.md
@@ -55,7 +55,7 @@ Immediately following the summary in the same turn, invoke the `ask_question` to
 
 ### Phase 4: Handling Gate Selection
 - **If "Yes, proceed"**: Transition immediately to task execution.
-- **If "Open in artifact"**: Use your file-writing tools to save the structured summary and execution plan as a markdown artifact (`.md` file) in the workspace. Configure the file to request interactive approval/feedback (e.g., set `RequestFeedback: true` in Jetski's `ArtifactMetadata` to render a 'Proceed' button). If the harness does not support interactive gates, instruct the user in chat to review the file and reply 'Proceed' when they are ready. Stop calling tools and wait for the user's review and comments.
+- **If "Open in artifact"**: Use your file-writing tools to save the structured summary and execution plan as a markdown artifact (`.md` file) in the workspace. Configure the file to request interactive approval/feedback (e.g., set `RequestFeedback: true` in Antigravity's `ArtifactMetadata` to render a 'Proceed' button). If the harness does not support interactive gates, instruct the user in chat to review the file and reply 'Proceed' when they are ready. Stop calling tools and wait for the user's review and comments.
 - **If "No, adjust in chat"**: Ask what needs adjustment or loop back to Phase 1.
 
 ## Critical Rule: Zero Execution Before Approval & Global Rules

--- a/skills/distilling-strategies-interactively/SKILL.md
+++ b/skills/distilling-strategies-interactively/SKILL.md
@@ -168,7 +168,10 @@ Dimension                                                              | Option 
 
 Create a definitive document named `DISTILLED_STRATEGY.md` in the conversation
 artifacts directory (`<appDataDir>/brain/<conversation-id>`) using the
-`write_to_file` tool. This document serves as the source of truth for execution.
+`write_to_file` tool. Save this document without requesting interactive
+approval/feedback (e.g., set `RequestFeedback: false` if using Jetski's
+`ArtifactMetadata`), as it serves as a strategic record rather than an
+interactive gateway to immediate execution. This document serves as the source of truth for execution.
 
 Structure the document as follows:
 

--- a/skills/distilling-strategies-interactively/SKILL.md
+++ b/skills/distilling-strategies-interactively/SKILL.md
@@ -104,6 +104,9 @@ highly targeted, interactive quiz to extract the user's latent constraints.
 - Limit the quiz to **4 to 6 questions** total to avoid fatigue.
 - Avoid vague questions (e.g., "What do you want?"). Use forced-choice or
   comparative questions.
+- **Interactive Option Selection**:
+  - If the hosting platform supports interactive choice modals (e.g., Antigravity's `ask_question` tool), you are strongly encouraged to present predictable or multiple-choice questions using that tool (configured with `is_multi_select: true` or single-select) to reduce user typing overhead.
+  - For open-ended questions, or if the harness does not support interactive question modals, fall back to outputting the quiz as a numbered Markdown list directly in chat.
 - Structure the quiz into exactly three categories:
 
 1. **Hard Constraints & Guardrails:** Focus on unyielding boundaries (e.g.,
@@ -169,7 +172,7 @@ Dimension                                                              | Option 
 Create a definitive document named `DISTILLED_STRATEGY.md` in the conversation
 artifacts directory (`<appDataDir>/brain/<conversation-id>`) using the
 `write_to_file` tool. Save this document without requesting interactive
-approval/feedback (e.g., set `RequestFeedback: false` if using Jetski's
+approval/feedback (e.g., set `RequestFeedback: false` if using Antigravity's
 `ArtifactMetadata`), as it serves as a strategic record rather than an
 interactive gateway to immediate execution. This document serves as the source of truth for execution.
 

--- a/skills/gob-curl/SKILL.md
+++ b/skills/gob-curl/SKILL.md
@@ -132,3 +132,8 @@ Check the `messages` array for the most recent status updates from CI bots
     `gob-curl` often prints it as is, and you can just read past it).
 *   Review the `messages` array in the change detail or the output of `comments`
     to identify specific feedback you need to address in the code.
+
+### Asynchronous Execution for Large Logs
+If fetching massive execution logs (e.g., `bb log <BUILD_ID> "<STEP_NAME>"` for a long build step), the download can block the session:
+- **Background Execution**: Propose the command asynchronously (e.g., in Antigravity, set `WaitMsBeforeAsync: 500` or let it background) and schedule a `schedule` wakeup timer to check the task status, allowing you to remain responsive.
+- **Harness-Agnostic Fallback**: Propose the command as a POSIX background job redirecting output to a file (e.g., `bb log ... > build_step.log 2>&1 &`) and monitor the file size or process status (`ps`) in subsequent turns.

--- a/skills/just-brainstorm/SKILL.md
+++ b/skills/just-brainstorm/SKILL.md
@@ -47,7 +47,7 @@ Examples of trigger phrases:
 - The output of this skill **MUST be saved as an artifact** (`.md` file in the
   conversation artifacts directory using the `write_to_file` tool) so the user
   can easily review, share, and comment on specific sections.
-- **Do Not Request Interactive Approval Gates**: When saving the design proposal artifact, ensure that you do not request interactive approval/feedback (e.g., set `RequestFeedback: false` if using Jetski's `ArtifactMetadata`). Because brainstorming is exploratory and does not define a single execution path, a blocking "Proceed" gate is inapplicable. Transition directly to discussion in chat.
+- **Do Not Request Interactive Approval Gates**: When saving the design proposal artifact, ensure that you do not request interactive approval/feedback (e.g., set `RequestFeedback: false` if using Antigravity's `ArtifactMetadata`). Because brainstorming is exploratory and does not define a single execution path, a blocking "Proceed" gate is inapplicable. Transition directly to discussion in chat.
 - Format the artifact clearly with headers, options tables, and pros/cons
   breakdowns.
 

--- a/skills/just-brainstorm/SKILL.md
+++ b/skills/just-brainstorm/SKILL.md
@@ -47,6 +47,7 @@ Examples of trigger phrases:
 - The output of this skill **MUST be saved as an artifact** (`.md` file in the
   conversation artifacts directory using the `write_to_file` tool) so the user
   can easily review, share, and comment on specific sections.
+- **Do Not Request Interactive Approval Gates**: When saving the design proposal artifact, ensure that you do not request interactive approval/feedback (e.g., set `RequestFeedback: false` if using Jetski's `ArtifactMetadata`). Because brainstorming is exploratory and does not define a single execution path, a blocking "Proceed" gate is inapplicable. Transition directly to discussion in chat.
 - Format the artifact clearly with headers, options tables, and pros/cons
   breakdowns.
 

--- a/skills/pr-loop/SKILL.md
+++ b/skills/pr-loop/SKILL.md
@@ -55,7 +55,7 @@ automated AI code review bot (such as `gemini-code-assist`,
 
 If the user halts the execution of `pr-loop` early, or if you decide to pivot to another task, you MUST clean up any active background timers or scheduled tasks to prevent orphaned wakeups:
 - **Antigravity Task Management**: Run `manage_task(Action="list")` to locate any active `schedule` timers created by this skill, and cancel them using `manage_task(Action="kill", TaskId="...")`.
-- **Harness-Agnostic Fallback**: If the harness does not support a graphical task manager, write the Task ID or system process PID (if using POSIX background tasks) to a `.tasks/` directory in the workspace, and ensure you kill those background jobs using standard shell signals (e.g., `kill <PID>`) upon termination.
+- **Harness-Agnostic Fallback**: If the harness does not support a graphical task manager, locate the system process PID (if using POSIX background tasks) by inspecting prior tool calls or using standard process commands (e.g., `ps` or `pgrep`), and ensure you kill those background jobs using standard shell signals (e.g., `kill <PID>`) upon termination. Avoid writing temporary state files to the workspace to prevent repository pollution.
 
 ## 🏗️ Architectural Relationship & Rule Inheritance
 This skill functions as an autonomous, multi-pass loop wrapper around the core

--- a/skills/pr-loop/SKILL.md
+++ b/skills/pr-loop/SKILL.md
@@ -51,6 +51,12 @@ automated AI code review bot (such as `gemini-code-assist`,
 - **NO Force Pushes**: Force pushing (`git push -f` or `--force-with-lease`) is
   strictly prohibited under any circumstances.
 
+## 🛑 Early Termination & Task Cleanup
+
+If the user halts the execution of `pr-loop` early, or if you decide to pivot to another task, you MUST clean up any active background timers or scheduled tasks to prevent orphaned wakeups:
+- **Antigravity Task Management**: Run `manage_task(Action="list")` to locate any active `schedule` timers created by this skill, and cancel them using `manage_task(Action="kill", TaskId="...")`.
+- **Harness-Agnostic Fallback**: If the harness does not support a graphical task manager, write the Task ID or system process PID (if using POSIX background tasks) to a `.tasks/` directory in the workspace, and ensure you kill those background jobs using standard shell signals (e.g., `kill <PID>`) upon termination.
+
 ## 🏗️ Architectural Relationship & Rule Inheritance
 This skill functions as an autonomous, multi-pass loop wrapper around the core
 triage capabilities defined in the `github-pr-triage` skill.

--- a/skills/sem-semantic-diff/SKILL.md
+++ b/skills/sem-semantic-diff/SKILL.md
@@ -155,3 +155,8 @@ sem entities src/ --format json
   # OR
   sem impact --entity-id "src/test_utils.ts::function::setup"
   ```
+
+### Asynchronous Execution for Heavy Codebases
+On very large codebases, generating the initial dependency graph (`sem graph` or `sem impact`) can take considerable time and block the session:
+- **Background Execution**: Propose the command asynchronously (e.g., in Antigravity, set `WaitMsBeforeAsync: 500` or let it background) and schedule a `schedule` wakeup timer to monitor the task status, keeping the main thread free.
+- **Harness-Agnostic Fallback**: Propose running the graph indexing command as a POSIX background job redirecting output (e.g., `sem graph --format json > graph.json 2>&1 &`) and check the process PID or verify the output file existence in subsequent turns.

--- a/skills/sidequest/SKILL.md
+++ b/skills/sidequest/SKILL.md
@@ -89,21 +89,23 @@ When an existing `sidequest.md` is active and a task progresses, completes, mean
 
 ### Mode B: Subagent Transcript Audit (`/sidequest rebuild`)
 To rebuild or initialize the map without burning main-session tokens or pausing the conversation:
-1. Spawn a background subagent using `invoke_subagent` (or equivalent subagent tool) with the following configuration:
-   - `TypeName`: `"self"`
-   - `Role`: `"Sidequest Log Auditor"`
-   - `Prompt`: Use this exact self-contained prompt:
-     ```
-     You are a background Sidequest Log Auditor. Your sole job is to inspect the full conversation transcript in the session's log directory and build/rebuild the visual hierarchy map.
+1. **Spawn a Background Auditor**: Spawn a background subagent using `invoke_subagent` (or equivalent platform-native multi-agent creation tool).
+   - **Antigravity Setup**: Use `TypeName: "self"`, `Role: "Sidequest Log Auditor"`, and provide the prompt below.
+   - **Fallback (Harnesses without Multi-Agent APIs)**: If the harness does not support spawning background subagents (like Claude Code), the agent should run the audit synchronously or perform a direct view/write of the transcript files in the session directory.
+2. **Subagent Prompt Configuration**:
+   Use this self-contained prompt:
+   ```
+   You are a background Sidequest Log Auditor. Your sole job is to inspect the full conversation transcript in the session's log directory and build/rebuild the visual hierarchy map.
 
-     1. Inspect `transcript.jsonl` using `view_file` (or search tools) to extract all major initiatives (Main Quests), sub-tasks (Sub-Quests), and digressions/blockers (Side Quests).
-     2. Format the findings strictly using the 3-Tier Hierarchy (`🎯 Main Quests`, `📂 Sub-Quests`, `🐇 Side Quests`) and status tags (`✅ [COMPLETED]`, `🎯 [ACTIVE HEAD]`, `⏸️ [PAUSED]`, `[Active]`, `[Parked / Tracked for Later]`).
-     3. Write the finalized markdown hierarchy map using `write_to_file` (with `Overwrite: true`) to `sidequest.md` in the session's artifact directory.
-     4. When done, call `send_message` to your parent agent confirming completion and providing the exact absolute path where `sidequest.md` was written.
-     ```
-2. **Continue Main Session:** Keep your primary context clean and continue pair programming with the user immediately while the subagent runs asynchronously.
-3. **Parent Handshake & UI Availability:** When the subagent sends its completion message confirming the absolute path where `sidequest.md` was written, the parent agent MUST immediately read the file's content and write it into the conversation artifacts directory as `sidequest.md` using `write_to_file` (or use file copy tools directly). This guarantees `sidequest.md` opens immediately when clicked by the user right here in the main chat UI.
-*(Note: For setups without `invoke_subagent` or `transcript.jsonl`, perform a direct view/write on your private session directory).*
+   1. Inspect `transcript.jsonl` using `view_file` (or search tools) to extract all major initiatives (Main Quests), sub-tasks (Sub-Quests), and digressions/blockers (Side Quests).
+   2. Format the findings strictly using the 3-Tier Hierarchy (`🎯 Main Quests`, `📂 Sub-Quests`, `🐇 Side Quests`) and status tags (`✅ [COMPLETED]`, `🎯 [ACTIVE HEAD]`, `⏸️ [PAUSED]`, `[Active]`, `[Parked / Tracked for Later]`).
+   3. Write the finalized markdown hierarchy map using `write_to_file` (with `Overwrite: true`) to `sidequest.md` in the session's artifact directory.
+   4. When done, notify your parent agent. (In Antigravity, call the `send_message` tool targeting the parent's conversation ID, confirming completion and providing the exact absolute path where `sidequest.md` was written. In harnesses without messaging, print the path to stdout or write it to a `.handshake` file).
+   ```
+3. **Continue Main Session**: Keep your primary context clean and continue pair programming with the user immediately while the subagent runs asynchronously (if supported).
+4. **Parent Handshake & UI Availability**: When the subagent sends its completion notification (or the background process completes):
+   - In Antigravity, after receiving the `send_message` notification confirming the absolute path, the parent agent MUST immediately read the file's content and write it into the conversation artifacts directory as `sidequest.md` using `write_to_file` (or copy it directly).
+   - If running synchronously, copy the compiled file to the conversation's active artifact path so it's immediately available to the user.
 
 ---
 

--- a/skills/sidequest/SKILL.md
+++ b/skills/sidequest/SKILL.md
@@ -100,7 +100,7 @@ To rebuild or initialize the map without burning main-session tokens or pausing 
    1. Inspect `transcript.jsonl` using `view_file` (or search tools) to extract all major initiatives (Main Quests), sub-tasks (Sub-Quests), and digressions/blockers (Side Quests).
    2. Format the findings strictly using the 3-Tier Hierarchy (`🎯 Main Quests`, `📂 Sub-Quests`, `🐇 Side Quests`) and status tags (`✅ [COMPLETED]`, `🎯 [ACTIVE HEAD]`, `⏸️ [PAUSED]`, `[Active]`, `[Parked / Tracked for Later]`).
    3. Write the finalized markdown hierarchy map using `write_to_file` (with `Overwrite: true`) to `sidequest.md` in the session's artifact directory.
-   4. When done, notify your parent agent. (In Antigravity, call the `send_message` tool targeting the parent's conversation ID, confirming completion and providing the exact absolute path where `sidequest.md` was written. In harnesses without messaging, print the path to stdout or write it to a `.handshake` file).
+   4. When done, notify your parent agent. (In Antigravity, call the `send_message` tool targeting the parent's conversation ID, confirming completion and providing the exact absolute path where `sidequest.md` was written. In harnesses without messaging, print the path to stdout or write it to a `.handshake` file in the session's artifact directory).
    ```
 3. **Continue Main Session**: Keep your primary context clean and continue pair programming with the user immediately while the subagent runs asynchronously (if supported).
 4. **Parent Handshake & UI Availability**: When the subagent sends its completion notification (or the background process completes):

--- a/skills/what-if/SKILL.md
+++ b/skills/what-if/SKILL.md
@@ -51,6 +51,7 @@ Examples of trigger phrases:
 - **Direct Chat Output**: Deliver the analysis inline directly to the user in
   your chat response. Do NOT create artifacts unless the analysis is
   exceptionally long or explicitly requested.
+- **Do Not Request Interactive Approval Gates**: If you generate an artifact for a long what-if analysis, ensure you do not request interactive approval/feedback (e.g., set `RequestFeedback: false` if using Jetski's `ArtifactMetadata`). This analysis is purely informational/analytical and should not block execution with a "Proceed" gate.
 - Outline the step-by-step impact if the change were actually executed.
 - Identify potential breaking changes, migration friction, and ripple effects
   across dependent packages or modules.

--- a/skills/what-if/SKILL.md
+++ b/skills/what-if/SKILL.md
@@ -51,7 +51,7 @@ Examples of trigger phrases:
 - **Direct Chat Output**: Deliver the analysis inline directly to the user in
   your chat response. Do NOT create artifacts unless the analysis is
   exceptionally long or explicitly requested.
-- **Do Not Request Interactive Approval Gates**: If you generate an artifact for a long what-if analysis, ensure you do not request interactive approval/feedback (e.g., set `RequestFeedback: false` if using Jetski's `ArtifactMetadata`). This analysis is purely informational/analytical and should not block execution with a "Proceed" gate.
+- **Do Not Request Interactive Approval Gates**: If you generate an artifact for a long what-if analysis, ensure you do not request interactive approval/feedback (e.g., set `RequestFeedback: false` if using Antigravity's `ArtifactMetadata`). This analysis is purely informational/analytical and should not block execution with a "Proceed" gate.
 - Outline the step-by-step impact if the change were actually executed.
 - Identify potential breaking changes, migration friction, and ripple effects
   across dependent packages or modules.


### PR DESCRIPTION
This PR refactors custom skills in `kevmoo_skills` to optimize their utilization of specialized agent tools (like `ask_question`, `schedule`, and `manage_task`) and improve their compatibility with external harnesses (such as Claude Code and open-source Antigravity).

### Key Changes
1. **Harness-Agnostic Gating & Diffs**:
   - Resolved the noisy "Proceed" button modals by disabling approval gates for exploratory skills (`just-brainstorm`, `what-if`, `distilling-strategies-interactively`).
   - Standardized `clarify-confirm-continue` to explicitly require interactive approval gates before execution starts.
   - Refactored all platform-specific `ArtifactMetadata` instructions to use generic, intent-based phrasing with conditional platform guides.
2. **Specialized Tools & Fallback Guidelines**:
   - Refactored `distilling-strategies-interactively` to suggest `ask_question` for predictable choices in Socratic quizzes, falling back to standard Markdown lists.
   - Updated `sidequest` to recommend `invoke_subagent`/`send_message` with generic process and file-based fallback paths.
   - Added `manage_task` cleanup instructions to `pr-loop` to terminate background timers cleanly on user cancellations, falling back to PID tracking and standard signals.
   - Introduced background execution instructions (`run_command` with scheduler wakeups) to `gob-curl` and `sem-semantic-diff` for heavyweight CLI jobs, with POSIX `nohup` fallbacks.
3. **Public Nomenclature**:
   - Replaced all Google-internal "JetSki" references with the public "Antigravity" terminology to ensure skills are clean and usable outside Google.