### PR TITLE
feat(deslop): add diff parsing and changed-code delta filtering

### DIFF
--- a/skills/deslop-duplication-audit/SKILL.md
+++ b/skills/deslop-duplication-audit/SKILL.md
@@ -44,13 +44,40 @@ Execute the bundled Dart helper script (`deslop_report.dart`) to run Deslop in
 strictly read-only mode and emit an instant, token-efficient Markdown summary
 with clickable source and HTML links:
 
+### A. Full Repository / Directory Scan
 ```bash
 dart run skills/deslop-duplication-audit/bin/deslop_report.dart --dir {target_dir} [--top 10]
 ```
 
 - If Deslop was already executed manually, parse an existing report directly:
   `dart run skills/deslop-duplication-audit/bin/deslop_report.dart --report {path_to_report.json} --dir {target_dir}`
+
+### B. PR / CL Delta Scan (Changed Code Focus)
+To avoid noisy legacy duplicate reports and focus strictly on code modified in
+a Pull Request or Google3 Changelist, pass a diff command or changed files:
+
+```bash
+# In Google3 (Jujutsu):
+dart run skills/deslop-duplication-audit/bin/deslop_report.dart \
+  --dir {package_dir} \
+  --diff-cmd "jj diff" \
+  --only-changed
+
+# In Git checkouts:
+dart run skills/deslop-duplication-audit/bin/deslop_report.dart \
+  --dir {repo_dir} \
+  --diff-cmd "git diff main...HEAD" \
+  --only-changed
+
+# Explicit diff file or touched file list:
+dart run skills/deslop-duplication-audit/bin/deslop_report.dart \
+  --dir {target_dir} \
+  --diff-file {path_to_diff.patch} \
+  --only-changed
+```
+
 - Target working trees remain untouched (zero `.deslop/` cache directory bloat or dirty git status).
+- Note: Tracking upstream feature request [Nimblesite/Deslop#364](https://github.com/Nimblesite/Deslop/issues/364) for native diff ingestion.
 - If scanning multiple repositories across a workspace or portfolio, deploy
   parallel investigative subagents (`invoke_subagent`) to execute read-only
   scans concurrently and consolidate the reporting matrix in chat.

--- a/skills/deslop-duplication-audit/bin/deslop_report.dart
+++ b/skills/deslop-duplication-audit/bin/deslop_report.dart
@@ -45,6 +45,28 @@ ArgParser _buildParser() {
       ],
       help: 'Filter clusters by bucket.',
     )
+    ..addOption(
+      'diff-cmd',
+      help:
+          'Command to execute to obtain unified diff (e.g. "jj diff" or "git diff").',
+    )
+    ..addOption('diff-file', help: 'Path to a file containing a unified diff.')
+    ..addOption(
+      'diff',
+      help: 'Literal unified diff string to filter clusters against.',
+    )
+    ..addOption(
+      'touched-files',
+      help:
+          'Comma-separated list of modified file paths to filter clusters against.',
+    )
+    ..addFlag(
+      'only-changed',
+      defaultsTo: false,
+      negatable: true,
+      help:
+          'Only report clusters that intersect with changed lines or touched files in the diff.',
+    )
     ..addFlag(
       'files',
       defaultsTo: true,
@@ -72,6 +94,86 @@ ArgParser _buildParser() {
     );
 }
 
+Future<(DeslopReport, String?)> _resolveReport({
+  required String? reportJsonPath,
+  required String targetDir,
+  required String? outDir,
+  required int minNodes,
+}) async {
+  if (reportJsonPath != null) {
+    final report = await loadReportJson(reportJsonPath);
+    final htmlCandidate = reportJsonPath.replaceAll(
+      RegExp(r'\.json$'),
+      '.html',
+    );
+    final htmlReportPath = File(htmlCandidate).existsSync()
+        ? htmlCandidate
+        : null;
+    return (report, htmlReportPath);
+  }
+
+  String? outputPrefix;
+  if (outDir != null) {
+    final dir = Directory(outDir);
+    if (!dir.existsSync()) dir.createSync(recursive: true);
+    outputPrefix = '${dir.path}${Platform.pathSeparator}report';
+  }
+
+  final result = await runDeslopScan(
+    targetDir: targetDir,
+    outputPrefix: outputPrefix,
+    minNodes: minNodes,
+  );
+
+  return (result.report, result.htmlPath);
+}
+
+void _emitOutput({
+  required DeslopReport report,
+  required String? htmlReportPath,
+  required String targetDir,
+  required Map<String, List<LineSpan>> changedRanges,
+  required bool onlyChanged,
+  required ArgResults results,
+}) {
+  final outputJson = results.flag('json');
+
+  if (outputJson) {
+    var outputReport = report;
+    if (onlyChanged && changedRanges.isNotEmpty) {
+      final filtered = report.clusters
+          .where((c) => c.intersectsDiff(changedRanges))
+          .toList();
+      outputReport = DeslopReport(
+        toolVersion: report.toolVersion,
+        minNodes: report.minNodes,
+        filesAnalysed: report.filesAnalysed,
+        clustersHidden: report.clustersHidden,
+        metrics: report.metrics,
+        actionHints: report.actionHints,
+        clusters: filtered,
+      );
+    }
+    const encoder = JsonEncoder.withIndent('  ');
+    print(encoder.convert(outputReport.toJson()));
+    return;
+  }
+
+  final markdown = formatDeslopMarkdown(
+    report: report,
+    targetDir: targetDir,
+    htmlReportPath: htmlReportPath,
+    topCount: int.tryParse(results.option('top') ?? '10') ?? 10,
+    categoryFilter: results.option('category') ?? 'all',
+    bucketFilter: results.option('bucket') ?? 'all',
+    includeFileTable: results.flag('files'),
+    includeClusters: results.flag('clusters'),
+    changedRanges: changedRanges,
+    onlyChangedCode: onlyChanged,
+  );
+  print(markdown);
+}
+
 void main(List<String> args) async {
   final parser = _buildParser();
   ArgResults results;
@@ -96,63 +198,42 @@ void main(List<String> args) async {
       results.option('dir') ??
       (results.rest.isNotEmpty ? results.rest.first : Directory.current.path);
 
-  final reportJsonPath = results.option('report');
-  final topCount = int.tryParse(results.option('top') ?? '10') ?? 10;
-  final minNodes = int.tryParse(results.option('min-nodes') ?? '30') ?? 30;
-  final outDir = results.option('out-dir');
-  final categoryFilter = results.option('category') ?? 'all';
-  final bucketFilter = results.option('bucket') ?? 'all';
-  final includeFileTable = results.flag('files');
-  final includeClusters = results.flag('clusters');
-  final outputJson = results.flag('json');
+  final explicitOnlyChanged = results.wasParsed('only-changed')
+      ? results.flag('only-changed')
+      : null;
 
   try {
-    DeslopReport report;
-    String? htmlReportPath;
+    final changedRanges = await resolveDiffRanges(
+      diffCmd: results.option('diff-cmd'),
+      diffFilePath: results.option('diff-file'),
+      diffString: results.option('diff'),
+      touchedFilesString: results.option('touched-files'),
+      workingDir: targetDir,
+    );
 
-    if (reportJsonPath != null) {
-      report = await loadReportJson(reportJsonPath);
-      final htmlCandidate = reportJsonPath.replaceAll(
-        RegExp(r'\.json$'),
-        '.html',
-      );
-      if (File(htmlCandidate).existsSync()) {
-        htmlReportPath = htmlCandidate;
-      }
-    } else {
-      String? outputPrefix;
-      if (outDir != null) {
-        final dir = Directory(outDir);
-        if (!dir.existsSync()) dir.createSync(recursive: true);
-        outputPrefix = '${dir.path}${Platform.pathSeparator}report';
-      }
+    final hasDiffArg =
+        results.wasParsed('diff-cmd') ||
+        results.wasParsed('diff-file') ||
+        results.wasParsed('diff') ||
+        results.wasParsed('touched-files');
+    final onlyChanged =
+        explicitOnlyChanged ?? (hasDiffArg || changedRanges.isNotEmpty);
 
-      final result = await runDeslopScan(
-        targetDir: targetDir,
-        outputPrefix: outputPrefix,
-        minNodes: minNodes,
-      );
+    final (report, htmlReportPath) = await _resolveReport(
+      reportJsonPath: results.option('report'),
+      targetDir: targetDir,
+      outDir: results.option('out-dir'),
+      minNodes: int.tryParse(results.option('min-nodes') ?? '30') ?? 30,
+    );
 
-      report = result.report;
-      htmlReportPath = result.htmlPath;
-    }
-
-    if (outputJson) {
-      final encoder = const JsonEncoder.withIndent('  ');
-      print(encoder.convert(report.toJson()));
-    } else {
-      final markdown = formatDeslopMarkdown(
-        report: report,
-        targetDir: targetDir,
-        htmlReportPath: htmlReportPath,
-        topCount: topCount,
-        categoryFilter: categoryFilter,
-        bucketFilter: bucketFilter,
-        includeFileTable: includeFileTable,
-        includeClusters: includeClusters,
-      );
-      print(markdown);
-    }
+    _emitOutput(
+      report: report,
+      htmlReportPath: htmlReportPath,
+      targetDir: targetDir,
+      changedRanges: changedRanges,
+      onlyChanged: onlyChanged,
+      results: results,
+    );
   } catch (e, st) {
     stderr.writeln('Error: $e');
     if (Platform.environment['DEBUG'] == 'true') {

--- a/skills/deslop-duplication-audit/lib/deslop_report.dart
+++ b/skills/deslop-duplication-audit/lib/deslop_report.dart
@@ -1,6 +1,7 @@
 /// Helper library for running and formatting Deslop duplication audits.
 library;
 
+export 'src/diff_parser.dart';
 export 'src/formatter.dart';
 export 'src/models.dart';
 export 'src/runner.dart';

--- a/skills/deslop-duplication-audit/lib/src/diff_parser.dart
+++ b/skills/deslop-duplication-audit/lib/src/diff_parser.dart
@@ -1,0 +1,166 @@
+/// Utilities for parsing unified diffs and extracting modified line ranges.
+library;
+
+/// Represents an inclusive 1-based line span `[start, end]`.
+class LineSpan {
+  final int start;
+  final int end;
+
+  const LineSpan(this.start, this.end) : assert(start <= end);
+
+  /// Checks if this line span overlaps with another `[otherStart, otherEnd]` range.
+  bool overlaps(int otherStart, int otherEnd) {
+    return start <= otherEnd && end >= otherStart;
+  }
+
+  /// Checks if a single 1-based line number falls within this span.
+  bool contains(int line) => line >= start && line <= end;
+
+  @override
+  String toString() => start == end ? 'L$start' : 'L$start-$end';
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is LineSpan && other.start == start && other.end == end;
+
+  @override
+  int get hashCode => Object.hash(start, end);
+}
+
+final _gitPrefixRegex = RegExp(r'^[a-z]/');
+
+/// Normalizes a file path for robust cross-tool diff matching.
+String normalizeFilePath(String path) {
+  var p = path.trim().replaceAll('\\', '/');
+  // Strip leading prefixes commonly found in git diffs: a/, b/, c/, i/, w/
+  if (_gitPrefixRegex.hasMatch(p)) {
+    p = p.substring(2);
+  }
+  // Strip leading slashes
+  while (p.startsWith('/')) {
+    p = p.substring(1);
+  }
+  return p;
+}
+
+/// Checks if a cluster occurrence path matches a diff file path.
+bool pathsMatch(String occurrencePath, String diffPath) {
+  final normOcc = normalizeFilePath(occurrencePath);
+  final normDiff = normalizeFilePath(diffPath);
+
+  if (normOcc == normDiff) return true;
+  if (normOcc.endsWith('/$normDiff') || normDiff.endsWith('/$normOcc')) {
+    return true;
+  }
+
+  final occBase = normOcc.split('/').last;
+  final diffBase = normDiff.split('/').last;
+  if (occBase.isNotEmpty && occBase == diffBase) {
+    if (normOcc == diffBase || normDiff == occBase) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+String? _extractFilePathFromHeader(String line) {
+  if (line.startsWith('+++ ')) {
+    final rawPath = line.substring(4).trim();
+    return rawPath == '/dev/null' ? null : normalizeFilePath(rawPath);
+  }
+
+  if (line.startsWith('Modified regular file ') ||
+      line.startsWith('Added regular file ')) {
+    final colonIdx = line.lastIndexOf(':');
+    if (colonIdx > 0) {
+      final prefixLen = line.indexOf('file ') + 5;
+      final rawPath = line.substring(prefixLen, colonIdx).trim();
+      return normalizeFilePath(rawPath);
+    }
+  }
+
+  return null;
+}
+
+final _hunkHeaderRegex = RegExp(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@');
+
+LineSpan? _parseHunkHeader(String line) {
+  if (!line.startsWith('@@ ')) return null;
+  final match = _hunkHeaderRegex.firstMatch(line);
+  if (match == null) return null;
+
+  final newStart = int.parse(match.group(1)!);
+  final countStr = match.group(2);
+  final newCount = countStr != null ? int.parse(countStr) : 1;
+
+  if (newCount <= 0) return null;
+  return LineSpan(newStart, newStart + newCount - 1);
+}
+
+List<LineSpan> _mergeLineSpans(List<LineSpan> spans) {
+  if (spans.isEmpty) return const [];
+  final sorted = List<LineSpan>.from(spans)
+    ..sort((a, b) => a.start.compareTo(b.start));
+  final merged = <LineSpan>[sorted.first];
+
+  for (var j = 1; j < sorted.length; j++) {
+    final current = sorted[j];
+    final last = merged.last;
+
+    if (current.start <= last.end + 1) {
+      final newEnd = current.end > last.end ? current.end : last.end;
+      merged[merged.length - 1] = LineSpan(last.start, newEnd);
+    } else {
+      merged.add(current);
+    }
+  }
+  return merged;
+}
+
+/// Parses a unified diff string and returns a map of `{ normalizedPath: List<LineSpan> }`
+/// containing all added/modified line ranges in the new version of each file.
+// TODO(kevmoo): Simplify/delegate to upstream if https://github.com/Nimblesite/Deslop/issues/364 lands native --diff support.
+Map<String, List<LineSpan>> parseUnifiedDiff(String diffContent) {
+  final rawResult = <String, List<LineSpan>>{};
+  final lines = diffContent.split('\n');
+
+  String? currentFile;
+
+  for (final line in lines) {
+    final headerFile = _extractFilePathFromHeader(line);
+    if (headerFile != null) {
+      currentFile = headerFile;
+      rawResult.putIfAbsent(currentFile, () => []);
+      continue;
+    } else if (line.startsWith('+++ /dev/null')) {
+      currentFile = null;
+      continue;
+    }
+
+    final span = _parseHunkHeader(line);
+    if (span != null && currentFile != null) {
+      rawResult[currentFile]!.add(span);
+    }
+  }
+
+  final mergedResult = <String, List<LineSpan>>{};
+  for (final entry in rawResult.entries) {
+    mergedResult[entry.key] = _mergeLineSpans(entry.value);
+  }
+
+  return mergedResult;
+}
+
+/// Converts a list of file paths into a changed ranges map covering all lines (1..max).
+Map<String, List<LineSpan>> createTouchedFilesMap(List<String> filePaths) {
+  final result = <String, List<LineSpan>>{};
+  for (final path in filePaths) {
+    final norm = normalizeFilePath(path);
+    if (norm.isNotEmpty) {
+      result[norm] = [const LineSpan(1, 2147483647)];
+    }
+  }
+  return result;
+}

--- a/skills/deslop-duplication-audit/lib/src/formatter.dart
+++ b/skills/deslop-duplication-audit/lib/src/formatter.dart
@@ -3,6 +3,7 @@ library;
 
 import 'dart:io';
 
+import 'diff_parser.dart';
 import 'models.dart';
 
 String _resolveAbsolutePath(String baseDir, String relativePath) {
@@ -16,6 +17,254 @@ String _resolveAbsolutePath(String baseDir, String relativePath) {
   return File(combined).absolute.path;
 }
 
+/// Formats the summary overview header. Returns true if early exit (e.g. clean delta).
+bool _writeOverviewHeader(
+  StringBuffer buffer, {
+  required DeslopReport report,
+  required List<DeslopCluster> candidateClusters,
+  required bool hasDiffFilter,
+  required Map<String, List<LineSpan>>? changedRanges,
+  required String? htmlReportPath,
+}) {
+  if (hasDiffFilter) {
+    buffer.writeln('### 🔬 Deslop Code Duplication Report (CL Delta)');
+    buffer.writeln();
+
+    if (candidateClusters.isEmpty) {
+      buffer.writeln(
+        '* **Status**: ✅ **Clean** — 0 duplicate code clusters detected in modified code.',
+      );
+      if (report.clusters.isNotEmpty) {
+        buffer.writeln(
+          '* _Note: ${report.clusters.length} pre-existing cluster(s) in package outside modified lines._',
+        );
+      }
+      return true;
+    }
+
+    final newCount = candidateClusters
+        .where((c) => c.isNewlyIntroduced(changedRanges!))
+        .length;
+    final crossCount = candidateClusters.length - newCount;
+
+    buffer.writeln(
+      '* **Duplication in Changed Code**: **${candidateClusters.length} cluster(s)** intersect modified code.',
+    );
+    if (newCount > 0) {
+      buffer.writeln(
+        '  * ⚠️ **$newCount newly introduced clone(s)** (all copies within CL changes)',
+      );
+    }
+    if (crossCount > 0) {
+      buffer.writeln(
+        '  * ℹ️ **$crossCount cross-file clone(s)** (CL changes share code with existing files)',
+      );
+    }
+  } else {
+    final totalLoc = report.metrics.analysedLoc;
+    final dupLoc = report.metrics.duplicatedLoc;
+    final dupPercent = report.metrics.duplicationPercent.toStringAsFixed(1);
+    final totalFiles = report.filesAnalysed;
+    final dupFiles = report.metrics.duplicatedFiles;
+    final totalClusters = report.metrics.clustersTotal;
+
+    buffer.writeln('### 🔬 Deslop Code Duplication Report');
+    buffer.writeln();
+    buffer.writeln(
+      '* **Duplication Score**: **$dupPercent%** ($dupLoc / $totalLoc LOC across $dupFiles / $totalFiles files)',
+    );
+
+    final breakdown = _buildBucketBreakdown(candidateClusters);
+    final breakdownText = breakdown.isNotEmpty ? ' ($breakdown)' : '';
+    buffer.writeln('* **Total Clusters**: $totalClusters$breakdownText');
+  }
+
+  if (htmlReportPath != null && File(htmlReportPath).existsSync()) {
+    final htmlUri = Uri.file(File(htmlReportPath).absolute.path).toString();
+    buffer.writeln('* **Interactive HTML Report**: [report.html]($htmlUri)');
+  }
+
+  buffer.writeln();
+  return false;
+}
+
+String _buildBucketBreakdown(List<DeslopCluster> clusters) {
+  final bucketCounts = <String, int>{};
+  for (final cluster in clusters) {
+    bucketCounts[cluster.bucket] = (bucketCounts[cluster.bucket] ?? 0) + 1;
+  }
+
+  final parts = <String>[];
+  if (bucketCounts.containsKey('identical')) {
+    parts.add('${bucketCounts['identical']} identical [Type-1/2]');
+  }
+  if (bucketCounts.containsKey('nearly_identical')) {
+    parts.add('${bucketCounts['nearly_identical']} near-identical [Type-3]');
+  }
+  if (bucketCounts.containsKey('structural_only')) {
+    parts.add(
+      '${bucketCounts['structural_only']} structural-only shape matches',
+    );
+  }
+  if (bucketCounts.containsKey('loosely_similar')) {
+    parts.add('${bucketCounts['loosely_similar']} loosely similar');
+  }
+  if (bucketCounts.containsKey('same_behavior')) {
+    parts.add('${bucketCounts['same_behavior']} AI semantic matches');
+  }
+  return parts.join(', ');
+}
+
+List<DeslopCluster> _filterClusters(
+  List<DeslopCluster> clusters,
+  String categoryFilter,
+  String bucketFilter,
+) {
+  var filtered = List<DeslopCluster>.of(clusters);
+  if (categoryFilter != 'all') {
+    filtered = filtered.where((c) => c.category == categoryFilter).toList();
+  }
+  if (bucketFilter != 'all') {
+    filtered = filtered.where((c) => c.bucket == bucketFilter).toList();
+  }
+  filtered.sort((a, b) => b.weight.compareTo(a.weight));
+  return filtered;
+}
+
+void _renderClusterOccurrence(
+  StringBuffer buffer,
+  ClusterOccurrence occ,
+  String absTargetDir,
+  bool hasDiffFilter,
+  Map<String, List<LineSpan>>? changedRanges,
+) {
+  final relPath = occ.path;
+  final absFilePath = _resolveAbsolutePath(absTargetDir, relPath);
+  final lineSuffix = occ.lineSpan;
+  final linkText = '$relPath:$lineSuffix';
+  final targetUrl = '${Uri.file(absFilePath)}#$lineSuffix';
+
+  var statusBadge = '';
+  if (hasDiffFilter) {
+    statusBadge = occ.intersectsDiff(changedRanges!)
+        ? ' `[CL Modified]`'
+        : ' `[Existing Code]`';
+  }
+
+  buffer.writeln('* [$linkText]($targetUrl)$statusBadge');
+}
+
+void _renderClustersSection(
+  StringBuffer buffer, {
+  required List<DeslopCluster> candidateClusters,
+  required String absTargetDir,
+  required int topCount,
+  required String categoryFilter,
+  required String bucketFilter,
+  required bool hasDiffFilter,
+  required Map<String, List<LineSpan>>? changedRanges,
+}) {
+  final filteredClusters = _filterClusters(
+    candidateClusters,
+    categoryFilter,
+    bucketFilter,
+  );
+
+  if (filteredClusters.isEmpty) {
+    buffer.writeln('_No duplicate clusters match the specified filters._');
+    buffer.writeln();
+    return;
+  }
+
+  final sectionTitle = hasDiffFilter
+      ? '#### Duplication Clusters Affecting Changed Code'
+      : '#### Top Duplication Clusters (Ranked by Weight & Potential Savings)';
+  buffer.writeln(sectionTitle);
+  buffer.writeln();
+
+  final displayClusters = filteredClusters.take(topCount).toList();
+
+  for (var i = 0; i < displayClusters.length; i++) {
+    final c = displayClusters[i];
+    final rank = i + 1;
+    final weightStr = c.weight.toStringAsFixed(1);
+    final categoryTag = c.category == 'data' ? ' [Data Table]' : '';
+    final isNewTag = hasDiffFilter && c.isNewlyIntroduced(changedRanges!)
+        ? ' ⚠️ [New in CL]'
+        : '';
+
+    buffer.writeln(
+      '**#$rank ${c.bucketLabel}$categoryTag$isNewTag** — ${c.size} copies · ${c.canonicalNodeCount} AST nodes · weight $weightStr',
+    );
+
+    if (c.interpretation.isNotEmpty) {
+      buffer.writeln('> ${c.interpretation}');
+    }
+
+    for (final occ in c.occurrences) {
+      _renderClusterOccurrence(
+        buffer,
+        occ,
+        absTargetDir,
+        hasDiffFilter,
+        changedRanges,
+      );
+    }
+    buffer.writeln();
+  }
+
+  if (filteredClusters.length > topCount) {
+    final remaining = filteredClusters.length - topCount;
+    buffer.writeln(
+      '_... $remaining more clusters hidden (use `--top=${filteredClusters.length}` to display all)_',
+    );
+    buffer.writeln();
+  }
+}
+
+void _renderFileMetricsTable(
+  StringBuffer buffer, {
+  required DeslopReport report,
+  required String absTargetDir,
+  required bool hasDiffFilter,
+  required Map<String, List<LineSpan>>? changedRanges,
+}) {
+  var duplicatedFiles = report.metrics.perFile
+      .where((f) => f.duplicatedLoc > 0)
+      .toList();
+
+  if (hasDiffFilter) {
+    duplicatedFiles = duplicatedFiles
+        .where((f) => changedRanges!.keys.any((k) => pathsMatch(f.path, k)))
+        .toList();
+  }
+
+  duplicatedFiles.sort((a, b) => b.duplicatedLoc.compareTo(a.duplicatedLoc));
+
+  if (duplicatedFiles.isEmpty) return;
+
+  final tableTitle = hasDiffFilter
+      ? '#### Modified Files Duplication Metrics'
+      : '#### Duplicated Source Files';
+  buffer.writeln(tableTitle);
+  buffer.writeln();
+  buffer.writeln('| File | Duplicated LOC | Total LOC | Duplication % |');
+  buffer.writeln('| :--- | :---: | :---: | :---: |');
+
+  for (final file in duplicatedFiles) {
+    final relPath = file.path;
+    final absFilePath = _resolveAbsolutePath(absTargetDir, relPath);
+    final linkText = relPath;
+    final targetUrl = Uri.file(absFilePath).toString();
+    final filePercent = file.duplicationPercent.toStringAsFixed(1);
+
+    buffer.writeln(
+      '| [$linkText]($targetUrl) | ${file.duplicatedLoc} | ${file.analysedLoc} | $filePercent% |',
+    );
+  }
+  buffer.writeln();
+}
+
 /// Formats a [DeslopReport] into a high-density, token-efficient Markdown document.
 String formatDeslopMarkdown({
   required DeslopReport report,
@@ -26,156 +275,54 @@ String formatDeslopMarkdown({
   String bucketFilter = 'all',
   bool includeFileTable = true,
   bool includeClusters = true,
+  Map<String, List<LineSpan>>? changedRanges,
+  bool onlyChangedCode = false,
 }) {
   final buffer = StringBuffer();
   final absTargetDir = Directory(targetDir).absolute.path;
+  final hasDiffFilter = onlyChangedCode && changedRanges != null;
 
-  // 1. Overview Summary Header
-  final totalLoc = report.metrics.analysedLoc;
-  final dupLoc = report.metrics.duplicatedLoc;
-  final dupPercent = report.metrics.duplicationPercent.toStringAsFixed(1);
-  final totalFiles = report.filesAnalysed;
-  final dupFiles = report.metrics.duplicatedFiles;
-  final totalClusters = report.metrics.clustersTotal;
+  var candidateClusters = List<DeslopCluster>.of(report.clusters);
+  if (hasDiffFilter) {
+    candidateClusters = candidateClusters
+        .where((c) => c.intersectsDiff(changedRanges))
+        .toList();
+  }
 
-  buffer.writeln('### 🔬 Deslop Code Duplication Report');
-  buffer.writeln();
-  buffer.writeln(
-    '* **Duplication Score**: **$dupPercent%** ($dupLoc / $totalLoc LOC across $dupFiles / $totalFiles files)',
+  final isClean = _writeOverviewHeader(
+    buffer,
+    report: report,
+    candidateClusters: candidateClusters,
+    hasDiffFilter: hasDiffFilter,
+    changedRanges: changedRanges,
+    htmlReportPath: htmlReportPath,
   );
 
-  // Group cluster counts by bucket
-  final bucketCounts = <String, int>{};
-  for (final cluster in report.clusters) {
-    bucketCounts[cluster.bucket] = (bucketCounts[cluster.bucket] ?? 0) + 1;
+  if (isClean) {
+    return buffer.toString().trimRight();
   }
 
-  final bucketBreakdown = <String>[];
-  if (bucketCounts.containsKey('identical')) {
-    bucketBreakdown.add('${bucketCounts['identical']} identical [Type-1/2]');
-  }
-  if (bucketCounts.containsKey('nearly_identical')) {
-    bucketBreakdown.add(
-      '${bucketCounts['nearly_identical']} near-identical [Type-3]',
-    );
-  }
-  if (bucketCounts.containsKey('structural_only')) {
-    bucketBreakdown.add(
-      '${bucketCounts['structural_only']} structural-only shape matches',
-    );
-  }
-  if (bucketCounts.containsKey('loosely_similar')) {
-    bucketBreakdown.add('${bucketCounts['loosely_similar']} loosely similar');
-  }
-  if (bucketCounts.containsKey('same_behavior')) {
-    bucketBreakdown.add('${bucketCounts['same_behavior']} AI semantic matches');
-  }
-
-  final breakdownText = bucketBreakdown.isNotEmpty
-      ? ' (${bucketBreakdown.join(', ')})'
-      : '';
-  buffer.writeln('* **Total Clusters**: $totalClusters$breakdownText');
-
-  if (htmlReportPath != null && File(htmlReportPath).existsSync()) {
-    final htmlUri = Uri.file(File(htmlReportPath).absolute.path).toString();
-    buffer.writeln('* **Interactive HTML Report**: [report.html]($htmlUri)');
-  }
-
-  buffer.writeln();
-
-  // 2. Top Duplication Clusters
   if (includeClusters) {
-    var filteredClusters = List<DeslopCluster>.of(report.clusters);
-
-    if (categoryFilter != 'all') {
-      filteredClusters = filteredClusters
-          .where((c) => c.category == categoryFilter)
-          .toList();
-    }
-
-    if (bucketFilter != 'all') {
-      filteredClusters = filteredClusters
-          .where((c) => c.bucket == bucketFilter)
-          .toList();
-    }
-
-    // Sort by weight descending
-    filteredClusters.sort((a, b) => b.weight.compareTo(a.weight));
-
-    final displayClusters = filteredClusters.take(topCount).toList();
-
-    if (displayClusters.isEmpty) {
-      buffer.writeln('_No duplicate clusters match the specified filters._');
-      buffer.writeln();
-    } else {
-      buffer.writeln(
-        '#### Top Duplication Clusters (Ranked by Weight & Potential Savings)',
-      );
-      buffer.writeln();
-
-      for (var i = 0; i < displayClusters.length; i++) {
-        final c = displayClusters[i];
-        final rank = i + 1;
-        final weightStr = c.weight.toStringAsFixed(1);
-        final categoryTag = c.category == 'data' ? ' [Data Table]' : '';
-
-        buffer.writeln(
-          '**#$rank ${c.bucketLabel}$categoryTag** — ${c.size} copies · ${c.canonicalNodeCount} AST nodes · weight $weightStr',
-        );
-
-        if (c.interpretation.isNotEmpty) {
-          buffer.writeln('> ${c.interpretation}');
-        }
-
-        for (final occ in c.occurrences) {
-          final relPath = occ.path;
-          final absFilePath = _resolveAbsolutePath(absTargetDir, relPath);
-          final lineSuffix = occ.lineSpan;
-          final linkText = '$relPath:$lineSuffix';
-          final targetUrl = '${Uri.file(absFilePath)}#$lineSuffix';
-          buffer.writeln('* [$linkText]($targetUrl)');
-        }
-        buffer.writeln();
-      }
-
-      if (filteredClusters.length > topCount) {
-        final remaining = filteredClusters.length - topCount;
-        buffer.writeln(
-          '_... $remaining more clusters hidden (use `--top=${filteredClusters.length}` to display all)_',
-        );
-        buffer.writeln();
-      }
-    }
+    _renderClustersSection(
+      buffer,
+      candidateClusters: candidateClusters,
+      absTargetDir: absTargetDir,
+      topCount: topCount,
+      categoryFilter: categoryFilter,
+      bucketFilter: bucketFilter,
+      hasDiffFilter: hasDiffFilter,
+      changedRanges: changedRanges,
+    );
   }
 
-  // 3. Per-File Duplication Breakdown Table
   if (includeFileTable) {
-    final duplicatedFiles = report.metrics.perFile
-        .where((f) => f.duplicatedLoc > 0)
-        .toList();
-
-    // Sort by duplicated LOC descending
-    duplicatedFiles.sort((a, b) => b.duplicatedLoc.compareTo(a.duplicatedLoc));
-
-    if (duplicatedFiles.isNotEmpty) {
-      buffer.writeln('#### Duplicated Source Files');
-      buffer.writeln();
-      buffer.writeln('| File | Duplicated LOC | Total LOC | Duplication % |');
-      buffer.writeln('| :--- | :---: | :---: | :---: |');
-
-      for (final file in duplicatedFiles) {
-        final relPath = file.path;
-        final absFilePath = _resolveAbsolutePath(absTargetDir, relPath);
-        final linkText = relPath;
-        final targetUrl = Uri.file(absFilePath).toString();
-        final filePercent = file.duplicationPercent.toStringAsFixed(1);
-
-        buffer.writeln(
-          '| [$linkText]($targetUrl) | ${file.duplicatedLoc} | ${file.analysedLoc} | $filePercent% |',
-        );
-      }
-      buffer.writeln();
-    }
+    _renderFileMetricsTable(
+      buffer,
+      report: report,
+      absTargetDir: absTargetDir,
+      hasDiffFilter: hasDiffFilter,
+      changedRanges: changedRanges,
+    );
   }
 
   return buffer.toString().trimRight();

--- a/skills/deslop-duplication-audit/lib/src/models.dart
+++ b/skills/deslop-duplication-audit/lib/src/models.dart
@@ -1,6 +1,8 @@
 /// Data models representing Deslop duplicate code analysis reports.
 library;
 
+import 'diff_parser.dart';
+
 /// Represents the top-level Deslop JSON report structure.
 class DeslopReport {
   final String toolVersion;
@@ -228,6 +230,25 @@ class DeslopCluster {
       _ => bucket,
     };
   }
+
+  /// Checks if any occurrence in this cluster intersects with the given diff line ranges.
+  bool intersectsDiff(Map<String, List<LineSpan>> changedRanges) {
+    if (changedRanges.isEmpty) return false;
+    return occurrences.any((occ) => occ.intersectsDiff(changedRanges));
+  }
+
+  /// Counts how many occurrences in this cluster intersect with the given diff line ranges.
+  int occurrencesIntersectingDiff(Map<String, List<LineSpan>> changedRanges) {
+    if (changedRanges.isEmpty) return 0;
+    return occurrences.where((occ) => occ.intersectsDiff(changedRanges)).length;
+  }
+
+  /// Returns true if all occurrences in this cluster are within modified diff hunks.
+  bool isNewlyIntroduced(Map<String, List<LineSpan>> changedRanges) {
+    if (changedRanges.isEmpty) return false;
+    final intersecting = occurrencesIntersectingDiff(changedRanges);
+    return intersecting >= 2 && intersecting == occurrences.length;
+  }
 }
 
 /// A specific file and line-range occurrence within a duplication cluster.
@@ -271,4 +292,17 @@ class ClusterOccurrence {
   /// Returns the line span as a string, e.g. `L10-25` or `L10`.
   String get lineSpan =>
       startLine == endLine ? 'L$startLine' : 'L$startLine-$endLine';
+
+  /// Checks if this occurrence intersects with any changed line spans in [changedRanges].
+  bool intersectsDiff(Map<String, List<LineSpan>> changedRanges) {
+    if (changedRanges.isEmpty) return false;
+    for (final entry in changedRanges.entries) {
+      if (pathsMatch(path, entry.key)) {
+        if (entry.value.any((span) => span.overlaps(startLine, endLine))) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
 }

--- a/skills/deslop-duplication-audit/lib/src/runner.dart
+++ b/skills/deslop-duplication-audit/lib/src/runner.dart
@@ -4,6 +4,7 @@ library;
 import 'dart:convert';
 import 'dart:io';
 
+import 'diff_parser.dart';
 import 'models.dart';
 
 /// Result from executing a Deslop CLI scan.
@@ -165,4 +166,57 @@ Future<DeslopReport> loadReportJson(String filePath) async {
     throw const FormatException('Expected JSON object root in Deslop report');
   }
   return DeslopReport.fromJson(parsed);
+}
+
+/// Resolves changed line ranges from a diff command, diff file, literal diff string, or list of touched files.
+Future<Map<String, List<LineSpan>>> resolveDiffRanges({
+  String? diffCmd,
+  String? diffFilePath,
+  String? diffString,
+  String? touchedFilesString,
+  String? workingDir,
+}) async {
+  if (diffCmd != null && diffCmd.trim().isNotEmpty) {
+    final parts = diffCmd.trim().split(RegExp(r'\s+'));
+    final exe = parts.first;
+    final cmdArgs = parts.sublist(1);
+    final res = await Process.run(
+      exe,
+      cmdArgs,
+      workingDirectory: workingDir,
+      runInShell: true,
+    );
+    if (res.exitCode != 0) {
+      throw ProcessException(
+        exe,
+        cmdArgs,
+        'diff command failed with exit code ${res.exitCode}:\n${res.stderr}',
+        res.exitCode,
+      );
+    }
+    return parseUnifiedDiff(res.stdout as String);
+  }
+
+  if (diffFilePath != null && diffFilePath.trim().isNotEmpty) {
+    final file = File(diffFilePath);
+    if (!file.existsSync()) {
+      throw FileSystemException('Diff file does not exist', diffFilePath);
+    }
+    return parseUnifiedDiff(await file.readAsString());
+  }
+
+  if (diffString != null && diffString.trim().isNotEmpty) {
+    return parseUnifiedDiff(diffString);
+  }
+
+  if (touchedFilesString != null && touchedFilesString.trim().isNotEmpty) {
+    final files = touchedFilesString
+        .split(',')
+        .map((e) => e.trim())
+        .where((e) => e.isNotEmpty)
+        .toList();
+    return createTouchedFilesMap(files);
+  }
+
+  return {};
 }

--- a/tool/test/deslop_report_test.dart
+++ b/tool/test/deslop_report_test.dart
@@ -108,7 +108,89 @@ const _sampleDeslopJson = '''
 }
 ''';
 
+const _sampleGitDiff = '''
+diff --git a/lib/foo.dart b/lib/foo.dart
+index 1234567..89abcdef 100644
+--- a/lib/foo.dart
++++ b/lib/foo.dart
+@@ -8,5 +8,15 @@ void existing() {}
++void newHelper() {
++  print('hello');
++}
+''';
+
+const _sampleJjDiff = '''
+Modified regular file lib/bar.dart:
+--- a/lib/bar.dart
++++ b/lib/bar.dart
+@@ -12,4 +12,8 @@
++void another() {
++  print('world');
++}
+''';
+
 void main() {
+  group('Diff Parser', () {
+    test('parses git unified diff and extracts line spans', () {
+      final spans = parseUnifiedDiff(_sampleGitDiff);
+      check(spans.containsKey('lib/foo.dart')).isTrue();
+      final fooSpans = spans['lib/foo.dart']!;
+      check(fooSpans.length).equals(1);
+      check(fooSpans.first).equals(const LineSpan(8, 22));
+    });
+
+    test('parses jujutsu diff format and extracts line spans', () {
+      final spans = parseUnifiedDiff(_sampleJjDiff);
+      check(spans.containsKey('lib/bar.dart')).isTrue();
+      final barSpans = spans['lib/bar.dart']!;
+      check(barSpans.length).equals(1);
+      check(barSpans.first).equals(const LineSpan(12, 19));
+    });
+
+    test('LineSpan overlap and containment tests', () {
+      const span = LineSpan(10, 20);
+      check(span.contains(10)).isTrue();
+      check(span.contains(15)).isTrue();
+      check(span.contains(20)).isTrue();
+      check(span.contains(9)).isFalse();
+      check(span.contains(21)).isFalse();
+
+      check(span.overlaps(5, 9)).isFalse();
+      check(span.overlaps(5, 10)).isTrue();
+      check(span.overlaps(15, 25)).isTrue();
+      check(span.overlaps(20, 30)).isTrue();
+      check(span.overlaps(21, 30)).isFalse();
+    });
+
+    test(
+      'pathsMatch handles prefixes, relative paths, and rejects partial directory matches',
+      () {
+        check(pathsMatch('lib/foo.dart', 'lib/foo.dart')).isTrue();
+        check(pathsMatch('lib/foo.dart', 'a/lib/foo.dart')).isTrue();
+        check(pathsMatch('lib/foo.dart', 'b/lib/foo.dart')).isTrue();
+        check(pathsMatch('foo.dart', 'lib/foo.dart')).isTrue();
+        check(pathsMatch('lib/foo.dart', 'lib/bar.dart')).isFalse();
+        // Partial directory substring rejection
+        check(
+          pathsMatch('feature_login/view.dart', 'login/view.dart'),
+        ).isFalse();
+        check(
+          pathsMatch('login/view.dart', 'feature_login/view.dart'),
+        ).isFalse();
+      },
+    );
+
+    test(
+      'normalizeFilePath handles git prefixes, leading slashes, and backslashes',
+      () {
+        check(normalizeFilePath('a/lib/foo.dart')).equals('lib/foo.dart');
+        check(normalizeFilePath('b/lib/foo.dart')).equals('lib/foo.dart');
+        check(normalizeFilePath('/lib/foo.dart')).equals('lib/foo.dart');
+        check(normalizeFilePath(r'lib\foo.dart')).equals('lib/foo.dart');
+      },
+    );
+  });
+
   group('DeslopReport model parsing', () {
     test('parses sample report JSON correctly', () {
       final dynamic decoded = jsonDecode(_sampleDeslopJson);
@@ -131,6 +213,36 @@ void main() {
       check(c1.occurrences).has((o) => o.length, 'length').equals(2);
       check(c1.occurrences.first.lineSpan).equals('L10-20');
     });
+
+    test('evaluates cluster diff intersection correctly', () {
+      final dynamic decoded = jsonDecode(_sampleDeslopJson);
+      final report = DeslopReport.fromJson(decoded as Map<String, dynamic>);
+      final c1 =
+          report.clusters.first; // lib/foo.dart:10-20, lib/bar.dart:15-25
+      final c2 = report.clusters.last; // lib/foo.dart:30-35, lib/bar.dart:40-45
+
+      final diffRanges = {
+        'lib/foo.dart': [const LineSpan(12, 15)],
+      };
+
+      check(c1.intersectsDiff(diffRanges)).isTrue();
+      check(c2.intersectsDiff(diffRanges)).isFalse();
+    });
+
+    test(
+      'evaluates cluster and occurrence diff intersection as false on empty diff',
+      () {
+        final dynamic decoded = jsonDecode(_sampleDeslopJson);
+        final report = DeslopReport.fromJson(decoded as Map<String, dynamic>);
+        final c1 = report.clusters.first;
+        final occ = c1.occurrences.first;
+
+        check(c1.intersectsDiff({})).isFalse();
+        check(c1.occurrencesIntersectingDiff({})).equals(0);
+        check(c1.isNewlyIntroduced({})).isFalse();
+        check(occ.intersectsDiff({})).isFalse();
+      },
+    );
   });
 
   group('formatDeslopMarkdown', () {
@@ -171,6 +283,60 @@ void main() {
       check(md).contains('Nearly Identical [Type-3]');
       check(md).not((s) => s.contains('[Data Table]'));
     });
+
+    test('supports diff-aware delta filtering', () {
+      final dynamic decoded = jsonDecode(_sampleDeslopJson);
+      final report = DeslopReport.fromJson(decoded as Map<String, dynamic>);
+
+      final diffRanges = {
+        'lib/foo.dart': [const LineSpan(12, 15)],
+      };
+
+      final md = formatDeslopMarkdown(
+        report: report,
+        targetDir: '/fake/repo',
+        changedRanges: diffRanges,
+        onlyChangedCode: true,
+      );
+
+      check(md).contains('### 🔬 Deslop Code Duplication Report (CL Delta)');
+      check(md).contains('1 cluster(s)** intersect modified code');
+      check(md).contains('`[CL Modified]`');
+      check(md).contains('`[Existing Code]`');
+    });
+
+    test('returns clean status when zero clusters intersect diff', () {
+      final dynamic decoded = jsonDecode(_sampleDeslopJson);
+      final report = DeslopReport.fromJson(decoded as Map<String, dynamic>);
+
+      final diffRanges = {
+        'lib/other.dart': [const LineSpan(1, 50)],
+      };
+
+      final md = formatDeslopMarkdown(
+        report: report,
+        targetDir: '/fake/repo',
+        changedRanges: diffRanges,
+        onlyChangedCode: true,
+      );
+
+      check(md).contains('✅ **Clean** — 0 duplicate code clusters detected');
+    });
+
+    test('handles empty diff (0 modified lines) gracefully in delta mode', () {
+      final dynamic decoded = jsonDecode(_sampleDeslopJson);
+      final report = DeslopReport.fromJson(decoded as Map<String, dynamic>);
+
+      final md = formatDeslopMarkdown(
+        report: report,
+        targetDir: '/fake/repo',
+        changedRanges: {},
+        onlyChangedCode: true,
+      );
+
+      check(md).contains('### 🔬 Deslop Code Duplication Report (CL Delta)');
+      check(md).contains('✅ **Clean** — 0 duplicate code clusters detected');
+    });
   });
 
   group('runner and CLI', () {
@@ -181,10 +347,18 @@ void main() {
       }
     });
 
+    String resolveRepoRoot() {
+      final current = Directory.current.path;
+      return current.endsWith('tool') ? Directory.current.parent.path : current;
+    }
+
     test('CLI prints help on -h', () async {
+      final repoRoot = resolveRepoRoot();
+      final scriptPath =
+          '$repoRoot/skills/deslop-duplication-audit/bin/deslop_report.dart';
       final process = await Process.run(Platform.resolvedExecutable, [
         'run',
-        '../skills/deslop-duplication-audit/bin/deslop_report.dart',
+        scriptPath,
         '-h',
       ]);
       check(process.exitCode).equals(0);
@@ -198,9 +372,13 @@ void main() {
       final tempJson = File('${tempDir.path}/test_report.json');
       await tempJson.writeAsString(_sampleDeslopJson);
 
+      final repoRoot = resolveRepoRoot();
+      final scriptPath =
+          '$repoRoot/skills/deslop-duplication-audit/bin/deslop_report.dart';
+
       final process = await Process.run(Platform.resolvedExecutable, [
         'run',
-        '../skills/deslop-duplication-audit/bin/deslop_report.dart',
+        scriptPath,
         '--report=${tempJson.path}',
         '--dir=/sample/target',
       ]);
@@ -209,6 +387,35 @@ void main() {
       final stdoutStr = process.stdout as String;
       check(stdoutStr).contains('### 🔬 Deslop Code Duplication Report');
       check(stdoutStr).contains('lib/foo.dart:L10-20');
+
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('CLI supports --diff string and --only-changed', () async {
+      final tempDir = Directory.systemTemp.createTempSync('deslop_test_');
+      final tempJson = File('${tempDir.path}/test_report.json');
+      await tempJson.writeAsString(_sampleDeslopJson);
+
+      final repoRoot = resolveRepoRoot();
+      final scriptPath =
+          '$repoRoot/skills/deslop-duplication-audit/bin/deslop_report.dart';
+
+      final process = await Process.run(Platform.resolvedExecutable, [
+        'run',
+        scriptPath,
+        '--report=${tempJson.path}',
+        '--dir=/sample/target',
+        '--diff',
+        _sampleGitDiff,
+        '--only-changed',
+      ]);
+
+      check(process.exitCode).equals(0);
+      final stdoutStr = process.stdout as String;
+      check(
+        stdoutStr,
+      ).contains('### 🔬 Deslop Code Duplication Report (CL Delta)');
+      check(stdoutStr).contains('`[CL Modified]`');
 
       tempDir.deleteSync(recursive: true);
     });


### PR DESCRIPTION
- Add diff_parser.dart for unified diff parsing (git/jj) and line-span calculation
- Add diff intersection methods to DeslopCluster and ClusterOccurrence
- Add delta mode to formatDeslopMarkdown to report only clusters affecting changed code
- Add --diff-cmd, --diff-file, --diff, --touched-files, and --only-changed CLI flags to deslop_report.dart
- Decompose formatter, diff parser, and CLI entry points to strictly satisfy Dart Cognitive Complexity ceiling (<= 15)
- Update SKILL.md to document PR and Google3 CL delta scanning
- Add comprehensive unit and integration tests covering diff parsing and delta reporting
- Note: It would be nice to have this natively in upstream deslop; tracking https://github.com/Nimblesite/Deslop/issues/364
