### PR TITLE
feat(sidequest): add first-run protocol and --help CLI support

### DIFF
--- a/skills/sidequest/SKILL.md
+++ b/skills/sidequest/SKILL.md
@@ -55,6 +55,14 @@ Synthesizes task hierarchies and context drift into a visual session map.
 
 When `/sidequest` triggers (via `/sidequest`, "where are we?", or context drift):
 
+### 🏁 First-Run Protocol (Session Initialization)
+Before performing updates or displaying map status, check if session state exists:
+1. **Check for state file:** Verify if `sidequest.json` exists in the conversation artifact directory (`<session_artifact_dir>`).
+2. **If NO state exists (First Run):** Immediately initialize the session map by executing:
+   `dart run skills/sidequest/bin/sidequest.dart init "<Current Main Task Title>" --dir="<session_artifact_dir>"`
+3. **If state exists:** Proceed directly to CLI mutations, rendering, or summaries.
+4. **DO NOT run `--help` or bare CLI commands on startup:** All valid subcommands and parameters are defined below.
+
 ### Mode A: In-Session CLI Mutation (Default `O(1)`)
 Run the Dart CLI tool via `run_command` (`dart run skills/sidequest/bin/sidequest.dart <cmd> --dir="<session_artifact_dir>"`):
 - `init "Quest Title"`: Initialize session map.
@@ -65,6 +73,7 @@ Run the Dart CLI tool via `run_command` (`dart run skills/sidequest/bin/sideques
 - `complete <id>`: Mark item done (auto-updates `lastCompletionOrder`, sets `[#N ⭐]`, emits `sidequest.md`).
 - `vcs <quest_id> --stage=dirty|local_commit|uploaded|merged|clean [--branch=B] [--files=F]`: Update VCS state.
 - `batch '<json_payload>'`: Perform multiple mutations in 1 turn.
+- `help`, `--help`, `-h`: Print CLI subcommand catalog.
 
 **User Output:** Output a brief, punchy chat summary covering active `⚔️ Main Quest`, current `🛡️ Sub-Quest`, VCS status, and recommended next step.
 

--- a/skills/sidequest/lib/src/cli/command_runner.dart
+++ b/skills/sidequest/lib/src/cli/command_runner.dart
@@ -15,9 +15,9 @@ class SidequestCliRunner {
   SidequestCliRunner({required this.store});
 
   Future<int> run(List<String> args) async {
-    if (args.isEmpty) {
+    if (args.isEmpty || args.contains('--help') || args.contains('-h')) {
       _printUsage();
-      return 1;
+      return 0;
     }
 
     final command = args[0];
@@ -25,6 +25,9 @@ class SidequestCliRunner {
 
     try {
       switch (command) {
+        case 'help':
+          _printUsage();
+          return 0;
         case 'init':
           return await _handleInit(subArgs);
         case 'quest':
@@ -687,7 +690,31 @@ class SidequestCliRunner {
   }
 
   void _printUsage() {
-    stdout.writeln('sidequest CLI - Deterministic session map manager');
-    stdout.writeln('Usage: sidequest <command> [args] [--dir=path]');
+    stdout.writeln('''
+sidequest CLI - Deterministic session map manager
+
+Usage:
+  sidequest <command> [args] [--dir=path]
+
+Global Options:
+  --dir=<path>            Path to session artifact directory containing sidequest.json
+
+Subcommands:
+  init [title]            Initialize sidequest session map (default: "Main Quest 1")
+  quest add <title>       Add a new main quest
+  quest activate <id>     Activate a main quest
+  quest pause <id>        Pause a main quest (--reason=...)
+  subquest add <qId> <t>  Add a sub-quest under main quest <qId>
+  step add <subId> <t>    Add a planned step under sub-quest <subId>
+  blocker add <subId> <t> Add an unplanned blocker under sub-quest <subId>
+  sidequest add <t>       Add a side quest (--quest=<qId>, --global, --parked, --note=<n>)
+  complete <id>           Mark item (quest, subquest, step, blocker, sidequest) completed
+  reopen <id>             Reopen a completed item
+  remove <id>             Remove an item from the session map
+  vcs <qId>               Update VCS state (--stage=dirty|local_commit|uploaded|merged|clean)
+  batch <json>            Execute multiple mutations in a single call
+  render                  Re-render sidequest.md from sidequest.json
+  merge-audit --input=<f> Merge audited delta JSON into session map
+  help, --help, -h        Show this help message''');
   }
 }

--- a/tool/test/sidequest_test.dart
+++ b/tool/test/sidequest_test.dart
@@ -408,5 +408,14 @@ void main() {
       check(data.quests[0].vcs?.stage).equals(VcsStage.dirty);
       check(data.quests[0].vcs?.branch).equals('feat/test');
     });
+
+    test('returns exit code 0 for help arguments and empty input', () async {
+      final runner = SidequestCliRunner(store: store);
+
+      check(await runner.run([])).equals(0);
+      check(await runner.run(['--help'])).equals(0);
+      check(await runner.run(['-h'])).equals(0);
+      check(await runner.run(['help'])).equals(0);
+    });
   });
 }


### PR DESCRIPTION
Add explicit first-run startup protocol to SKILL.md and add first-class --help / -h / help handling to the sidequest CLI runner with exit code 0 and full subcommand catalog documentation.

- Add First-Run Protocol to SKILL.md to guide agents to auto-initialize on first run
- Support --help, -h, help, and empty args returning exit code 0
- Expand _printUsage in command_runner.dart with full subcommand descriptions
- Add unit test coverage in sidequest_test.dart for help flags
