### PR TITLE
feat(dart-cleanup): register dart-undead skill

### DIFF
--- a/skills/dart-cleanup/SKILL.md
+++ b/skills/dart-cleanup/SKILL.md
@@ -49,6 +49,8 @@ If a target `SKILL.md` is selected but missing from the local filesystem, output
 ### A. Refactoring & Code Quality
 * **`dart-cognitive-complexity`**: Reduces cognitive complexity, nested loops, and deep conditionals via pattern matching & guard clauses. Includes a gated Tier 3 method-object reference for extreme cases.
   * *Path*: [SKILL.md](file://~/github/kevmoo/analytica.dart/skills/dart-cognitive-complexity/SKILL.md)
+* **`dart-undead`**: Audits, triages, and safely remediates unreachable and dead declarations in Dart and Flutter codebases using deterministic reachability analysis (`pkg:undead`).
+  * *Path*: [SKILL.md](file://~/github/kevmoo/analytica.dart/skills/dart-undead/SKILL.md)
 * **`deslop-duplication-audit`**: Detects, audits, and remediates structural code duplication across Dart and Flutter repositories using the standalone Deslop CLI tool and empirical test gating.
   * *Path*: [SKILL.md](file://~/github/kevmoo/kevmoo_skills/skills/deslop-duplication-audit/SKILL.md)
 * **`dart-build-cli-app`**: CLI entrypoint structure, argument parsing, cross-platform scripts, exit codes.


### PR DESCRIPTION
Add `dart-undead` reachability and dead code analysis skill to the
`dart-cleanup` router catalog under Refactoring & Code Quality.

- Point `dart-undead` catalog path to `~/github/kevmoo/analytica.dart/skills/dart-undead/SKILL.md`
