### PR TITLE
feat(deslop): add standalone report generator script and tests

### DIFF
--- a/skills/deslop-duplication-audit/SKILL.md
+++ b/skills/deslop-duplication-audit/SKILL.md
@@ -38,27 +38,19 @@ using Deslop (a tree-sitter structural duplicate code detection engine).
     exceptions (`PathNotFoundException`, `errno = 2`), pass `--no-precompile`
     (e.g., `dart test --no-precompile`).
 
-## 2. Phase 1: Read-Only Discovery Scans
+## 2. Phase 1: Read-Only Discovery Scans & Reporting
 
-When asked to scan single or multiple repositories for duplication, execute
-Deslop in strictly read-only mode so target Git working trees remain untouched
-(zero `.deslop/` cache directory bloat or dirty git status). Output reports
-should target a dedicated scratch or temporary directory:
+Execute the bundled Dart helper script (`deslop_report.dart`) to run Deslop in
+strictly read-only mode and emit an instant, token-efficient Markdown summary
+with clickable source and HTML links:
 
 ```bash
-mkdir -p {scratch_dir}/deslop_reports/{repo_name}
-deslop {target_dir} \
-  --output {scratch_dir}/deslop_reports/{repo_name}/report \
-  --no-incremental \
-  --no-fail-over \
-  --log-to-console \
-  --log-level warn
+dart run skills/deslop-duplication-audit/bin/deslop_report.dart --dir {target_dir} [--top 10]
 ```
 
-- Read the generated summary at
-  `{scratch_dir}/deslop_reports/{repo_name}/report.txt` or parse
-  `{scratch_dir}/deslop_reports/{repo_name}/report.json` using `jq` to rank top
-  offending clusters.
+- If Deslop was already executed manually, parse an existing report directly:
+  `dart run skills/deslop-duplication-audit/bin/deslop_report.dart --report {path_to_report.json} --dir {target_dir}`
+- Target working trees remain untouched (zero `.deslop/` cache directory bloat or dirty git status).
 - If scanning multiple repositories across a workspace or portfolio, deploy
   parallel investigative subagents (`invoke_subagent`) to execute read-only
   scans concurrently and consolidate the reporting matrix in chat.

--- a/skills/deslop-duplication-audit/bin/deslop_report.dart
+++ b/skills/deslop-duplication-audit/bin/deslop_report.dart
@@ -1,0 +1,160 @@
+import 'dart:convert';
+import 'dart:io';
+
+import '../lib/deslop_report.dart';
+
+void _printUsage() {
+  print('''
+Deslop Duplication Audit Report Generator
+
+Usage:
+  dart run skills/deslop-duplication-audit/bin/deslop_report.dart [options] [target_dir]
+
+Options:
+  -C, --dir=<path>        Target repository directory to scan (defaults to current directory)
+  --report=<path>         Path to an existing report.json (skips running Deslop CLI)
+  --top=<count>           Number of top duplicate clusters to display (default: 10)
+  --min-nodes=<count>     Minimum AST subtree node count passed to Deslop (default: 30)
+  --out-dir=<path>        Custom directory to store rendered Deslop reports
+  --category=<cat>        Filter clusters by category: all, logic, data (default: all)
+  --bucket=<bucket>       Filter clusters by bucket: all, identical, nearly_identical, structural_only (default: all)
+  --no-files              Omit the per-file duplication table from output
+  --no-clusters           Omit the clusters list from output
+  --json                  Output filtered report as machine-readable JSON instead of Markdown
+  -h, --help              Show this help message
+''');
+}
+
+void main(List<String> args) async {
+  String targetDir = Directory.current.path;
+  String? reportJsonPath;
+  var topCount = 10;
+  var minNodes = 30;
+  String? outDir;
+  var categoryFilter = 'all';
+  var bucketFilter = 'all';
+  var includeFileTable = true;
+  var includeClusters = true;
+  var outputJson = false;
+
+  for (var i = 0; i < args.length; i++) {
+    final arg = args[i];
+    if (arg == '-h' || arg == '--help') {
+      _printUsage();
+      exit(0);
+    } else if (arg == '-C' || arg == '--dir') {
+      if (i + 1 < args.length) {
+        targetDir = args[++i];
+      } else {
+        stderr.writeln('Error: Missing value for $arg');
+        exit(1);
+      }
+    } else if (arg.startsWith('--dir=')) {
+      targetDir = arg.substring('--dir='.length);
+    } else if (arg == '--report') {
+      if (i + 1 < args.length) {
+        reportJsonPath = args[++i];
+      } else {
+        stderr.writeln('Error: Missing value for --report');
+        exit(1);
+      }
+    } else if (arg.startsWith('--report=')) {
+      reportJsonPath = arg.substring('--report='.length);
+    } else if (arg == '--top') {
+      if (i + 1 < args.length) {
+        topCount = int.tryParse(args[++i]) ?? topCount;
+      }
+    } else if (arg.startsWith('--top=')) {
+      topCount = int.tryParse(arg.substring('--top='.length)) ?? topCount;
+    } else if (arg == '--min-nodes') {
+      if (i + 1 < args.length) {
+        minNodes = int.tryParse(args[++i]) ?? minNodes;
+      }
+    } else if (arg.startsWith('--min-nodes=')) {
+      minNodes = int.tryParse(arg.substring('--min-nodes='.length)) ?? minNodes;
+    } else if (arg == '--out-dir') {
+      if (i + 1 < args.length) {
+        outDir = args[++i];
+      }
+    } else if (arg.startsWith('--out-dir=')) {
+      outDir = arg.substring('--out-dir='.length);
+    } else if (arg == '--category') {
+      if (i + 1 < args.length) {
+        categoryFilter = args[++i];
+      }
+    } else if (arg.startsWith('--category=')) {
+      categoryFilter = arg.substring('--category='.length);
+    } else if (arg == '--bucket') {
+      if (i + 1 < args.length) {
+        bucketFilter = args[++i];
+      }
+    } else if (arg.startsWith('--bucket=')) {
+      bucketFilter = arg.substring('--bucket='.length);
+    } else if (arg == '--no-files') {
+      includeFileTable = false;
+    } else if (arg == '--no-clusters') {
+      includeClusters = false;
+    } else if (arg == '--json') {
+      outputJson = true;
+    } else if (!arg.startsWith('-')) {
+      targetDir = arg;
+    } else {
+      stderr.writeln('Warning: Unrecognized option "$arg"');
+    }
+  }
+
+  try {
+    DeslopReport report;
+    String? htmlReportPath;
+
+    if (reportJsonPath != null) {
+      report = await loadReportJson(reportJsonPath);
+      final htmlCandidate = reportJsonPath.replaceAll(
+        RegExp(r'\.json$'),
+        '.html',
+      );
+      if (File(htmlCandidate).existsSync()) {
+        htmlReportPath = htmlCandidate;
+      }
+    } else {
+      String? outputPrefix;
+      if (outDir != null) {
+        final dir = Directory(outDir);
+        if (!dir.existsSync()) dir.createSync(recursive: true);
+        outputPrefix = '${dir.path}${Platform.pathSeparator}report';
+      }
+
+      final result = await runDeslopScan(
+        targetDir: targetDir,
+        outputPrefix: outputPrefix,
+        minNodes: minNodes,
+      );
+
+      report = result.report;
+      htmlReportPath = result.htmlPath;
+    }
+
+    if (outputJson) {
+      final encoder = const JsonEncoder.withIndent('  ');
+      print(encoder.convert(report.toJson()));
+    } else {
+      final markdown = formatDeslopMarkdown(
+        report: report,
+        targetDir: targetDir,
+        htmlReportPath: htmlReportPath,
+        topCount: topCount,
+        categoryFilter: categoryFilter,
+        bucketFilter: bucketFilter,
+        includeFileTable: includeFileTable,
+        includeClusters: includeClusters,
+      );
+      print(markdown);
+    }
+  } catch (e, st) {
+    stderr.writeln('Error: $e');
+    if (Platform.environment['DEBUG'] == 'true') {
+      stderr.writeln(st);
+    }
+    exit(1);
+  }
+}

--- a/skills/deslop-duplication-audit/bin/deslop_report.dart
+++ b/skills/deslop-duplication-audit/bin/deslop_report.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 
-import '../lib/deslop_report.dart';
+import 'package:deslop_duplication_audit/deslop_report.dart';
 
 ArgParser _buildParser() {
   return ArgParser()

--- a/skills/deslop-duplication-audit/bin/deslop_report.dart
+++ b/skills/deslop-duplication-audit/bin/deslop_report.dart
@@ -1,107 +1,110 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:args/args.dart';
+
 import '../lib/deslop_report.dart';
 
-void _printUsage() {
-  print('''
-Deslop Duplication Audit Report Generator
-
-Usage:
-  dart run skills/deslop-duplication-audit/bin/deslop_report.dart [options] [target_dir]
-
-Options:
-  -C, --dir=<path>        Target repository directory to scan (defaults to current directory)
-  --report=<path>         Path to an existing report.json (skips running Deslop CLI)
-  --top=<count>           Number of top duplicate clusters to display (default: 10)
-  --min-nodes=<count>     Minimum AST subtree node count passed to Deslop (default: 30)
-  --out-dir=<path>        Custom directory to store rendered Deslop reports
-  --category=<cat>        Filter clusters by category: all, logic, data (default: all)
-  --bucket=<bucket>       Filter clusters by bucket: all, identical, nearly_identical, structural_only (default: all)
-  --no-files              Omit the per-file duplication table from output
-  --no-clusters           Omit the clusters list from output
-  --json                  Output filtered report as machine-readable JSON instead of Markdown
-  -h, --help              Show this help message
-''');
+ArgParser _buildParser() {
+  return ArgParser()
+    ..addOption('dir', abbr: 'C', help: 'Target repository directory to scan.')
+    ..addOption(
+      'report',
+      help: 'Path to an existing report.json (skips running Deslop CLI).',
+    )
+    ..addOption(
+      'top',
+      defaultsTo: '10',
+      help: 'Number of top duplicate clusters to display.',
+    )
+    ..addOption(
+      'min-nodes',
+      defaultsTo: '30',
+      help: 'Minimum AST subtree node count passed to Deslop.',
+    )
+    ..addOption(
+      'out-dir',
+      help: 'Custom directory to store rendered Deslop reports.',
+    )
+    ..addOption(
+      'category',
+      defaultsTo: 'all',
+      allowed: ['all', 'logic', 'data'],
+      help: 'Filter clusters by category.',
+    )
+    ..addOption(
+      'bucket',
+      defaultsTo: 'all',
+      allowed: [
+        'all',
+        'identical',
+        'nearly_identical',
+        'structural_only',
+        'loosely_similar',
+        'same_behavior',
+      ],
+      help: 'Filter clusters by bucket.',
+    )
+    ..addFlag(
+      'files',
+      defaultsTo: true,
+      negatable: true,
+      help: 'Include the per-file duplication table in output.',
+    )
+    ..addFlag(
+      'clusters',
+      defaultsTo: true,
+      negatable: true,
+      help: 'Include the clusters list in output.',
+    )
+    ..addFlag(
+      'json',
+      defaultsTo: false,
+      negatable: false,
+      help:
+          'Output filtered report as machine-readable JSON instead of Markdown.',
+    )
+    ..addFlag(
+      'help',
+      abbr: 'h',
+      negatable: false,
+      help: 'Show this help message.',
+    );
 }
 
 void main(List<String> args) async {
-  String targetDir = Directory.current.path;
-  String? reportJsonPath;
-  var topCount = 10;
-  var minNodes = 30;
-  String? outDir;
-  var categoryFilter = 'all';
-  var bucketFilter = 'all';
-  var includeFileTable = true;
-  var includeClusters = true;
-  var outputJson = false;
-
-  for (var i = 0; i < args.length; i++) {
-    final arg = args[i];
-    if (arg == '-h' || arg == '--help') {
-      _printUsage();
-      exit(0);
-    } else if (arg == '-C' || arg == '--dir') {
-      if (i + 1 < args.length) {
-        targetDir = args[++i];
-      } else {
-        stderr.writeln('Error: Missing value for $arg');
-        exit(1);
-      }
-    } else if (arg.startsWith('--dir=')) {
-      targetDir = arg.substring('--dir='.length);
-    } else if (arg == '--report') {
-      if (i + 1 < args.length) {
-        reportJsonPath = args[++i];
-      } else {
-        stderr.writeln('Error: Missing value for --report');
-        exit(1);
-      }
-    } else if (arg.startsWith('--report=')) {
-      reportJsonPath = arg.substring('--report='.length);
-    } else if (arg == '--top') {
-      if (i + 1 < args.length) {
-        topCount = int.tryParse(args[++i]) ?? topCount;
-      }
-    } else if (arg.startsWith('--top=')) {
-      topCount = int.tryParse(arg.substring('--top='.length)) ?? topCount;
-    } else if (arg == '--min-nodes') {
-      if (i + 1 < args.length) {
-        minNodes = int.tryParse(args[++i]) ?? minNodes;
-      }
-    } else if (arg.startsWith('--min-nodes=')) {
-      minNodes = int.tryParse(arg.substring('--min-nodes='.length)) ?? minNodes;
-    } else if (arg == '--out-dir') {
-      if (i + 1 < args.length) {
-        outDir = args[++i];
-      }
-    } else if (arg.startsWith('--out-dir=')) {
-      outDir = arg.substring('--out-dir='.length);
-    } else if (arg == '--category') {
-      if (i + 1 < args.length) {
-        categoryFilter = args[++i];
-      }
-    } else if (arg.startsWith('--category=')) {
-      categoryFilter = arg.substring('--category='.length);
-    } else if (arg == '--bucket') {
-      if (i + 1 < args.length) {
-        bucketFilter = args[++i];
-      }
-    } else if (arg.startsWith('--bucket=')) {
-      bucketFilter = arg.substring('--bucket='.length);
-    } else if (arg == '--no-files') {
-      includeFileTable = false;
-    } else if (arg == '--no-clusters') {
-      includeClusters = false;
-    } else if (arg == '--json') {
-      outputJson = true;
-    } else if (!arg.startsWith('-')) {
-      targetDir = arg;
-    } else {
-      stderr.writeln('Warning: Unrecognized option "$arg"');
-    }
+  final parser = _buildParser();
+  ArgResults results;
+  try {
+    results = parser.parse(args);
+  } on FormatException catch (e) {
+    stderr.writeln('Error: ${e.message}\n');
+    stderr.writeln(parser.usage);
+    exit(1);
   }
+
+  if (results.flag('help')) {
+    print('Deslop Duplication Audit Report Generator\n');
+    print(
+      'Usage: dart run skills/deslop-duplication-audit/bin/deslop_report.dart [options] [target_dir]\n',
+    );
+    print(parser.usage);
+    exit(0);
+  }
+
+  final targetDir =
+      results.option('dir') ??
+      (results.rest.isNotEmpty ? results.rest.first : Directory.current.path);
+
+  final reportJsonPath = results.option('report');
+  final topCount = int.tryParse(results.option('top') ?? '10') ?? 10;
+  final minNodes = int.tryParse(results.option('min-nodes') ?? '30') ?? 30;
+  final outDir = results.option('out-dir');
+  final categoryFilter = results.option('category') ?? 'all';
+  final bucketFilter = results.option('bucket') ?? 'all';
+  final includeFileTable = results.flag('files');
+  final includeClusters = results.flag('clusters');
+  final outputJson = results.flag('json');
 
   try {
     DeslopReport report;

--- a/skills/deslop-duplication-audit/lib/deslop_report.dart
+++ b/skills/deslop-duplication-audit/lib/deslop_report.dart
@@ -1,0 +1,6 @@
+/// Helper library for running and formatting Deslop duplication audits.
+library;
+
+export 'src/formatter.dart';
+export 'src/models.dart';
+export 'src/runner.dart';

--- a/skills/deslop-duplication-audit/lib/src/formatter.dart
+++ b/skills/deslop-duplication-audit/lib/src/formatter.dart
@@ -1,0 +1,184 @@
+/// Formats Deslop duplication reports into token-efficient Markdown summaries.
+library;
+
+import 'dart:io';
+
+import 'models.dart';
+
+String _resolveAbsolutePath(String baseDir, String relativePath) {
+  if (relativePath.startsWith(Platform.pathSeparator)) {
+    return Uri.file(relativePath).normalizePath().toFilePath();
+  }
+  final combined = baseDir.endsWith(Platform.pathSeparator)
+      ? '$baseDir$relativePath'
+      : '$baseDir${Platform.pathSeparator}$relativePath';
+  return Uri.file(combined).normalizePath().toFilePath();
+}
+
+/// Formats a [DeslopReport] into a high-density, token-efficient Markdown document.
+String formatDeslopMarkdown({
+  required DeslopReport report,
+  required String targetDir,
+  String? htmlReportPath,
+  int topCount = 10,
+  String categoryFilter = 'all',
+  String bucketFilter = 'all',
+  bool includeFileTable = true,
+  bool includeClusters = true,
+}) {
+  final buffer = StringBuffer();
+  final absTargetDir = Directory(targetDir).absolute.path;
+
+  // 1. Overview Summary Header
+  final totalLoc = report.metrics.analysedLoc;
+  final dupLoc = report.metrics.duplicatedLoc;
+  final dupPercent = report.metrics.duplicationPercent.toStringAsFixed(1);
+  final totalFiles = report.filesAnalysed;
+  final dupFiles = report.metrics.duplicatedFiles;
+  final totalClusters = report.metrics.clustersTotal;
+
+  buffer.writeln('### 🔬 Deslop Code Duplication Report');
+  buffer.writeln();
+  buffer.writeln(
+    '* **Duplication Score**: **$dupPercent%** ($dupLoc / $totalLoc LOC across $dupFiles / $totalFiles files)',
+  );
+
+  // Group cluster counts by bucket
+  final bucketCounts = <String, int>{};
+  for (final cluster in report.clusters) {
+    bucketCounts[cluster.bucket] = (bucketCounts[cluster.bucket] ?? 0) + 1;
+  }
+
+  final bucketBreakdown = <String>[];
+  if (bucketCounts.containsKey('identical')) {
+    bucketBreakdown.add('${bucketCounts['identical']} identical [Type-1/2]');
+  }
+  if (bucketCounts.containsKey('nearly_identical')) {
+    bucketBreakdown.add(
+      '${bucketCounts['nearly_identical']} near-identical [Type-3]',
+    );
+  }
+  if (bucketCounts.containsKey('structural_only')) {
+    bucketBreakdown.add(
+      '${bucketCounts['structural_only']} structural-only shape matches',
+    );
+  }
+  if (bucketCounts.containsKey('loosely_similar')) {
+    bucketBreakdown.add('${bucketCounts['loosely_similar']} loosely similar');
+  }
+  if (bucketCounts.containsKey('same_behavior')) {
+    bucketBreakdown.add('${bucketCounts['same_behavior']} AI semantic matches');
+  }
+
+  final breakdownText = bucketBreakdown.isNotEmpty
+      ? ' (${bucketBreakdown.join(', ')})'
+      : '';
+  buffer.writeln('* **Total Clusters**: $totalClusters$breakdownText');
+
+  if (htmlReportPath != null && File(htmlReportPath).existsSync()) {
+    final absHtmlPath = Uri.file(
+      File(htmlReportPath).absolute.path,
+    ).normalizePath().toFilePath();
+    final htmlUri = 'file://$absHtmlPath';
+    buffer.writeln('* **Interactive HTML Report**: [report.html]($htmlUri)');
+  }
+
+  buffer.writeln();
+
+  // 2. Top Duplication Clusters
+  if (includeClusters) {
+    var filteredClusters = report.clusters;
+
+    if (categoryFilter != 'all') {
+      filteredClusters = filteredClusters
+          .where((c) => c.category == categoryFilter)
+          .toList();
+    }
+
+    if (bucketFilter != 'all') {
+      filteredClusters = filteredClusters
+          .where((c) => c.bucket == bucketFilter)
+          .toList();
+    }
+
+    // Sort by weight descending
+    filteredClusters.sort((a, b) => b.weight.compareTo(a.weight));
+
+    final displayClusters = filteredClusters.take(topCount).toList();
+
+    if (displayClusters.isEmpty) {
+      buffer.writeln('_No duplicate clusters match the specified filters._');
+      buffer.writeln();
+    } else {
+      buffer.writeln(
+        '#### Top Duplication Clusters (Ranked by Weight & Potential Savings)',
+      );
+      buffer.writeln();
+
+      for (var i = 0; i < displayClusters.length; i++) {
+        final c = displayClusters[i];
+        final rank = i + 1;
+        final weightStr = c.weight.toStringAsFixed(1);
+        final categoryTag = c.category == 'data' ? ' [Data Table]' : '';
+
+        buffer.writeln(
+          '**#$rank ${c.bucketLabel}$categoryTag** — ${c.size} copies · ${c.canonicalNodeCount} AST nodes · weight $weightStr',
+        );
+
+        if (c.interpretation.isNotEmpty) {
+          buffer.writeln('> ${c.interpretation}');
+        }
+
+        for (final occ in c.occurrences) {
+          final relPath = occ.path;
+          final absFilePath = _resolveAbsolutePath(absTargetDir, relPath);
+          final lineSuffix = occ.lineSpan;
+          final linkText = '$relPath:$lineSuffix';
+          final targetUrl = 'file://$absFilePath#$lineSuffix';
+          buffer.writeln('* [$linkText]($targetUrl)');
+        }
+        buffer.writeln();
+      }
+
+      if (filteredClusters.length > topCount) {
+        final remaining = filteredClusters.length - topCount;
+        buffer.writeln(
+          '_... $remaining more clusters hidden (use `--top=${filteredClusters.length}` to display all)_',
+        );
+        buffer.writeln();
+      }
+    }
+  }
+
+  // 3. Per-File Duplication Breakdown Table
+  if (includeFileTable) {
+    final duplicatedFiles = report.metrics.perFile
+        .where((f) => f.duplicatedLoc > 0)
+        .toList();
+
+    // Sort by duplicated LOC descending
+    duplicatedFiles.sort((a, b) => b.duplicatedLoc.compareTo(a.duplicatedLoc));
+
+    if (duplicatedFiles.isNotEmpty) {
+      buffer.writeln('#### Duplicated Source Files');
+      buffer.writeln();
+      buffer.writeln('| File | Duplicated LOC | Total LOC | Duplication % |');
+      buffer.writeln('| :--- | :---: | :---: | :---: |');
+
+      for (final file in duplicatedFiles) {
+        final relPath = file.path;
+        final absFilePath = _resolveAbsolutePath(absTargetDir, relPath);
+        final linkText = relPath;
+        final targetUrl = 'file://$absFilePath';
+        final filePercent = file.duplicationPercent.toStringAsFixed(1);
+
+        buffer.writeln(
+          '| [$linkText]($targetUrl) | ${file.duplicatedLoc} | ${file.analysedLoc} | $filePercent% |',
+        );
+      }
+      buffer.writeln();
+    }
+  }
+
+  return buffer.toString().trimRight();
+}

--- a/skills/deslop-duplication-audit/lib/src/formatter.dart
+++ b/skills/deslop-duplication-audit/lib/src/formatter.dart
@@ -6,13 +6,14 @@ import 'dart:io';
 import 'models.dart';
 
 String _resolveAbsolutePath(String baseDir, String relativePath) {
-  if (relativePath.startsWith(Platform.pathSeparator)) {
-    return Uri.file(relativePath).normalizePath().toFilePath();
+  final file = File(relativePath);
+  if (file.isAbsolute) {
+    return file.absolute.path;
   }
   final combined = baseDir.endsWith(Platform.pathSeparator)
       ? '$baseDir$relativePath'
       : '$baseDir${Platform.pathSeparator}$relativePath';
-  return Uri.file(combined).normalizePath().toFilePath();
+  return File(combined).absolute.path;
 }
 
 /// Formats a [DeslopReport] into a high-density, token-efficient Markdown document.
@@ -76,10 +77,7 @@ String formatDeslopMarkdown({
   buffer.writeln('* **Total Clusters**: $totalClusters$breakdownText');
 
   if (htmlReportPath != null && File(htmlReportPath).existsSync()) {
-    final absHtmlPath = Uri.file(
-      File(htmlReportPath).absolute.path,
-    ).normalizePath().toFilePath();
-    final htmlUri = 'file://$absHtmlPath';
+    final htmlUri = Uri.file(File(htmlReportPath).absolute.path).toString();
     buffer.writeln('* **Interactive HTML Report**: [report.html]($htmlUri)');
   }
 
@@ -87,7 +85,7 @@ String formatDeslopMarkdown({
 
   // 2. Top Duplication Clusters
   if (includeClusters) {
-    var filteredClusters = report.clusters;
+    var filteredClusters = List<DeslopCluster>.of(report.clusters);
 
     if (categoryFilter != 'all') {
       filteredClusters = filteredClusters
@@ -134,7 +132,7 @@ String formatDeslopMarkdown({
           final absFilePath = _resolveAbsolutePath(absTargetDir, relPath);
           final lineSuffix = occ.lineSpan;
           final linkText = '$relPath:$lineSuffix';
-          final targetUrl = 'file://$absFilePath#$lineSuffix';
+          final targetUrl = '${Uri.file(absFilePath)}#$lineSuffix';
           buffer.writeln('* [$linkText]($targetUrl)');
         }
         buffer.writeln();
@@ -169,7 +167,7 @@ String formatDeslopMarkdown({
         final relPath = file.path;
         final absFilePath = _resolveAbsolutePath(absTargetDir, relPath);
         final linkText = relPath;
-        final targetUrl = 'file://$absFilePath';
+        final targetUrl = Uri.file(absFilePath).toString();
         final filePercent = file.duplicationPercent.toStringAsFixed(1);
 
         buffer.writeln(

--- a/skills/deslop-duplication-audit/lib/src/models.dart
+++ b/skills/deslop-duplication-audit/lib/src/models.dart
@@ -1,0 +1,274 @@
+/// Data models representing Deslop duplicate code analysis reports.
+library;
+
+/// Represents the top-level Deslop JSON report structure.
+class DeslopReport {
+  final String toolVersion;
+  final int minNodes;
+  final int filesAnalysed;
+  final int clustersHidden;
+  final DeslopMetrics metrics;
+  final List<ActionHint> actionHints;
+  final List<DeslopCluster> clusters;
+
+  DeslopReport({
+    required this.toolVersion,
+    required this.minNodes,
+    required this.filesAnalysed,
+    required this.clustersHidden,
+    required this.metrics,
+    required this.actionHints,
+    required this.clusters,
+  });
+
+  factory DeslopReport.fromJson(Map<String, dynamic> json) {
+    final metricsJson = json['metrics'] as Map<String, dynamic>? ?? {};
+    final actionHintsList = json['action_hints'] as List<dynamic>? ?? [];
+    final clustersList = json['clusters'] as List<dynamic>? ?? [];
+
+    return DeslopReport(
+      toolVersion: json['tool_version'] as String? ?? 'unknown',
+      minNodes: json['min_nodes'] as int? ?? 30,
+      filesAnalysed: json['files_analysed'] as int? ?? 0,
+      clustersHidden: json['clusters_hidden'] as int? ?? 0,
+      metrics: DeslopMetrics.fromJson(metricsJson),
+      actionHints: actionHintsList
+          .map((e) => ActionHint.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      clusters: clustersList
+          .map((e) => DeslopCluster.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'tool_version': toolVersion,
+    'min_nodes': minNodes,
+    'files_analysed': filesAnalysed,
+    'clusters_hidden': clustersHidden,
+    'metrics': metrics.toJson(),
+    'action_hints': actionHints.map((e) => e.toJson()).toList(),
+    'clusters': clusters.map((e) => e.toJson()).toList(),
+  };
+}
+
+/// Overall duplication metrics and per-file statistics.
+class DeslopMetrics {
+  final int analysedLoc;
+  final int duplicatedLoc;
+  final double duplicationPercent;
+  final int clustersTotal;
+  final int duplicatedFiles;
+  final List<FileMetric> perFile;
+
+  DeslopMetrics({
+    required this.analysedLoc,
+    required this.duplicatedLoc,
+    required this.duplicationPercent,
+    required this.clustersTotal,
+    required this.duplicatedFiles,
+    required this.perFile,
+  });
+
+  factory DeslopMetrics.fromJson(Map<String, dynamic> json) {
+    final perFileList = json['per_file'] as List<dynamic>? ?? [];
+    return DeslopMetrics(
+      analysedLoc: json['analysed_loc'] as int? ?? 0,
+      duplicatedLoc: json['duplicated_loc'] as int? ?? 0,
+      duplicationPercent:
+          (json['duplication_percent'] as num?)?.toDouble() ?? 0.0,
+      clustersTotal: json['clusters_total'] as int? ?? 0,
+      duplicatedFiles: json['duplicated_files'] as int? ?? 0,
+      perFile: perFileList
+          .map((e) => FileMetric.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'analysed_loc': analysedLoc,
+    'duplicated_loc': duplicatedLoc,
+    'duplication_percent': duplicationPercent,
+    'clusters_total': clustersTotal,
+    'duplicated_files': duplicatedFiles,
+    'per_file': perFile.map((e) => e.toJson()).toList(),
+  };
+}
+
+/// Duplication statistics for an individual source file.
+class FileMetric {
+  final String path;
+  final int analysedLoc;
+  final int duplicatedLoc;
+  final double duplicationPercent;
+
+  FileMetric({
+    required this.path,
+    required this.analysedLoc,
+    required this.duplicatedLoc,
+    required this.duplicationPercent,
+  });
+
+  factory FileMetric.fromJson(Map<String, dynamic> json) {
+    return FileMetric(
+      path: json['path'] as String? ?? '',
+      analysedLoc: json['analysed_loc'] as int? ?? 0,
+      duplicatedLoc: json['duplicated_loc'] as int? ?? 0,
+      duplicationPercent:
+          (json['duplication_percent'] as num?)?.toDouble() ?? 0.0,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'path': path,
+    'analysed_loc': analysedLoc,
+    'duplicated_loc': duplicatedLoc,
+    'duplication_percent': duplicationPercent,
+  };
+}
+
+/// Generic action recommendation hint emitted by Deslop.
+class ActionHint {
+  final String pattern;
+  final String recommendation;
+
+  ActionHint({required this.pattern, required this.recommendation});
+
+  factory ActionHint.fromJson(Map<String, dynamic> json) {
+    return ActionHint(
+      pattern: json['pattern'] as String? ?? '',
+      recommendation: json['recommendation'] as String? ?? '',
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'pattern': pattern,
+    'recommendation': recommendation,
+  };
+}
+
+/// A cluster of duplicated code blocks identified by Deslop.
+class DeslopCluster {
+  final String id;
+  final double weight;
+  final int size;
+  final int canonicalNodeCount;
+  final Map<String, double> signals;
+  final String bucket;
+  final String category;
+  final List<ClusterOccurrence> occurrences;
+  final int occurrencesTotal;
+  final String summary;
+  final String interpretation;
+
+  DeslopCluster({
+    required this.id,
+    required this.weight,
+    required this.size,
+    required this.canonicalNodeCount,
+    required this.signals,
+    required this.bucket,
+    required this.category,
+    required this.occurrences,
+    required this.occurrencesTotal,
+    required this.summary,
+    required this.interpretation,
+  });
+
+  factory DeslopCluster.fromJson(Map<String, dynamic> json) {
+    final signalsMap = <String, double>{};
+    final rawSignals = json['signals'] as Map<String, dynamic>? ?? {};
+    for (final entry in rawSignals.entries) {
+      if (entry.value is num) {
+        signalsMap[entry.key] = (entry.value as num).toDouble();
+      }
+    }
+
+    final occList = json['occurrences'] as List<dynamic>? ?? [];
+
+    return DeslopCluster(
+      id: json['id'] as String? ?? '',
+      weight: (json['weight'] as num?)?.toDouble() ?? 0.0,
+      size: json['size'] as int? ?? 0,
+      canonicalNodeCount: json['canonical_node_count'] as int? ?? 0,
+      signals: signalsMap,
+      bucket: json['bucket'] as String? ?? '',
+      category: json['category'] as String? ?? 'logic',
+      occurrences: occList
+          .map((e) => ClusterOccurrence.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      occurrencesTotal: json['occurrences_total'] as int? ?? occList.length,
+      summary: json['summary'] as String? ?? '',
+      interpretation: json['interpretation'] as String? ?? '',
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'weight': weight,
+    'size': size,
+    'canonical_node_count': canonicalNodeCount,
+    'signals': signals,
+    'bucket': bucket,
+    'category': category,
+    'occurrences': occurrences.map((e) => e.toJson()).toList(),
+    'occurrences_total': occurrencesTotal,
+    'summary': summary,
+    'interpretation': interpretation,
+  };
+
+  /// Human-readable label for the duplication bucket.
+  String get bucketLabel {
+    return switch (bucket) {
+      'identical' => 'Identical [Type-1/2]',
+      'nearly_identical' => 'Nearly Identical [Type-3]',
+      'structural_only' => 'Structural-Only',
+      'loosely_similar' => 'Loosely Similar',
+      'same_behavior' => 'Same Behavior [AI]',
+      _ => bucket,
+    };
+  }
+}
+
+/// A specific file and line-range occurrence within a duplication cluster.
+class ClusterOccurrence {
+  final String path;
+  final int startByte;
+  final int endByte;
+  final int startLine;
+  final int endLine;
+  final bool hidden;
+
+  ClusterOccurrence({
+    required this.path,
+    required this.startByte,
+    required this.endByte,
+    required this.startLine,
+    required this.endLine,
+    required this.hidden,
+  });
+
+  factory ClusterOccurrence.fromJson(Map<String, dynamic> json) {
+    return ClusterOccurrence(
+      path: json['path'] as String? ?? '',
+      startByte: json['start_byte'] as int? ?? 0,
+      endByte: json['end_byte'] as int? ?? 0,
+      startLine: json['start_line'] as int? ?? 1,
+      endLine: json['end_line'] as int? ?? 1,
+      hidden: json['hidden'] as bool? ?? false,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+    'path': path,
+    'start_byte': startByte,
+    'end_byte': endByte,
+    'start_line': startLine,
+    'end_line': endLine,
+    'hidden': hidden,
+  };
+
+  /// Returns the line span as a string, e.g. `L10-25` or `L10`.
+  String get lineSpan =>
+      startLine == endLine ? 'L$startLine' : 'L$startLine-$endLine';
+}

--- a/skills/deslop-duplication-audit/lib/src/runner.dart
+++ b/skills/deslop-duplication-audit/lib/src/runner.dart
@@ -1,0 +1,168 @@
+/// Orchestrates the discovery and execution of the Deslop CLI binary.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'models.dart';
+
+/// Result from executing a Deslop CLI scan.
+class DeslopRunResult {
+  final String targetDir;
+  final String outputPrefix;
+  final String jsonPath;
+  final String txtPath;
+  final String htmlPath;
+  final DeslopReport report;
+
+  DeslopRunResult({
+    required this.targetDir,
+    required this.outputPrefix,
+    required this.jsonPath,
+    required this.txtPath,
+    required this.htmlPath,
+    required this.report,
+  });
+}
+
+/// Locates the `deslop` binary on `$PATH` or common installation paths.
+String? findDeslopExecutable() {
+  // 1. Check if deslop is already available on PATH
+  final envPath = Platform.environment['PATH'] ?? '';
+  final separator = Platform.isWindows ? ';' : ':';
+  final paths = envPath.split(separator);
+
+  final exeName = Platform.isWindows ? 'deslop.exe' : 'deslop';
+
+  for (final dir in paths) {
+    if (dir.trim().isEmpty) continue;
+    final candidate = File(
+      dir.endsWith(Platform.pathSeparator)
+          ? '$dir$exeName'
+          : '$dir${Platform.pathSeparator}$exeName',
+    );
+    if (candidate.existsSync()) {
+      return candidate.path;
+    }
+  }
+
+  // 2. Check common known locations
+  final home =
+      Platform.environment['HOME'] ?? Platform.environment['USERPROFILE'] ?? '';
+  if (home.isNotEmpty) {
+    final candidatePaths = [
+      '$home/.cargo/bin/$exeName',
+      '$home/.local/share/mise/shims/$exeName',
+      '/opt/homebrew/bin/$exeName',
+      '/usr/local/bin/$exeName',
+    ];
+
+    for (final path in candidatePaths) {
+      if (File(path).existsSync()) {
+        return path;
+      }
+    }
+  }
+
+  return null;
+}
+
+/// Runs a Deslop scan over [targetDir] and parses the generated report.
+Future<DeslopRunResult> runDeslopScan({
+  required String targetDir,
+  String? outputPrefix,
+  int minNodes = 30,
+  String? configPath,
+}) async {
+  final targetDirectory = Directory(targetDir);
+  if (!targetDirectory.existsSync()) {
+    throw FileSystemException(
+      'Target directory does not exist',
+      targetDirectory.path,
+    );
+  }
+
+  final executable = findDeslopExecutable();
+  if (executable == null) {
+    throw StateError(
+      'Could not find "deslop" executable on PATH or common installation directories.\n'
+      'Install via: cargo install deslop (or cargo binstall deslop / mise use -g github:Nimblesite/deslop@latest)',
+    );
+  }
+
+  // Determine output prefix
+  final effectiveOutputPrefix =
+      outputPrefix ??
+      '${Directory.systemTemp.createTempSync('deslop_').path}${Platform.pathSeparator}report';
+
+  final parentDir = File(effectiveOutputPrefix).parent;
+  if (!parentDir.existsSync()) {
+    parentDir.createSync(recursive: true);
+  }
+
+  final args = <String>[
+    targetDirectory.path,
+    '--output',
+    effectiveOutputPrefix,
+    '--min-nodes',
+    minNodes.toString(),
+    '--no-incremental',
+    '--no-fail-over',
+    '--log-to-console',
+    '--log-level',
+    'warn',
+  ];
+
+  if (configPath != null && configPath.isNotEmpty) {
+    args.addAll(['--config', configPath]);
+  }
+
+  final result = await Process.run(executable, args);
+  if (result.exitCode != 0 && result.exitCode != 3) {
+    // Note: exitCode 3 is fail-over threshold if tripped, but we passed --no-fail-over
+    throw ProcessException(
+      executable,
+      args,
+      'deslop failed with exit code ${result.exitCode}:\n${result.stderr}\n${result.stdout}',
+      result.exitCode,
+    );
+  }
+
+  final jsonFile = File('$effectiveOutputPrefix.json');
+  if (!jsonFile.existsSync()) {
+    throw StateError(
+      'Deslop finished but JSON report was not found at ${jsonFile.path}',
+    );
+  }
+
+  final jsonContent = await jsonFile.readAsString();
+  final dynamic parsed = jsonDecode(jsonContent);
+  if (parsed is! Map<String, dynamic>) {
+    throw const FormatException('Expected JSON object root in Deslop report');
+  }
+
+  final report = DeslopReport.fromJson(parsed);
+
+  return DeslopRunResult(
+    targetDir: targetDirectory.path,
+    outputPrefix: effectiveOutputPrefix,
+    jsonPath: jsonFile.path,
+    txtPath: '$effectiveOutputPrefix.txt',
+    htmlPath: '$effectiveOutputPrefix.html',
+    report: report,
+  );
+}
+
+/// Loads and parses an existing Deslop JSON report file.
+Future<DeslopReport> loadReportJson(String filePath) async {
+  final file = File(filePath);
+  if (!file.existsSync()) {
+    throw FileSystemException('Report JSON file does not exist', filePath);
+  }
+  final jsonContent = await file.readAsString();
+  final dynamic parsed = jsonDecode(jsonContent);
+  if (parsed is! Map<String, dynamic>) {
+    throw const FormatException('Expected JSON object root in Deslop report');
+  }
+  return DeslopReport.fromJson(parsed);
+}

--- a/skills/deslop-duplication-audit/pubspec.yaml
+++ b/skills/deslop-duplication-audit/pubspec.yaml
@@ -1,0 +1,7 @@
+name: deslop_duplication_audit
+description: Standalone helper tools for the deslop duplication audit skill.
+version: 1.0.0
+publish_to: none
+
+environment:
+  sdk: ^3.12.0

--- a/skills/deslop-duplication-audit/pubspec.yaml
+++ b/skills/deslop-duplication-audit/pubspec.yaml
@@ -5,3 +5,6 @@ publish_to: none
 
 environment:
   sdk: ^3.12.0
+
+dependencies:
+  args: ^2.4.0

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -11,6 +11,8 @@ dependencies:
   path: ^1.9.0
 
 dev_dependencies:
+  deslop_duplication_audit:
+    path: ../skills/deslop-duplication-audit
   sidequest:
     path: ../skills/sidequest
   test: ^1.24.0

--- a/tool/test/deslop_report_test.dart
+++ b/tool/test/deslop_report_test.dart
@@ -1,0 +1,216 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:checks/checks.dart';
+import 'package:deslop_duplication_audit/deslop_report.dart';
+import 'package:test/test.dart';
+
+const _sampleDeslopJson = '''
+{
+  "tool_version": "0.31.0",
+  "min_nodes": 30,
+  "files_analysed": 18,
+  "clusters_hidden": 5,
+  "metrics": {
+    "analysed_loc": 1000,
+    "duplicated_loc": 150,
+    "duplication_percent": 15.0,
+    "clusters_total": 2,
+    "duplicated_files": 2,
+    "per_file": [
+      {
+        "path": "lib/foo.dart",
+        "analysed_loc": 500,
+        "duplicated_loc": 100,
+        "duplication_percent": 20.0
+      },
+      {
+        "path": "lib/bar.dart",
+        "analysed_loc": 500,
+        "duplicated_loc": 50,
+        "duplication_percent": 10.0
+      }
+    ]
+  },
+  "action_hints": [
+    {
+      "pattern": "bucket=identical",
+      "recommendation": "Safe to extract"
+    }
+  ],
+  "clusters": [
+    {
+      "id": "c1",
+      "weight": 120.5,
+      "size": 2,
+      "canonical_node_count": 45,
+      "signals": {
+        "structural": 1.0,
+        "token_jaccard": 0.95
+      },
+      "bucket": "nearly_identical",
+      "category": "logic",
+      "occurrences": [
+        {
+          "path": "lib/foo.dart",
+          "start_byte": 100,
+          "end_byte": 200,
+          "start_line": 10,
+          "end_line": 20,
+          "hidden": false
+        },
+        {
+          "path": "lib/bar.dart",
+          "start_byte": 150,
+          "end_byte": 250,
+          "start_line": 15,
+          "end_line": 25,
+          "hidden": false
+        }
+      ],
+      "occurrences_total": 2,
+      "summary": "2 copies of a 45-node subtree",
+      "interpretation": "Review differences before merging"
+    },
+    {
+      "id": "c2",
+      "weight": 80.0,
+      "size": 2,
+      "canonical_node_count": 30,
+      "signals": {
+        "structural": 1.0
+      },
+      "bucket": "identical",
+      "category": "data",
+      "occurrences": [
+        {
+          "path": "lib/foo.dart",
+          "start_byte": 300,
+          "end_byte": 350,
+          "start_line": 30,
+          "end_line": 35,
+          "hidden": false
+        },
+        {
+          "path": "lib/bar.dart",
+          "start_byte": 350,
+          "end_byte": 400,
+          "start_line": 40,
+          "end_line": 45,
+          "hidden": false
+        }
+      ],
+      "occurrences_total": 2,
+      "summary": "2 copies of data table",
+      "interpretation": "Repeated data rows"
+    }
+  ]
+}
+''';
+
+void main() {
+  group('DeslopReport model parsing', () {
+    test('parses sample report JSON correctly', () {
+      final dynamic decoded = jsonDecode(_sampleDeslopJson);
+      final report = DeslopReport.fromJson(decoded as Map<String, dynamic>);
+
+      check(report.toolVersion).equals('0.31.0');
+      check(report.minNodes).equals(30);
+      check(report.filesAnalysed).equals(18);
+      check(report.clustersHidden).equals(5);
+      check(report.metrics.analysedLoc).equals(1000);
+      check(report.metrics.duplicatedLoc).equals(150);
+      check(report.metrics.duplicationPercent).equals(15.0);
+      check(report.metrics.perFile).has((p) => p.length, 'length').equals(2);
+      check(report.clusters).has((c) => c.length, 'length').equals(2);
+
+      final c1 = report.clusters.first;
+      check(c1.id).equals('c1');
+      check(c1.bucket).equals('nearly_identical');
+      check(c1.bucketLabel).equals('Nearly Identical [Type-3]');
+      check(c1.occurrences).has((o) => o.length, 'length').equals(2);
+      check(c1.occurrences.first.lineSpan).equals('L10-20');
+    });
+  });
+
+  group('formatDeslopMarkdown', () {
+    test('renders markdown with proper clickable file links', () {
+      final dynamic decoded = jsonDecode(_sampleDeslopJson);
+      final report = DeslopReport.fromJson(decoded as Map<String, dynamic>);
+
+      final md = formatDeslopMarkdown(
+        report: report,
+        targetDir: '/fake/repo',
+        htmlReportPath: '/fake/repo/report.html',
+        topCount: 5,
+      );
+
+      check(md).contains('### 🔬 Deslop Code Duplication Report');
+      check(md).contains('**15.0%** (150 / 1000 LOC across 2 / 18 files)');
+      check(md).contains(
+        '[lib/foo.dart:L10-20](file:///fake/repo/lib/foo.dart#L10-20)',
+      );
+      check(md).contains(
+        '[lib/bar.dart:L15-25](file:///fake/repo/lib/bar.dart#L15-25)',
+      );
+      check(md).contains(
+        '| [lib/foo.dart](file:///fake/repo/lib/foo.dart) | 100 | 500 | 20.0% |',
+      );
+    });
+
+    test('supports filtering by category', () {
+      final dynamic decoded = jsonDecode(_sampleDeslopJson);
+      final report = DeslopReport.fromJson(decoded as Map<String, dynamic>);
+
+      final md = formatDeslopMarkdown(
+        report: report,
+        targetDir: '/fake/repo',
+        categoryFilter: 'logic',
+      );
+
+      check(md).contains('Nearly Identical [Type-3]');
+      check(md).not((s) => s.contains('[Data Table]'));
+    });
+  });
+
+  group('runner and CLI', () {
+    test('findDeslopExecutable returns a non-empty string if installed', () {
+      final exe = findDeslopExecutable();
+      if (exe != null) {
+        check(File(exe).existsSync()).isTrue();
+      }
+    });
+
+    test('CLI prints help on -h', () async {
+      final process = await Process.run(Platform.resolvedExecutable, [
+        'run',
+        '../skills/deslop-duplication-audit/bin/deslop_report.dart',
+        '-h',
+      ]);
+      check(process.exitCode).equals(0);
+      check(
+        process.stdout as String,
+      ).contains('Deslop Duplication Audit Report Generator');
+    });
+
+    test('CLI processes --report json file and outputs markdown', () async {
+      final tempDir = Directory.systemTemp.createTempSync('deslop_test_');
+      final tempJson = File('${tempDir.path}/test_report.json');
+      await tempJson.writeAsString(_sampleDeslopJson);
+
+      final process = await Process.run(Platform.resolvedExecutable, [
+        'run',
+        '../skills/deslop-duplication-audit/bin/deslop_report.dart',
+        '--report=${tempJson.path}',
+        '--dir=/sample/target',
+      ]);
+
+      check(process.exitCode).equals(0);
+      final stdoutStr = process.stdout as String;
+      check(stdoutStr).contains('### 🔬 Deslop Code Duplication Report');
+      check(stdoutStr).contains('lib/foo.dart:L10-20');
+
+      tempDir.deleteSync(recursive: true);
+    });
+  });
+}


### PR DESCRIPTION
Add a standalone Dart CLI script (deslop_report.dart) and library to the deslop-duplication-audit skill to run Deslop scans and parse results deterministically without context overhead.

- Add DeslopReport models and JSON parser
- Add runner.dart to discover and run deslop binary
- Add formatter.dart for token-efficient Markdown reports with clickable links
- Add unit and integration tests in tool/test/deslop_report_test.dart
- Update SKILL.md to reference deslop_report.dart
