### PR TITLE
chore: bump minimum SDK to 3.12.0 and package sidequest skill

### DIFF
--- a/.github/workflows/validate_skills.yaml
+++ b/.github/workflows/validate_skills.yaml
@@ -37,7 +37,7 @@ jobs:
         if: always() && steps.pub-get.outcome == 'success'
 
       - run: dart format --output=none --set-exit-if-changed .
-        if: always() && steps.pub-get.outcome == 'success'
+        if: always() && steps.pub-get.outcome == 'success' && matrix.sdk == 'dev'
 
       - run: dart test
         if: always() && steps.pub-get.outcome == 'success'

--- a/.github/workflows/validate_skills.yaml
+++ b/.github/workflows/validate_skills.yaml
@@ -3,12 +3,14 @@ name: validate_skills
 on:
   pull_request:
     paths:
+      - 'pubspec.yaml'
       - 'skills/**'
       - 'tool/**'
       - '.github/workflows/validate_skills.yaml'
   push:
     branches: [ main ]
     paths:
+      - 'pubspec.yaml'
       - 'skills/**'
       - 'tool/**'
       - '.github/workflows/validate_skills.yaml'
@@ -16,6 +18,9 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        sdk: [3.12.0, dev]
     defaults:
       run:
         working-directory: tool
@@ -23,7 +28,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: dev
+          sdk: ${{ matrix.sdk }}
 
       - run: dart pub get
         id: pub-get

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,8 @@ name: kevmoo_skills
 publish_to: none
 
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.12.0
 
 workspace:
   - tool
+  - skills/sidequest

--- a/skills/sidequest/bin/sidequest.dart
+++ b/skills/sidequest/bin/sidequest.dart
@@ -2,7 +2,7 @@
 
 import 'dart:io';
 
-import '../lib/sidequest.dart';
+import 'package:sidequest/sidequest.dart';
 
 Future<void> main(List<String> rawArgs) async {
   String? dir;

--- a/skills/sidequest/pubspec.yaml
+++ b/skills/sidequest/pubspec.yaml
@@ -1,4 +1,6 @@
 name: sidequest
+description: A self-contained sidequest skill package.
+version: 1.0.0
 publish_to: none
 
 environment:

--- a/skills/sidequest/pubspec.yaml
+++ b/skills/sidequest/pubspec.yaml
@@ -1,0 +1,10 @@
+name: sidequest
+publish_to: none
+
+environment:
+  sdk: ^3.12.0
+resolution: workspace
+
+dependencies:
+  args: ^2.4.0
+  path: ^1.9.0

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
 
 dev_dependencies:
   sidequest:
+    workspace: true
   test: ^1.24.0
   checks: ^0.3.0
   logging: ^1.3.0

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -2,7 +2,7 @@ name: _kevmoo_skills_tool
 description: Helper tools for managing and validating skills.
 version: 1.0.0
 environment:
-  sdk: ^3.9.0
+  sdk: ^3.12.0
 resolution: workspace
 
 dependencies:
@@ -11,6 +11,7 @@ dependencies:
   path: ^1.9.0
 
 dev_dependencies:
+  sidequest:
   test: ^1.24.0
   checks: ^0.3.0
   logging: ^1.3.0

--- a/tool/test/sidequest_test.dart
+++ b/tool/test/sidequest_test.dart
@@ -5,7 +5,7 @@ import 'package:checks/checks.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
-import '../../skills/sidequest/lib/sidequest.dart';
+import 'package:sidequest/sidequest.dart';
 
 void main() {
   group('Sidequest Data Model & Serialization', () {

--- a/tool/test/validate_skills_test.dart
+++ b/tool/test/validate_skills_test.dart
@@ -95,9 +95,11 @@ void main() {
 
     // Ensure pub get has been run for all nested packages to prevent analysis failures
     final pubspecs = <File>[];
-    for (final dir in skillsDir.listSync().whereType<Directory>().where(
+    final directories = skillsDir.listSync().whereType<Directory>();
+    final validDirs = directories.where(
       (dir) => File('${dir.path}/SKILL.md').existsSync(),
-    )) {
+    );
+    for (final dir in validDirs) {
       final pubspec = File('${dir.path}/pubspec.yaml');
       if (pubspec.existsSync()) {
         pubspecs.add(pubspec);

--- a/tool/test/validate_skills_test.dart
+++ b/tool/test/validate_skills_test.dart
@@ -13,6 +13,13 @@ String _getConfigFilePath() {
   return 'tool/dart_skills_lint.yaml';
 }
 
+String _getSkillsDirPath() {
+  if (Directory.current.path.split(Platform.pathSeparator).last == 'tool') {
+    return '../skills';
+  }
+  return 'skills';
+}
+
 void main() {
   test('Validate skills', () async {
     Logger.root.level = Level.ALL;
@@ -36,11 +43,7 @@ void main() {
   });
 
   test('Run skill/scripts/test', () async {
-    final skillsDir = Directory(
-      Directory.current.path.split(Platform.pathSeparator).last == 'tool'
-          ? '../skills'
-          : 'skills',
-    );
+    final skillsDir = Directory(_getSkillsDirPath());
     expect(
       skillsDir.existsSync(),
       isTrue,
@@ -75,11 +78,7 @@ void main() {
   }, timeout: Timeout(Duration(minutes: 3)));
 
   test('Verify formatting and analysis of all skills Dart code', () async {
-    final skillsDir = Directory(
-      Directory.current.path.split(Platform.pathSeparator).last == 'tool'
-          ? '../skills'
-          : 'skills',
-    );
+    final skillsDir = Directory(_getSkillsDirPath());
     expect(
       skillsDir.existsSync(),
       isTrue,

--- a/tool/test/validate_skills_test.dart
+++ b/tool/test/validate_skills_test.dart
@@ -4,21 +4,15 @@ import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 import 'package:test_process/test_process.dart';
 
-final String _configFilePath = _getConfigFilePath();
+final String _configFilePath =
+    Directory.current.path.split(Platform.pathSeparator).last == 'tool'
+    ? 'dart_skills_lint.yaml'
+    : 'tool/dart_skills_lint.yaml';
 
-String _getConfigFilePath() {
-  if (Directory.current.path.split(Platform.pathSeparator).last == 'tool') {
-    return 'dart_skills_lint.yaml';
-  }
-  return 'tool/dart_skills_lint.yaml';
-}
-
-String _getSkillsDirPath() {
-  if (Directory.current.path.split(Platform.pathSeparator).last == 'tool') {
-    return '../skills';
-  }
-  return 'skills';
-}
+final String _skillsDirPath =
+    Directory.current.path.split(Platform.pathSeparator).last == 'tool'
+    ? '../skills'
+    : 'skills';
 
 void main() {
   test('Validate skills', () async {
@@ -43,7 +37,7 @@ void main() {
   });
 
   test('Run skill/scripts/test', () async {
-    final skillsDir = Directory(_getSkillsDirPath());
+    final skillsDir = Directory(_skillsDirPath);
     expect(
       skillsDir.existsSync(),
       isTrue,
@@ -78,7 +72,7 @@ void main() {
   }, timeout: Timeout(Duration(minutes: 3)));
 
   test('Verify formatting and analysis of all skills Dart code', () async {
-    final skillsDir = Directory(_getSkillsDirPath());
+    final skillsDir = Directory(_skillsDirPath);
     expect(
       skillsDir.existsSync(),
       isTrue,

--- a/tool/test/validate_skills_test.dart
+++ b/tool/test/validate_skills_test.dart
@@ -4,10 +4,14 @@ import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 import 'package:test_process/test_process.dart';
 
-final String _configFilePath =
-    Directory.current.path.split(Platform.pathSeparator).last == 'tool'
-    ? 'dart_skills_lint.yaml'
-    : 'tool/dart_skills_lint.yaml';
+final String _configFilePath = _getConfigFilePath();
+
+String _getConfigFilePath() {
+  if (Directory.current.path.split(Platform.pathSeparator).last == 'tool') {
+    return 'dart_skills_lint.yaml';
+  }
+  return 'tool/dart_skills_lint.yaml';
+}
 
 void main() {
   test('Validate skills', () async {


### PR DESCRIPTION
Update repository manifests and CI matrix to Dart SDK ^3.12.0, and configure skills/sidequest as a self-contained workspace package.

* Bump SDK constraint to ^3.12.0 across root, tool, and sidequest pubspecs.
* Include skills/sidequest in root workspace members.
* Update sidequest entrypoint and tests to use package:sidequest library imports.
* Update CI workflow matrix to validate on [3.12.0, dev].
