### PR TITLE
fix(dart-cleanup): update cognitive complexity skill path to analytica.dart

### DIFF
--- a/skills/dart-cleanup/SKILL.md
+++ b/skills/dart-cleanup/SKILL.md
@@ -48,7 +48,7 @@ If a target `SKILL.md` is selected but missing from the local filesystem, output
 
 ### A. Refactoring & Code Quality
 * **`dart-cognitive-complexity`**: Reduces cognitive complexity, nested loops, and deep conditionals via pattern matching & guard clauses. Includes a gated Tier 3 method-object reference for extreme cases.
-  * *Path*: [SKILL.md](file://~/github/kevmoo/cognitive_complexity.dart/skills/dart-cognitive-complexity/SKILL.md)
+  * *Path*: [SKILL.md](file://~/github/kevmoo/analytica.dart/skills/dart-cognitive-complexity/SKILL.md)
 * **`deslop-duplication-audit`**: Detects, audits, and remediates structural code duplication across Dart and Flutter repositories using the standalone Deslop CLI tool and empirical test gating.
   * *Path*: [SKILL.md](file://~/github/kevmoo/kevmoo_skills/skills/deslop-duplication-audit/SKILL.md)
 * **`dart-build-cli-app`**: CLI entrypoint structure, argument parsing, cross-platform scripts, exit codes.


### PR DESCRIPTION
Update the local path for `dart-cognitive-complexity` in the skill catalog to reflect the upstream repository rename from `cognitive_complexity.dart` to `analytica.dart`.

- Point `dart-cognitive-complexity` catalog path to `~/github/kevmoo/analytica.dart/skills/dart-cognitive-complexity/SKILL.md`
