### PR TITLE
fix(skills): migrate triage.dart and pr_status.dart invocations to dart run

### DIFF
--- a/skills/github-pr-triage/SKILL.md
+++ b/skills/github-pr-triage/SKILL.md
@@ -63,11 +63,11 @@ key_features:
    underlying `git` and `gh` commands resolve to the correct repository and
    branch:
    ```bash
-   dart <path-to-github-pr-triage-skill>/bin/triage.dart --dir <path-to-target-repository>
+   dart run <path-to-github-pr-triage-skill>/bin/triage.dart --dir <path-to-target-repository>
    ```
    *Note*: If you need to target a specific PR or URL, you can also pass `--pr`:
    ```bash
-   dart <path-to-github-pr-triage-skill>/bin/triage.dart --dir <path-to-target-repository> --pr <pr-number-or-url>
+   dart run <path-to-github-pr-triage-skill>/bin/triage.dart --dir <path-to-target-repository> --pr <pr-number-or-url>
    ```
    **Save the raw stdout of this script** as a new markdown artifact named
    `raw_triage_output.md` in the artifacts directory (using the `write_to_file`
@@ -203,10 +203,10 @@ Use the `resolve` subcommand in `triage.dart` to programmatically reply to comme
 
 ```bash
 # Reply to a comment and resolve its thread:
-dart <path-to-github-pr-triage-skill>/bin/triage.dart resolve <thread_graphql_id> <comment_database_id> "<your reply body>"
+dart run <path-to-github-pr-triage-skill>/bin/triage.dart resolve <thread_graphql_id> <comment_database_id> "<your reply body>"
 
 # Or resolve a thread without posting a reply:
-dart <path-to-github-pr-triage-skill>/bin/triage.dart resolve <thread_graphql_id>
+dart run <path-to-github-pr-triage-skill>/bin/triage.dart resolve <thread_graphql_id>
 ```
 
 

--- a/skills/github-pr-triage/bin/triage.dart
+++ b/skills/github-pr-triage/bin/triage.dart
@@ -30,8 +30,8 @@ void main(List<String> args) async {
     stdout.writeln('GitHub PR Triage Tool\n');
     stdout.writeln(
       'Usage:\n'
-      '  dart triage.dart [options]\n'
-      '  dart triage.dart resolve <thread_id> [<comment_id> "<body_text>"]\n',
+      '  dart run triage.dart [options]\n'
+      '  dart run triage.dart resolve <thread_id> [<comment_id> "<body_text>"]\n',
     );
     stdout.writeln('Options:');
     stdout.writeln(parser.usage);
@@ -47,8 +47,8 @@ void main(List<String> args) async {
         stderr.writeln(
           'Error: Invalid arguments for resolve subcommand.\n'
           'Usage:\n'
-          '  dart triage.dart resolve <thread_id>\n'
-          '  dart triage.dart resolve <thread_id> <comment_id> "<body_text>"',
+          '  dart run triage.dart resolve <thread_id>\n'
+          '  dart run triage.dart resolve <thread_id> <comment_id> "<body_text>"',
         );
         exit(1);
       }

--- a/skills/pr-loop/SKILL.md
+++ b/skills/pr-loop/SKILL.md
@@ -93,7 +93,7 @@ which are bypassed in favor of autonomous execution):
 
 ### 2. [START] Immediate Status Check & Polling Timer
 * **Immediate Initial Check**: Before scheduling a background timer, execute an
-  immediate check of PR status (`dart <path-to-pr-loop-skill>/bin/pr_status.dart --dir .` or `gh pr view`).
+  immediate check of PR status (`dart run <path-to-pr-loop-skill>/bin/pr_status.dart --dir .` or `gh pr view`).
   * If actionable review comments or failed CI checks already exist, **bypass the initial timer** and proceed directly to Step 3/4.
   * If review feedback or CI checks are still in progress, proceed to schedule the background wakeup timer.
 * **Transition to Wait State**:
@@ -133,7 +133,7 @@ which are bypassed in favor of autonomous execution):
   Run the `pr_status.dart` helper script to evaluate whether the PR is ready for
   termination or requires further triage:
   ```bash
-  dart <path-to-pr-loop-skill>/bin/pr_status.dart --dir .
+  dart run <path-to-pr-loop-skill>/bin/pr_status.dart --dir .
   ```
 * **Strict Termination Rules ([STOP])**:
   A PR is ONLY clean and ready for loop termination when `pr_status.dart`
@@ -182,7 +182,7 @@ which are bypassed in favor of autonomous execution):
   failed CI runs exist (`"can_terminate": false`), run `triage.dart` as defined
   in `github-pr-triage`:
   ```bash
-  dart <path-to-github-pr-triage-skill>/bin/triage.dart --dir .
+  dart run <path-to-github-pr-triage-skill>/bin/triage.dart --dir .
   ```
 
 ### 4. Critical Assessment, Empirical Verification & Loop Convergence
@@ -233,7 +233,7 @@ which are bypassed in favor of autonomous execution):
   For every addressed review thread, you MUST execute thread resolution (thread resolution is explicit, mandatory, and un-skippable).
   Use the `resolve` subcommand in `triage.dart`:
   ```bash
-  dart <path-to-github-pr-triage-skill>/bin/triage.dart resolve <thread_id> <comment_id> "<your concise explanation>"
+  dart run <path-to-github-pr-triage-skill>/bin/triage.dart resolve <thread_id> <comment_id> "<your concise explanation>"
   ```
 
 * **Pre-Timer Verification Gate (MANDATORY)**:

--- a/skills/pr-loop/bin/pr_status.dart
+++ b/skills/pr-loop/bin/pr_status.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
-import '../../github-pr-triage/lib/github_cli.dart';
+import 'package:github_pr_triage/github_cli.dart';
 
 /// Main entry point for the PR status verification tool (`pr_status.dart`).
 ///

--- a/skills/pr-loop/pubspec.yaml
+++ b/skills/pr-loop/pubspec.yaml
@@ -1,0 +1,12 @@
+name: pr_loop
+description: Autonomous pull request review loop tools for GitHub PRs.
+version: 1.0.0
+publish_to: none
+
+environment:
+  sdk: ^3.12.0
+
+dependencies:
+  args: ^2.4.0
+  github_pr_triage:
+    path: ../github-pr-triage


### PR DESCRIPTION
- Update github-pr-triage and pr-loop SKILL.md docs to use dart run
- Update triage.dart CLI usage messages to reflect dart run
- Add pubspec.yaml for pr-loop package with dependency on github_pr_triage
- Update pr_status.dart import to package:github_pr_triage/github_cli.dart
