### PR TITLE
feat(github-pr-triage): support top-level review comments & fix dirty menu

### DIFF
--- a/skills/github-pr-triage/SKILL.md
+++ b/skills/github-pr-triage/SKILL.md
@@ -83,11 +83,12 @@ key_features:
      - Do not start making code edits while the local workspace is out of sync with the remote PR.
 
 3. **Analyze Open Comments**:
-   - The script lists all unresolved comment threads.
+   - The script lists all unresolved review threads, top-level review comments
+     (overall review summaries), and general PR conversation comments.
    - Read the conversations carefully to understand what reviewers are
      requesting.
-   - Focus *only* on unresolved comments. Ignore comments marked as resolved
-     unless they provide necessary context.
+   - Focus *only* on unresolved or actionable comments. Ignore comments marked
+     as resolved unless they provide necessary context.
    - Ignore comments from the PR author themselves unless they clarify a
      reviewer's comment.
 
@@ -126,13 +127,13 @@ key_features:
      - **Summary of Feedback/Failure**: A concise summary of the reviewer
        comment(s) or CI failure(s), including direct markdown links back to the
        comments/checks on GitHub. When linking to comments, use a descriptive
-       link that includes both the comment number and the GitHub username of the
-       reviewer (e.g. `[Comment #1 by @reviewer_username](#)`).
-     - **Thread & Comment Identifiers (For Comments)**: Explicitly preserve the
-       `Thread ID` (e.g. `PRRT_...`) and `Comment ID` (e.g. `3438780787`) from
-       the comment header in `raw_triage_output.md` under each action item so
-       the resolution step (`gh api`) has immediate access to both parameters
-       without extra API lookups.
+       link that includes both the comment/review number and the GitHub username of the
+       reviewer (e.g. `[Comment #1 by @reviewer_username](#)` or `[Review #1 by @reviewer_username](#)`).
+     - **Thread & Comment/Review Identifiers (For Comments)**: Explicitly preserve the
+       `Thread ID` (e.g. `PRRT_...`), `Comment ID` (e.g. `3438780787`), or `Review ID`
+       (e.g. `PRR_...`) from the header in `raw_triage_output.md` under each action
+       item so the resolution step (`gh api` or `gh pr comment`) has immediate access
+       to the identifiers without extra API lookups.
      - **Agent Assessment (For Comments)**:
        - **Agreement Level**: A short indicator of your agreement using one of
          these categories:
@@ -182,7 +183,7 @@ key_features:
      - **If uncommitted changes or unpushed commits exist**, offer:
        1. `(Recommended) Commit fixes, push branch, reply to comments, and resolve threads`
        2. `Commit fixes and push branch only`
-       3. `Reply to comments and resolve threads without committing/pushing`
+       3. `Commit fixes locally only`
        4. `Do nothing`
      - **If working tree is clean and all commits are pushed**, offer:
        1. `(Recommended) Reply to comments and resolve threads`
@@ -229,8 +230,7 @@ dart run <path-to-github-pr-triage-skill>/bin/triage.dart resolve <thread_graphq
   like `pr-loop` with upfront user consent).
 - **Sync Code Before Comments**: Do not post "Done" or "Fixed" comment replies
   or resolve threads on GitHub while the corresponding code fixes remain
-  uncommitted or unpushed, unless the user explicitly selects an option
-  directing you to do so.
+  uncommitted or unpushed.
 - Do NOT address resolved comments unless requested.
 - **NO `commit --amend`**: Modifying commit history via `git commit --amend` is
   strictly prohibited. Always create new, atomic commits.

--- a/skills/github-pr-triage/bin/triage.dart
+++ b/skills/github-pr-triage/bin/triage.dart
@@ -144,11 +144,17 @@ void main(List<String> args) async {
       stdout.writeln('\nWARNING: ${syncStatus.warning}\n');
     }
 
-    // 5. Fetch unresolved review comments using unified GraphQL helper.
-    stdout.writeln('Fetching unresolved review comments...');
+    // 5. Fetch review comments and threads using unified GraphQL helper.
+    stdout.writeln('Fetching review comments and threads...');
     final graphData = await fetchPrGraphQLData(context);
     final unresolvedThreads = graphData.reviewThreads
         .where((t) => !t.isResolved)
+        .toList();
+    final reviewComments = graphData.reviews
+        .where((r) => r.body.trim().isNotEmpty)
+        .toList();
+    final generalComments = graphData.comments
+        .where((c) => c.body.trim().isNotEmpty)
         .toList();
 
     // 6. Fetch CI check runs using unified checks helper.
@@ -221,6 +227,56 @@ $syncWarningBlock## Unresolved Review Comments (${unresolvedThreads.length})
 Link: $url
 
 $commentsMarkdown
+
+---
+
+''');
+      }
+    }
+
+    if (reviewComments.isNotEmpty) {
+      report.write(
+        '## Top-Level Review Comments (${reviewComments.length})\n\n',
+      );
+      for (var i = 0; i < reviewComments.length; i++) {
+        final review = reviewComments[i];
+        final reviewId = review.id;
+        final reviewDbId = review.databaseId;
+        final state = review.state;
+        final author = review.author;
+        final submittedAt = review.submittedAt;
+        final url = review.url;
+        final body = review.body;
+
+        report.write('''
+### Review #${i + 1} (Review `$reviewId`, Database ID `$reviewDbId`): `$state` by @$author
+Link: $url
+
+**@$author** ($submittedAt):
+> ${body.replaceAll('\n', '\n> ')}
+
+---
+
+''');
+      }
+    }
+
+    if (generalComments.isNotEmpty) {
+      report.write('## Conversation Comments (${generalComments.length})\n\n');
+      for (var i = 0; i < generalComments.length; i++) {
+        final comment = generalComments[i];
+        final commentDbId = comment.databaseId;
+        final author = comment.author;
+        final createdAt = comment.createdAt;
+        final url = comment.url;
+        final body = comment.body;
+
+        report.write('''
+### Conversation Comment #${i + 1} (Comment `$commentDbId`) by @$author
+Link: $url
+
+**@$author** ($createdAt):
+> ${body.replaceAll('\n', '\n> ')}
 
 ---
 

--- a/skills/github-pr-triage/lib/github_cli.dart
+++ b/skills/github-pr-triage/lib/github_cli.dart
@@ -289,7 +289,15 @@ typedef PrReviewThread = ({
 });
 
 /// Represents a submitted review on a PR.
-typedef PrReview = ({String author, String submittedAt});
+typedef PrReview = ({
+  String id,
+  String databaseId,
+  String author,
+  String body,
+  String state,
+  String submittedAt,
+  String url,
+});
 
 /// Container for GraphQL PR data.
 typedef PrGraphData = ({
@@ -690,8 +698,13 @@ Future<PrGraphData> fetchPrGraphQLData(
         }
         reviews(last: 100) {
           nodes {
+            id
+            databaseId
             author { login }
+            body
+            state
             submittedAt
+            url
           }
         }
         reviewThreads(first: 100) {
@@ -884,10 +897,15 @@ PrComment _parsePrComment(Map json) {
 PrReview _parsePrReview(Map json) {
   final authorLogin = switch (json['author']) {
     {'login': final String login} => login,
-    _ => '',
+    _ => 'ghost',
   };
   return (
+    id: json['id']?.toString() ?? '',
+    databaseId: json['databaseId']?.toString() ?? '',
     author: authorLogin,
+    body: json['body']?.toString() ?? '',
+    state: json['state']?.toString() ?? '',
     submittedAt: json['submittedAt']?.toString() ?? '',
+    url: json['url']?.toString() ?? '',
   );
 }

--- a/tool/test/comments_triage_test.dart
+++ b/tool/test/comments_triage_test.dart
@@ -1,0 +1,162 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:test/test.dart';
+import '../../skills/github-pr-triage/lib/github_cli.dart';
+
+void main() {
+  group('fetchPrGraphQLData tests', () {
+    late Directory tempDir;
+    late PrContext context;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('comments_triage_test_');
+      context = PrContext(
+        workingDir: tempDir.path,
+        prNumber: '38',
+        owner: 'dart-lang',
+        repo: 'skills',
+      );
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('extracts reviews, comments, and reviewThreads properly', () async {
+      final mockGraphqlData = {
+        'data': {
+          'repository': {
+            'pullRequest': {
+              'comments': {
+                'nodes': [
+                  {
+                    'databaseId': 1234567,
+                    'author': {'login': 'alice'},
+                    'body': 'This is a general conversation comment on the PR.',
+                    'createdAt': '2026-08-24T06:00:00Z',
+                    'url':
+                        'https://github.com/dart-lang/skills/pull/38#issuecomment-1234567',
+                  },
+                ],
+              },
+              'reviews': {
+                'nodes': [
+                  {
+                    'id': 'PRR_kwDORY_9Dc8AAAABKlLgCw',
+                    'databaseId': 5005041675,
+                    'author': {'login': 'bob'},
+                    'body': '',
+                    'state': 'COMMENTED',
+                    'submittedAt': '2026-08-24T06:24:19Z',
+                    'url':
+                        'https://github.com/dart-lang/skills/pull/38#pullrequestreview-5005041675',
+                  },
+                  {
+                    'id': 'PRR_kwDORY_9Dc8AAAABKlMYNQ',
+                    'databaseId': 5005056053,
+                    'author': {'login': 'kevmoo'},
+                    'body':
+                        'we should enable (at least) `dart analyze` and `dart format` for these files we\'ve added',
+                    'state': 'COMMENTED',
+                    'submittedAt': '2026-08-24T06:27:09Z',
+                    'url':
+                        'https://github.com/dart-lang/skills/pull/38#pullrequestreview-5005056053',
+                  },
+                ],
+              },
+              'reviewThreads': {
+                'nodes': [
+                  {
+                    'id': 'PRRT_kwDORY_9Dc8AAAAB12345',
+                    'isResolved': false,
+                    'comments': {
+                      'nodes': [
+                        {
+                          'databaseId': 9876543,
+                          'author': {'login': 'charlie'},
+                          'body': 'Please check this line.',
+                          'path': 'lib/foo.dart',
+                          'line': 42,
+                          'originalLine': 42,
+                          'createdAt': '2026-08-24T06:10:00Z',
+                          'url':
+                              'https://github.com/dart-lang/skills/pull/38#discussion_r9876543',
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      };
+
+      final data = await fetchPrGraphQLData(
+        context,
+        runCommand: (command, args, {workingDirectory}) async {
+          expect(command, equals('gh'));
+          expect(args, contains('graphql'));
+          return jsonEncode(mockGraphqlData);
+        },
+      );
+
+      // Verify comments
+      expect(data.comments, hasLength(1));
+      final comment = data.comments.first;
+      expect(comment.databaseId, equals('1234567'));
+      expect(comment.author, equals('alice'));
+      expect(
+        comment.body,
+        equals('This is a general conversation comment on the PR.'),
+      );
+      expect(comment.createdAt, equals('2026-08-24T06:00:00Z'));
+      expect(
+        comment.url,
+        equals(
+          'https://github.com/dart-lang/skills/pull/38#issuecomment-1234567',
+        ),
+      );
+
+      // Verify reviews
+      expect(data.reviews, hasLength(2));
+      final emptyReview = data.reviews[0];
+      expect(emptyReview.id, equals('PRR_kwDORY_9Dc8AAAABKlLgCw'));
+      expect(emptyReview.databaseId, equals('5005041675'));
+      expect(emptyReview.author, equals('bob'));
+      expect(emptyReview.body, isEmpty);
+      expect(emptyReview.state, equals('COMMENTED'));
+      expect(emptyReview.submittedAt, equals('2026-08-24T06:24:19Z'));
+
+      final substantiveReview = data.reviews[1];
+      expect(substantiveReview.id, equals('PRR_kwDORY_9Dc8AAAABKlMYNQ'));
+      expect(substantiveReview.databaseId, equals('5005056053'));
+      expect(substantiveReview.author, equals('kevmoo'));
+      expect(
+        substantiveReview.body,
+        equals(
+          'we should enable (at least) `dart analyze` and `dart format` for these files we\'ve added',
+        ),
+      );
+      expect(substantiveReview.state, equals('COMMENTED'));
+      expect(
+        substantiveReview.url,
+        equals(
+          'https://github.com/dart-lang/skills/pull/38#pullrequestreview-5005056053',
+        ),
+      );
+
+      // Verify review threads
+      expect(data.reviewThreads, hasLength(1));
+      final thread = data.reviewThreads.first;
+      expect(thread.id, equals('PRRT_kwDORY_9Dc8AAAAB12345'));
+      expect(thread.isResolved, isFalse);
+      expect(thread.comments, hasLength(1));
+      expect(thread.comments.first.path, equals('lib/foo.dart'));
+      expect(thread.comments.first.line, equals(42));
+    });
+  });
+}


### PR DESCRIPTION
- Fix #71: update dirty-tree resolution menu to a ladder of strictly decreasing outwardness and remove sync constraint escape hatch
- Update GraphQL query and parser to fetch review bodies, states, database IDs, and URLs
- Update triage report generation to display top-level review comments and PR conversation comments
- Add comprehensive unit tests in tool/test/comments_triage_test.dart

Fixes #71
