### PR TITLE
feat(sidequest): modernize CLI ergonomics and auto-discovery

### DIFF
--- a/skills/sidequest/SKILL.md
+++ b/skills/sidequest/SKILL.md
@@ -71,7 +71,6 @@ sidequest sidequest add "Tangent item" [--global] [--parked] [--note="..."]
 
 # 3. Complete One or Multiple Items (Atomic disk write & star update)
 sidequest complete 1.1.1 1.1.2 1.1
-# Aliases: sidequest done 1.1 / sidequest finish 1.1 / sidequest resolve 1.1
 
 # 4. Update VCS Lifecycle
 sidequest vcs 1 --stage=dirty|local_commit|uploaded|merged|clean [--branch=B] [--files=F]

--- a/skills/sidequest/SKILL.md
+++ b/skills/sidequest/SKILL.md
@@ -21,17 +21,17 @@ Synthesizes task hierarchies and context drift into a visual session map.
 
 ## ⚠️ Mandatory Execution Contract (5 Core Rules)
 
-1. **Tool-Driven State Updates:** Always update state via the CLI tool (`sidequest.dart`). Never edit `sidequest.json` manually.
-2. **Tool-Driven Map Compilation:** Always generate/compile `sidequest.md` via `sidequest.dart`. Never format the markdown map by hand.
+1. **Tool-Driven State Updates:** Always update state via the CLI tool (`sidequest`). Never edit `sidequest.json` manually.
+2. **Tool-Driven Map Compilation:** Always generate/compile `sidequest.md` via `sidequest`. Never format the markdown map by hand.
 3. **Strict Internal Privacy:** **NEVER** mention or reference `sidequest.json` in user-facing conversation. Treat JSON state as a private implementation detail.
 4. **Markdown User Interface:** Always reference `sidequest.md` or provide concise inline markdown summaries when communicating progress to the human.
-5. **Subagent History Ingestion:** Never read `transcript.jsonl` directly in the main conversation; always delegate history parsing to an auditor subagent.
+5. **Subagent History Ingestion:** Never read `transcript.jsonl` directly in the main conversation; delegate deep history rebuilds exclusively via `/sidequest rebuild`.
 
 ---
 
 ## 🏗️ Storage & Architecture
 
-- **Session-Private Artifacts:** All state files (`sidequest.json`, `sidequest.md`) reside strictly in the session artifact directory. Never write to user repositories or dotfiles.
+- **Session-Private Artifacts:** All state files (`sidequest.json`, `sidequest.md`) reside strictly in the session artifact directory (auto-discovered via `ANTIGRAVITY_CONVERSATION_ID`, `CLAUDE_ARTIFACT_DIR`, `GEMINI_ARTIFACT_DIR`, or `--dir`). Never write to user repositories or dotfiles.
 - **Compaction Resilient:** `sidequest.json` maintains the deterministic state model (quests, completion orders, VCS state, step watermark) across context truncations.
 
 ---
@@ -55,33 +55,39 @@ Synthesizes task hierarchies and context drift into a visual session map.
 
 When `/sidequest` triggers (via `/sidequest`, "where are we?", or context drift):
 
-### 🏁 First-Run Protocol (Session Initialization)
-Before performing updates or displaying map status, check if session state exists:
-1. **Check for state file:** Verify if `sidequest.json` exists in the conversation artifact directory (`<session_artifact_dir>`).
-2. **If NO state exists (First Run):** Immediately initialize the session map by executing:
-   `dart run skills/sidequest/bin/sidequest.dart init "<Current Main Task Title>" --dir="<session_artifact_dir>"`
-3. **If state exists:** Proceed directly to CLI mutations, rendering, or summaries.
-4. **DO NOT run `--help` or bare CLI commands on startup:** All valid subcommands and parameters are defined below.
-
 ### Mode A: In-Session CLI Mutation (Default `O(1)`)
-Run the Dart CLI tool via `run_command` (`dart run skills/sidequest/bin/sidequest.dart <cmd> --dir="<session_artifact_dir>"`):
-- `init "Quest Title"`: Initialize session map.
-- `quest add "Title"`: Add a new main quest.
-- `subquest add <quest_id> "Title"`: Add sub-quest (e.g. `subquest add 1 "UI"`).
-- `step add <subquest_id> "Desc"` / `blocker add <subquest_id> "Desc"`: Add step/blocker.
-- `sidequest add "Desc" [--global] [--parked]`: Add tangent/side quest.
-- `complete <id>`: Mark item done (auto-updates `lastCompletionOrder`, sets `[#N ⭐]`, emits `sidequest.md`).
-- `vcs <quest_id> --stage=dirty|local_commit|uploaded|merged|clean [--branch=B] [--files=F]`: Update VCS state.
-- `batch '<json_payload>'`: Perform multiple mutations in 1 turn.
-- `help`, `--help`, `-h`: Print CLI subcommand catalog.
+Execute `sidequest` (or `dart run <path-to-skill>/bin/sidequest.dart`):
+
+```bash
+# 1. Inspect Current State (Outputs compact overview to stdout)
+sidequest status
+
+# 2. Add Quests, Sub-Quests, Steps, Blockers (Auto-initializes if not present)
+sidequest quest add "Title"
+sidequest subquest add 1 "UI Implementation"
+sidequest step add 1.1 "Draft UI widget"
+sidequest blocker add 1.1 "Broken build dependency"
+sidequest sidequest add "Tangent item" [--global] [--parked] [--note="..."]
+
+# 3. Complete One or Multiple Items (Atomic disk write & star update)
+sidequest complete 1.1.1 1.1.2 1.1
+# Aliases: sidequest done 1.1 / sidequest finish 1.1 / sidequest resolve 1.1
+
+# 4. Update VCS Lifecycle
+sidequest vcs 1 --stage=dirty|local_commit|uploaded|merged|clean [--branch=B] [--files=F]
+
+# 5. Reopen or Remove
+sidequest reopen 1.1
+sidequest remove 1.1.2
+```
 
 **User Output:** Output a brief, punchy chat summary covering active `⚔️ Main Quest`, current `🛡️ Sub-Quest`, VCS status, and recommended next step.
 
-### Mode B: Subagent Transcript Audit (`/sidequest rebuild`)
-Use when initializing from long history or explicitly requested via `/sidequest rebuild`:
+### Mode B: Subagent Transcript Rebuild (`/sidequest rebuild`)
+Use **only** when initializing from long unmapped history or explicitly requested via `/sidequest rebuild`:
 1. **Spawn Auditor Subagent:** `TypeName: "research"`, `Role: "Sidequest Log Auditor"`, passing baseline `sidequest.json` and [auditor_prompt.txt](resources/auditor_prompt.txt).
 2. **Delta Audit:** Subagent inspects `transcript.jsonl` from `watermark.stepIndex` onwards and returns audited JSON payload in `send_message`.
-3. **Merge & Emit:** Parent runs `dart run skills/sidequest/bin/sidequest.dart merge-audit --input=<payload_file>` to update JSON and compile `sidequest.md`.
+3. **Merge & Emit:** Parent runs `sidequest merge-audit --input=<payload_file>` to update JSON and compile `sidequest.md`.
 
 ---
 

--- a/skills/sidequest/bin/sidequest.dart
+++ b/skills/sidequest/bin/sidequest.dart
@@ -5,22 +5,7 @@ import 'dart:io';
 import 'package:sidequest/sidequest.dart';
 
 Future<void> main(List<String> rawArgs) async {
-  String? dir;
-  final cleanArgs = <String>[];
-
-  for (var i = 0; i < rawArgs.length; i++) {
-    final arg = rawArgs[i];
-    if (arg.startsWith('--dir=')) {
-      dir = arg.substring('--dir='.length);
-    } else if (arg == '--dir' && i + 1 < rawArgs.length) {
-      dir = rawArgs[++i];
-    } else {
-      cleanArgs.add(arg);
-    }
-  }
-
-  final store = SessionStore(directory: dir);
-  final runner = SidequestCliRunner(store: store);
-  final exitCode = await runner.run(cleanArgs);
+  final runner = SidequestCliRunner();
+  final exitCode = await runner.run(rawArgs);
   exit(exitCode);
 }

--- a/skills/sidequest/lib/src/cli/command_runner.dart
+++ b/skills/sidequest/lib/src/cli/command_runner.dart
@@ -9,13 +9,24 @@ import '../models/sidequest_data.dart';
 import '../models/vcs_state.dart';
 import '../storage/session_store.dart';
 
+enum _ItemCompleteResult { completed, alreadyCompleted, notFound }
+
 class SidequestCliRunner {
   final SessionStore store;
 
   SidequestCliRunner({required this.store});
 
   Future<int> run(List<String> args) async {
-    if (args.isEmpty || args.contains('--help') || args.contains('-h')) {
+    if (args.contains('--help') || args.contains('-h')) {
+      _printUsage();
+      return 0;
+    }
+
+    if (args.isEmpty) {
+      final existing = await store.load();
+      if (existing != null && existing.quests.isNotEmpty) {
+        return await _handleStatus();
+      }
       _printUsage();
       return 0;
     }
@@ -28,6 +39,11 @@ class SidequestCliRunner {
         case 'help':
           _printUsage();
           return 0;
+        case 'status':
+        case 'show':
+        case 'summary':
+        case 'list':
+          return await _handleStatus();
         case 'init':
           return await _handleInit(subArgs);
         case 'quest':
@@ -40,11 +56,18 @@ class SidequestCliRunner {
           return await _handleBlocker(subArgs);
         case 'sidequest':
           return await _handleSideQuest(subArgs);
+        case 'add':
+          return await _handleDispatchAdd(subArgs);
         case 'complete':
+        case 'done':
+        case 'finish':
+        case 'resolve':
           return await _handleComplete(subArgs);
         case 'reopen':
           return await _handleReopen(subArgs);
         case 'remove':
+        case 'delete':
+        case 'rm':
           return await _handleRemove(subArgs);
         case 'vcs':
           return await _handleVcs(subArgs);
@@ -62,6 +85,119 @@ class SidequestCliRunner {
     } catch (e) {
       stderr.writeln('Error running sidequest command "$command": $e');
       return 1;
+    }
+  }
+
+  Future<int> _handleStatus() async {
+    final data = await store.load();
+    if (data == null || data.quests.isEmpty) {
+      stdout.writeln(
+        'No active sidequest session map found in ${store.directory}.',
+      );
+      stdout.writeln(
+        'Run "sidequest init <title>" to initialize a session map.',
+      );
+      return 0;
+    }
+
+    final activeQuest =
+        data.quests.where((q) => q.status == QuestStatus.active).firstOrNull ??
+        data.quests.first;
+
+    stdout.writeln('🧭 Sidequest Status (${store.directory}):');
+    stdout.writeln(
+      '⚔️  Main Quest ${activeQuest.id}: "${activeQuest.title}" [${activeQuest.status.toJson().toUpperCase()}]',
+    );
+
+    if (activeQuest.vcs != null) {
+      final vcs = activeQuest.vcs!;
+      final branch = vcs.branch ?? 'N/A';
+      final files = vcs.modifiedFiles.isEmpty
+          ? 'none'
+          : vcs.modifiedFiles.join(', ');
+      stdout.writeln(
+        '   VCS: ${vcs.stage.badge} | Branch: $branch | Modified: $files',
+      );
+    }
+
+    final blockers = <String>[];
+    for (final sq in activeQuest.subQuests) {
+      for (final item in sq.items) {
+        if (item.status != TaskStatus.completed &&
+            item.type == TaskType.blocker) {
+          blockers.add('👾 Blocker ${item.id}: "${item.title}"');
+        }
+      }
+    }
+
+    if (blockers.isNotEmpty) {
+      stdout.writeln('   Blockers:');
+      for (final b in blockers) {
+        stdout.writeln('     * $b');
+      }
+    }
+
+    if (activeQuest.subQuests.isNotEmpty) {
+      stdout.writeln('   Sub-Quests & Steps:');
+      for (final sq in activeQuest.subQuests) {
+        final doneStr = sq.status == TaskStatus.completed
+            ? '✔ (Done)'
+            : '⏳ (In Progress)';
+        stdout.writeln('     🛡️  Sub-Quest ${sq.id}: "${sq.title}" $doneStr');
+        for (final item in sq.items) {
+          final itemDone = item.status == TaskStatus.completed ? '✔' : ' ';
+          final icon = item.type == TaskType.blocker ? '👾' : '👣';
+          final order = item.completionOrder != null
+              ? (item.completionOrder == data.lastCompletionOrder
+                    ? '[#${item.completionOrder} ⭐]'
+                    : '[#${item.completionOrder}]')
+              : '';
+          final orderStr = order.isNotEmpty ? '$order ' : '';
+          stdout.writeln(
+            '        [$itemDone] $orderStr$icon ${item.id}: "${item.title}"',
+          );
+        }
+      }
+    }
+
+    final allSideQuests = [...data.globalSideQuests, ...activeQuest.sideQuests];
+    if (allSideQuests.isNotEmpty) {
+      stdout.writeln('   🌿 Side Quests:');
+      for (final sq in allSideQuests) {
+        final statusIcon = switch (sq.status) {
+          SideQuestStatus.completed => '✔ Completed',
+          SideQuestStatus.parked => '🎒 Parked',
+          SideQuestStatus.active => '⚡ Active',
+        };
+        final note = sq.note != null ? ' (${sq.note})' : '';
+        stdout.writeln('     * [$statusIcon] ${sq.id}: "${sq.title}"$note');
+      }
+    }
+
+    return 0;
+  }
+
+  Future<int> _handleDispatchAdd(List<String> args) async {
+    if (args.isEmpty) {
+      return await _handleSideQuest(['add']);
+    }
+    final target = args[0];
+    final rest = args.sublist(1);
+
+    switch (target) {
+      case 'quest':
+        return await _handleQuest(['add', ...rest]);
+      case 'subquest':
+        return await _handleSubQuest(['add', ...rest]);
+      case 'step':
+        return await _handleStep(['add', ...rest]);
+      case 'blocker':
+        return await _handleBlocker(['add', ...rest]);
+      case 'sidequest':
+        return await _handleSideQuest(['add', ...rest]);
+      default:
+        // Default treat "add <title>" as adding a sidequest
+        return await _handleSideQuest(['add', ...args]);
     }
   }
 
@@ -137,12 +273,16 @@ class SidequestCliRunner {
     required String label,
     required TaskStatus defaultStatus,
   }) async {
-    if (args.length < 3 || args[0] != 'add') {
-      stderr.writeln('Usage: $commandName add <subquest-id> <title>');
+    final effectiveArgs = args.isNotEmpty && args[0] == 'add'
+        ? args.sublist(1)
+        : args;
+
+    if (effectiveArgs.length < 2) {
+      stderr.writeln('Usage: $commandName [add] <subquest-id> <title>');
       return 1;
     }
-    final subId = args[1];
-    final title = args.sublist(2).join(' ');
+    final subId = effectiveArgs[0];
+    final title = effectiveArgs.sublist(1).join(' ');
     final data = await _requireData();
     final sub = _findSubQuest(data, subId);
     if (sub == null) return 1;
@@ -158,12 +298,16 @@ class SidequestCliRunner {
   }
 
   Future<int> _handleSubQuest(List<String> args) async {
-    if (args.length < 3 || args[0] != 'add') {
-      stderr.writeln('Usage: subquest add <quest-id> <title>');
+    final effectiveArgs = args.isNotEmpty && args[0] == 'add'
+        ? args.sublist(1)
+        : args;
+
+    if (effectiveArgs.length < 2) {
+      stderr.writeln('Usage: subquest [add] <quest-id> <title>');
       return 1;
     }
-    final questId = args[1];
-    final title = args.sublist(2).join(' ');
+    final questId = effectiveArgs[0];
+    final title = effectiveArgs.sublist(1).join(' ');
     final data = await _requireData();
     final quest = _findQuest(data, questId);
     if (quest == null) return 1;
@@ -195,19 +339,17 @@ class SidequestCliRunner {
   );
 
   Future<int> _handleSideQuest(List<String> args) async {
-    if (args.isEmpty || args[0] != 'add') {
-      stderr.writeln(
-        'Usage: sidequest add <title> [--quest=id] [--global] [--parked] [--note=...]',
-      );
-      return 1;
-    }
+    final effectiveArgs = args.isNotEmpty && args[0] == 'add'
+        ? args.sublist(1)
+        : args;
+
     final parser = ArgParser()
       ..addOption('quest')
       ..addFlag('global', defaultsTo: false)
       ..addFlag('parked', defaultsTo: false)
       ..addOption('note');
 
-    final results = parser.parse(args.sublist(1));
+    final results = parser.parse(effectiveArgs);
     final title = results.rest.isNotEmpty
         ? results.rest.join(' ')
         : 'New Side Quest';
@@ -241,192 +383,227 @@ class SidequestCliRunner {
     return 0;
   }
 
+  List<String> _extractIds(List<String> args) => args
+      .expand((arg) => arg.split(','))
+      .map((s) => s.trim())
+      .where((s) => s.isNotEmpty)
+      .toList();
+
   Future<int> _handleComplete(List<String> args) async {
-    if (args.isEmpty) {
-      stderr.writeln('Usage: complete <id>');
+    final ids = _extractIds(args);
+    if (ids.isEmpty) {
+      stderr.writeln('Usage: complete <id> [id2] [id3]...');
       return 1;
     }
-    final id = args[0];
     final data = await _requireData();
+    final completedIds = <String>[];
+    final alreadyCompletedIds = <String>[];
+    final notFoundIds = <String>[];
 
-    final nextOrder = data.lastCompletionOrder + 1;
-    bool found = false;
+    for (final id in ids) {
+      final nextOrder = data.lastCompletionOrder + 1;
+      final result = _completeSingleItem(data, id, nextOrder);
+      if (result == _ItemCompleteResult.completed) {
+        data.lastCompletionOrder = nextOrder;
+        completedIds.add(id);
+      } else if (result == _ItemCompleteResult.alreadyCompleted) {
+        alreadyCompletedIds.add(id);
+      } else {
+        notFoundIds.add(id);
+      }
+    }
 
+    if (completedIds.isNotEmpty) {
+      await store.save(data);
+      stdout.writeln(
+        '✔ Completed item(s): ${completedIds.join(", ")} (Order [#${data.lastCompletionOrder} ⭐])',
+      );
+    }
+    if (alreadyCompletedIds.isNotEmpty) {
+      stdout.writeln('ℹ Already completed: ${alreadyCompletedIds.join(", ")}');
+    }
+    if (notFoundIds.isNotEmpty) {
+      stderr.writeln('Error: Items not found: ${notFoundIds.join(", ")}');
+      return completedIds.isEmpty && alreadyCompletedIds.isEmpty ? 1 : 0;
+    }
+    return 0;
+  }
+
+  _ItemCompleteResult _completeSingleItem(
+    SidequestData data,
+    String id,
+    int nextOrder,
+  ) {
     for (final q in data.quests) {
       if (q.id == id) {
         if (q.status == QuestStatus.completed) {
-          stdout.writeln('✔ Main Quest $id is already completed.');
-          return 0;
+          return _ItemCompleteResult.alreadyCompleted;
         }
         q.status = QuestStatus.completed;
-        found = true;
-        break;
+        return _ItemCompleteResult.completed;
       }
       for (final sq in q.subQuests) {
         if (sq.id == id) {
           if (sq.status == TaskStatus.completed) {
-            stdout.writeln('✔ Sub-Quest $id is already completed.');
-            return 0;
+            return _ItemCompleteResult.alreadyCompleted;
           }
           sq.status = TaskStatus.completed;
           sq.completionOrder = nextOrder;
-          data.lastCompletionOrder = nextOrder;
-          found = true;
-          break;
+          return _ItemCompleteResult.completed;
         }
         for (final item in sq.items) {
           if (item.id == id) {
             if (item.status == TaskStatus.completed) {
-              stdout.writeln('✔ Item $id is already completed.');
-              return 0;
+              return _ItemCompleteResult.alreadyCompleted;
             }
             item.status = TaskStatus.completed;
             item.completionOrder = nextOrder;
-            data.lastCompletionOrder = nextOrder;
-            found = true;
-            break;
-          }
-        }
-        if (found) break;
-      }
-      if (found) break;
-      for (final sq in q.sideQuests) {
-        if (sq.id == id) {
-          if (sq.status == SideQuestStatus.completed) {
-            stdout.writeln('✔ Side Quest $id is already completed.');
-            return 0;
-          }
-          sq.status = SideQuestStatus.completed;
-          sq.completionOrder = nextOrder;
-          data.lastCompletionOrder = nextOrder;
-          found = true;
-          break;
-        }
-      }
-      if (found) break;
-    }
-
-    if (!found) {
-      for (final sq in data.globalSideQuests) {
-        if (sq.id == id) {
-          if (sq.status == SideQuestStatus.completed) {
-            stdout.writeln('✔ Global Side Quest $id is already completed.');
-            return 0;
-          }
-          sq.status = SideQuestStatus.completed;
-          sq.completionOrder = nextOrder;
-          data.lastCompletionOrder = nextOrder;
-          found = true;
-          break;
-        }
-      }
-    }
-
-    if (!found) {
-      stderr.writeln('Error: Item with ID "$id" not found.');
-      return 1;
-    }
-
-    await store.save(data);
-    stdout.writeln('✔ Completed item $id (Order [#$nextOrder ⭐])');
-    return 0;
-  }
-
-  Future<int> _handleReopen(List<String> args) async {
-    if (args.isEmpty) {
-      stderr.writeln('Usage: reopen <id>');
-      return 1;
-    }
-    final id = args[0];
-    final data = await _requireData();
-    bool found = false;
-
-    for (final q in data.quests) {
-      if (q.id == id) {
-        q.status = QuestStatus.active;
-        found = true;
-      }
-      for (final sq in q.subQuests) {
-        if (sq.id == id) {
-          sq.status = TaskStatus.inProgress;
-          sq.completionOrder = null;
-          found = true;
-        }
-        for (final item in sq.items) {
-          if (item.id == id) {
-            item.status = TaskStatus.pending;
-            item.completionOrder = null;
-            found = true;
+            return _ItemCompleteResult.completed;
           }
         }
       }
       for (final sq in q.sideQuests) {
         if (sq.id == id) {
-          sq.status = SideQuestStatus.active;
-          sq.completionOrder = null;
-          found = true;
+          if (sq.status == SideQuestStatus.completed) {
+            return _ItemCompleteResult.alreadyCompleted;
+          }
+          sq.status = SideQuestStatus.completed;
+          sq.completionOrder = nextOrder;
+          return _ItemCompleteResult.completed;
         }
       }
     }
 
     for (final sq in data.globalSideQuests) {
       if (sq.id == id) {
-        sq.status = SideQuestStatus.active;
-        sq.completionOrder = null;
-        found = true;
+        if (sq.status == SideQuestStatus.completed) {
+          return _ItemCompleteResult.alreadyCompleted;
+        }
+        sq.status = SideQuestStatus.completed;
+        sq.completionOrder = nextOrder;
+        return _ItemCompleteResult.completed;
       }
     }
 
-    if (!found) {
-      stderr.writeln('Error: Item with ID "$id" not found.');
+    return _ItemCompleteResult.notFound;
+  }
+
+  Future<int> _handleReopen(List<String> args) async {
+    final ids = _extractIds(args);
+    if (ids.isEmpty) {
+      stderr.writeln('Usage: reopen <id> [id2]...');
       return 1;
     }
+    final data = await _requireData();
+    final reopenedIds = <String>[];
+    final notFoundIds = <String>[];
 
-    _recalculateMaxCompletionOrder(data);
-    await store.save(data);
-    stdout.writeln('✔ Reopened item $id');
+    for (final id in ids) {
+      bool found = false;
+      for (final q in data.quests) {
+        if (q.id == id) {
+          q.status = QuestStatus.active;
+          found = true;
+        }
+        for (final sq in q.subQuests) {
+          if (sq.id == id) {
+            sq.status = TaskStatus.inProgress;
+            sq.completionOrder = null;
+            found = true;
+          }
+          for (final item in sq.items) {
+            if (item.id == id) {
+              item.status = TaskStatus.pending;
+              item.completionOrder = null;
+              found = true;
+            }
+          }
+        }
+        for (final sq in q.sideQuests) {
+          if (sq.id == id) {
+            sq.status = SideQuestStatus.active;
+            sq.completionOrder = null;
+            found = true;
+          }
+        }
+      }
+
+      for (final sq in data.globalSideQuests) {
+        if (sq.id == id) {
+          sq.status = SideQuestStatus.active;
+          sq.completionOrder = null;
+          found = true;
+        }
+      }
+
+      if (found) {
+        reopenedIds.add(id);
+      } else {
+        notFoundIds.add(id);
+      }
+    }
+
+    if (reopenedIds.isNotEmpty) {
+      _recalculateMaxCompletionOrder(data);
+      await store.save(data);
+      stdout.writeln('✔ Reopened item(s): ${reopenedIds.join(", ")}');
+    }
+    if (notFoundIds.isNotEmpty) {
+      stderr.writeln('Error: Items not found: ${notFoundIds.join(", ")}');
+      return reopenedIds.isEmpty ? 1 : 0;
+    }
     return 0;
   }
 
   Future<int> _handleRemove(List<String> args) async {
-    if (args.isEmpty) {
-      stderr.writeln('Usage: remove <id>');
+    final ids = _extractIds(args);
+    if (ids.isEmpty) {
+      stderr.writeln('Usage: remove <id> [id2]...');
       return 1;
     }
-    final id = args[0];
     final data = await _requireData();
+    final removedIds = <String>[];
+    final notFoundIds = <String>[];
 
-    bool found = false;
-
-    if (data.quests.any((q) => q.id == id)) {
-      data.quests.removeWhere((q) => q.id == id);
-      found = true;
-    }
-
-    for (final q in data.quests) {
-      if (q.subQuests.any((sq) => sq.id == id)) found = true;
-      q.subQuests.removeWhere((sq) => sq.id == id);
-      for (final sq in q.subQuests) {
-        if (sq.items.any((item) => item.id == id)) found = true;
-        sq.items.removeWhere((item) => item.id == id);
+    for (final id in ids) {
+      bool found = false;
+      if (data.quests.any((q) => q.id == id)) {
+        data.quests.removeWhere((q) => q.id == id);
+        found = true;
       }
-      if (q.sideQuests.any((sq) => sq.id == id)) found = true;
-      q.sideQuests.removeWhere((sq) => sq.id == id);
+
+      for (final q in data.quests) {
+        if (q.subQuests.any((sq) => sq.id == id)) found = true;
+        q.subQuests.removeWhere((sq) => sq.id == id);
+        for (final sq in q.subQuests) {
+          if (sq.items.any((item) => item.id == id)) found = true;
+          sq.items.removeWhere((item) => item.id == id);
+        }
+        if (q.sideQuests.any((sq) => sq.id == id)) found = true;
+        q.sideQuests.removeWhere((sq) => sq.id == id);
+      }
+
+      if (data.globalSideQuests.any((sq) => sq.id == id)) {
+        data.globalSideQuests.removeWhere((sq) => sq.id == id);
+        found = true;
+      }
+
+      if (found) {
+        removedIds.add(id);
+      } else {
+        notFoundIds.add(id);
+      }
     }
 
-    if (data.globalSideQuests.any((sq) => sq.id == id)) {
-      data.globalSideQuests.removeWhere((sq) => sq.id == id);
-      found = true;
+    if (removedIds.isNotEmpty) {
+      _recalculateMaxCompletionOrder(data);
+      await store.save(data);
+      stdout.writeln('✔ Removed item(s): ${removedIds.join(", ")}');
     }
-
-    if (!found) {
-      stderr.writeln('Error: Item with ID "$id" not found.');
-      return 1;
+    if (notFoundIds.isNotEmpty) {
+      stderr.writeln('Error: Items not found: ${notFoundIds.join(", ")}');
+      return removedIds.isEmpty ? 1 : 0;
     }
-
-    _recalculateMaxCompletionOrder(data);
-    await store.save(data);
-    stdout.writeln('✔ Removed item $id');
     return 0;
   }
 
@@ -469,62 +646,213 @@ class SidequestCliRunner {
       stderr.writeln('Usage: batch <json-string>');
       return 1;
     }
-    final batchMap = jsonDecode(args[0]) as Map<String, dynamic>;
+    final decoded = jsonDecode(args[0]);
     final data = await _requireData();
 
-    if (batchMap['complete'] is List) {
-      for (final id in batchMap['complete'] as List) {
-        final nextOrder = data.lastCompletionOrder + 1;
-        final updated = _setItemStatus(
-          data,
-          id.toString(),
-          TaskStatus.completed,
-          nextOrder,
-        );
-        if (updated) {
-          data.lastCompletionOrder = nextOrder;
+    if (decoded is List) {
+      for (final op in decoded) {
+        if (op is Map<String, dynamic>) {
+          _applyBatchOp(data, op);
         }
       }
-    }
+    } else if (decoded is Map<String, dynamic>) {
+      if (decoded['operations'] is List) {
+        for (final op in decoded['operations'] as List) {
+          if (op is Map<String, dynamic>) {
+            _applyBatchOp(data, op);
+          }
+        }
+      } else {
+        // Legacy batchMap format
+        if (decoded['complete'] is List) {
+          for (final id in decoded['complete'] as List) {
+            final nextOrder = data.lastCompletionOrder + 1;
+            final updated = _setItemStatus(
+              data,
+              id.toString(),
+              TaskStatus.completed,
+              nextOrder,
+            );
+            if (updated) {
+              data.lastCompletionOrder = nextOrder;
+            }
+          }
+        }
 
-    if (batchMap['addSubQuest'] is Map) {
-      final map = batchMap['addSubQuest'] as Map<String, dynamic>;
-      final qId = map['quest'] as String? ?? '1';
-      final quest = _findQuest(data, qId);
-      if (quest != null) {
-        final nextSubNumber = _nextSuffixNumber(
-          quest.subQuests.map((sq) => sq.id),
-        );
-        final subId = '$qId.$nextSubNumber';
-        quest.subQuests.add(
-          SubQuest(
-            id: subId,
-            title: map['title'] as String? ?? 'New SubQuest',
-            status: TaskStatus.inProgress,
-          ),
-        );
-      }
-    }
+        if (decoded['addSubQuest'] is Map) {
+          final map = decoded['addSubQuest'] as Map<String, dynamic>;
+          final qId = map['quest'] as String? ?? '1';
+          final quest = _findQuest(data, qId);
+          if (quest != null) {
+            final nextSubNumber = _nextSuffixNumber(
+              quest.subQuests.map((sq) => sq.id),
+            );
+            final subId = '$qId.$nextSubNumber';
+            quest.subQuests.add(
+              SubQuest(
+                id: subId,
+                title: map['title'] as String? ?? 'New SubQuest',
+                status: TaskStatus.inProgress,
+              ),
+            );
+          }
+        }
 
-    if (batchMap['vcs'] is Map) {
-      final map = batchMap['vcs'] as Map<String, dynamic>;
-      final qId = map['quest'] as String? ?? '1';
-      final quest = _findQuest(data, qId);
-      if (quest != null) {
-        final files =
-            (map['files'] as List<dynamic>?)?.cast<String>() ?? const [];
-        quest.vcs = VcsState(
-          stage: VcsStage.fromJson(map['stage'] as String? ?? 'dirty'),
-          branch: map['branch'] as String?,
-          modifiedFiles: files,
-          details: map['details'] as String?,
-        );
+        if (decoded['vcs'] is Map) {
+          final map = decoded['vcs'] as Map<String, dynamic>;
+          final qId = map['quest'] as String? ?? '1';
+          final quest = _findQuest(data, qId);
+          if (quest != null) {
+            final files =
+                (map['files'] as List<dynamic>?)?.cast<String>() ?? const [];
+            quest.vcs = VcsState(
+              stage: VcsStage.fromJson(map['stage'] as String? ?? 'dirty'),
+              branch: map['branch'] as String?,
+              modifiedFiles: files,
+              details: map['details'] as String?,
+            );
+          }
+        }
       }
     }
 
     await store.save(data);
     stdout.writeln('✔ Executed batch operations');
     return 0;
+  }
+
+  void _applyBatchOp(SidequestData data, Map<String, dynamic> op) {
+    final type = (op['type'] as String? ?? '').toLowerCase();
+
+    switch (type) {
+      case 'complete':
+      case 'done':
+      case 'finish':
+        final rawIds = op['ids'] ?? op['id'];
+        final idList = rawIds is List
+            ? rawIds.map((e) => e.toString()).toList()
+            : [rawIds?.toString() ?? ''];
+        for (final id in idList.where((s) => s.isNotEmpty)) {
+          final nextOrder = data.lastCompletionOrder + 1;
+          final updated = _setItemStatus(
+            data,
+            id,
+            TaskStatus.completed,
+            nextOrder,
+          );
+          if (updated) {
+            data.lastCompletionOrder = nextOrder;
+          }
+        }
+        break;
+      case 'subquest_add':
+      case 'add_subquest':
+      case 'subquest':
+        final qId = op['questId']?.toString() ?? op['quest']?.toString() ?? '1';
+        final title =
+            op['title']?.toString() ??
+            op['description']?.toString() ??
+            'SubQuest';
+        final quest = data.quests.where((q) => q.id == qId).firstOrNull;
+        if (quest != null) {
+          final nextSubNumber = _nextSuffixNumber(
+            quest.subQuests.map((sq) => sq.id),
+          );
+          final subId = '$qId.$nextSubNumber';
+          quest.subQuests.add(
+            SubQuest(id: subId, title: title, status: TaskStatus.inProgress),
+          );
+        }
+        break;
+      case 'step_add':
+      case 'add_step':
+      case 'step':
+        final subId =
+            op['subquestId']?.toString() ?? op['subquest']?.toString() ?? '1.1';
+        final title =
+            op['title']?.toString() ?? op['description']?.toString() ?? 'Step';
+        final sub = _findSubQuest(data, subId);
+        if (sub != null) {
+          final nextNumber = _nextSuffixNumber(sub.items.map((i) => i.id));
+          sub.items.add(
+            TaskItem(
+              id: '$subId.$nextNumber',
+              type: TaskType.step,
+              title: title,
+              status: TaskStatus.pending,
+            ),
+          );
+        }
+        break;
+      case 'blocker_add':
+      case 'add_blocker':
+      case 'blocker':
+        final subId =
+            op['subquestId']?.toString() ?? op['subquest']?.toString() ?? '1.1';
+        final title =
+            op['title']?.toString() ??
+            op['description']?.toString() ??
+            'Blocker';
+        final sub = _findSubQuest(data, subId);
+        if (sub != null) {
+          final nextNumber = _nextSuffixNumber(sub.items.map((i) => i.id));
+          sub.items.add(
+            TaskItem(
+              id: '$subId.$nextNumber',
+              type: TaskType.blocker,
+              title: title,
+              status: TaskStatus.inProgress,
+            ),
+          );
+        }
+        break;
+      case 'sidequest_add':
+      case 'add_sidequest':
+      case 'sidequest':
+        final title =
+            op['title']?.toString() ??
+            op['description']?.toString() ??
+            'Side Quest';
+        final isGlobal =
+            op['global'] == true ||
+            (op['quest'] == null && data.quests.isEmpty);
+        final isParked = op['parked'] == true;
+        final status = isParked
+            ? SideQuestStatus.parked
+            : SideQuestStatus.active;
+        final note = op['note']?.toString();
+
+        if (isGlobal || op['quest'] == null) {
+          final id = data.generateNextGlobalSideQuestId();
+          data.globalSideQuests.add(
+            SideQuest(id: id, title: title, status: status, note: note),
+          );
+        } else {
+          final qId = op['quest'].toString();
+          final quest = data.quests.where((q) => q.id == qId).firstOrNull;
+          if (quest != null) {
+            final id = data.generateNextSideQuestId(quest);
+            quest.sideQuests.add(
+              SideQuest(id: id, title: title, status: status, note: note),
+            );
+          }
+        }
+        break;
+      case 'vcs':
+        final qId = op['quest']?.toString() ?? '1';
+        final quest = data.quests.where((q) => q.id == qId).firstOrNull;
+        if (quest != null) {
+          final files =
+              (op['files'] as List<dynamic>?)?.cast<String>() ?? const [];
+          quest.vcs = VcsState(
+            stage: VcsStage.fromJson(op['stage']?.toString() ?? 'dirty'),
+            branch: op['branch']?.toString(),
+            modifiedFiles: files,
+            details: op['details']?.toString(),
+          );
+        }
+        break;
+    }
   }
 
   Future<int> _handleRender() async {
@@ -628,21 +956,25 @@ class SidequestCliRunner {
     int maxOrder = 0;
     for (final q in data.quests) {
       for (final sq in q.subQuests) {
-        if (sq.completionOrder != null)
+        if (sq.completionOrder != null) {
           maxOrder = max(maxOrder, sq.completionOrder!);
+        }
         for (final item in sq.items) {
-          if (item.completionOrder != null)
+          if (item.completionOrder != null) {
             maxOrder = max(maxOrder, item.completionOrder!);
+          }
         }
       }
       for (final sq in q.sideQuests) {
-        if (sq.completionOrder != null)
+        if (sq.completionOrder != null) {
           maxOrder = max(maxOrder, sq.completionOrder!);
+        }
       }
     }
     for (final sq in data.globalSideQuests) {
-      if (sq.completionOrder != null)
+      if (sq.completionOrder != null) {
         maxOrder = max(maxOrder, sq.completionOrder!);
+      }
     }
     data.lastCompletionOrder = maxOrder;
   }
@@ -652,23 +984,24 @@ class SidequestCliRunner {
 sidequest CLI - Deterministic session map manager
 
 Usage:
-  sidequest <command> [args] [--dir=path]
+  sidequest [command] [args] [--dir=path]
 
 Global Options:
   --dir=<path>            Path to session artifact directory containing sidequest.json
 
-Subcommands:
+Inspection:
+  status, show, summary   Print compact 10-line session overview (default if state exists)
+
+Mutations:
   init [title]            Initialize sidequest session map (default: "Main Quest 1")
   quest add <title>       Add a new main quest
-  quest activate <id>     Activate a main quest
-  quest pause <id>        Pause a main quest (--reason=...)
   subquest add <qId> <t>  Add a sub-quest under main quest <qId>
   step add <subId> <t>    Add a planned step under sub-quest <subId>
   blocker add <subId> <t> Add an unplanned blocker under sub-quest <subId>
   sidequest add <t>       Add a side quest (--quest=<qId>, --global, --parked, --note=<n>)
-  complete <id>           Mark item (quest, subquest, step, blocker, sidequest) completed
-  reopen <id>             Reopen a completed item
-  remove <id>             Remove an item from the session map
+  complete <id...>        Mark one or more items completed (alias: done, finish, resolve)
+  reopen <id...>          Reopen one or more completed items
+  remove <id...>          Remove one or more items (alias: delete, rm)
   vcs <qId>               Update VCS state (--stage=dirty|local_commit|uploaded|merged|clean)
   batch <json>            Execute multiple mutations in a single call
   render                  Re-render sidequest.md from sidequest.json

--- a/skills/sidequest/lib/src/cli/command_runner.dart
+++ b/skills/sidequest/lib/src/cli/command_runner.dart
@@ -115,18 +115,29 @@ class SidequestCliRunner {
     );
 
     if (activeQuest.vcs != null) {
-      final vcs = activeQuest.vcs!;
-      final branch = vcs.branch ?? 'N/A';
-      final files = vcs.modifiedFiles.isEmpty
-          ? 'none'
-          : vcs.modifiedFiles.join(', ');
-      stdout.writeln(
-        '   VCS: ${vcs.stage.badge} | Branch: $branch | Modified: $files',
-      );
+      _printVcsStatus(activeQuest.vcs!);
     }
 
+    _printBlockers(activeQuest.subQuests);
+    _printSubQuests(activeQuest.subQuests, data.lastCompletionOrder);
+    _printSideQuests([...data.globalSideQuests, ...activeQuest.sideQuests]);
+
+    return 0;
+  }
+
+  void _printVcsStatus(VcsState vcs) {
+    final branch = vcs.branch ?? 'N/A';
+    final files = vcs.modifiedFiles.isEmpty
+        ? 'none'
+        : vcs.modifiedFiles.join(', ');
+    stdout.writeln(
+      '   VCS: ${vcs.stage.badge} | Branch: $branch | Modified: $files',
+    );
+  }
+
+  void _printBlockers(List<SubQuest> subQuests) {
     final blockers = <String>[];
-    for (final sq in activeQuest.subQuests) {
+    for (final sq in subQuests) {
       for (final item in sq.items) {
         if (item.status != TaskStatus.completed &&
             item.type == TaskType.blocker) {
@@ -141,45 +152,50 @@ class SidequestCliRunner {
         stdout.writeln('     * $b');
       }
     }
+  }
 
-    if (activeQuest.subQuests.isNotEmpty) {
-      stdout.writeln('   Sub-Quests & Steps:');
-      for (final sq in activeQuest.subQuests) {
-        final doneStr = sq.status == TaskStatus.completed
-            ? '✔ (Done)'
-            : '⏳ (In Progress)';
-        stdout.writeln('     🛡️  Sub-Quest ${sq.id}: "${sq.title}" $doneStr');
-        for (final item in sq.items) {
-          final itemDone = item.status == TaskStatus.completed ? '✔' : ' ';
-          final icon = item.type == TaskType.blocker ? '👾' : '👣';
-          final order = item.completionOrder != null
-              ? (item.completionOrder == data.lastCompletionOrder
-                    ? '[#${item.completionOrder} ⭐]'
-                    : '[#${item.completionOrder}]')
-              : '';
-          final orderStr = order.isNotEmpty ? '$order ' : '';
-          stdout.writeln(
-            '        [$itemDone] $orderStr$icon ${item.id}: "${item.title}"',
-          );
-        }
+  void _printSubQuests(List<SubQuest> subQuests, int lastCompletionOrder) {
+    if (subQuests.isEmpty) return;
+
+    stdout.writeln('   Sub-Quests & Steps:');
+    for (final sq in subQuests) {
+      final doneStr = sq.status == TaskStatus.completed
+          ? '✔ (Done)'
+          : '⏳ (In Progress)';
+      stdout.writeln('     🛡️  Sub-Quest ${sq.id}: "${sq.title}" $doneStr');
+      for (final item in sq.items) {
+        _printTaskItem(item, lastCompletionOrder);
       }
     }
+  }
 
-    final allSideQuests = [...data.globalSideQuests, ...activeQuest.sideQuests];
-    if (allSideQuests.isNotEmpty) {
-      stdout.writeln('   🌿 Side Quests:');
-      for (final sq in allSideQuests) {
-        final statusIcon = switch (sq.status) {
-          SideQuestStatus.completed => '✔ Completed',
-          SideQuestStatus.parked => '🎒 Parked',
-          SideQuestStatus.active => '⚡ Active',
-        };
-        final note = sq.note != null ? ' (${sq.note})' : '';
-        stdout.writeln('     * [$statusIcon] ${sq.id}: "${sq.title}"$note');
-      }
+  void _printTaskItem(TaskItem item, int lastCompletionOrder) {
+    final itemDone = item.status == TaskStatus.completed ? '✔' : ' ';
+    final icon = item.type == TaskType.blocker ? '👾' : '👣';
+    final order = item.completionOrder != null
+        ? (item.completionOrder == lastCompletionOrder
+              ? '[#${item.completionOrder} ⭐]'
+              : '[#${item.completionOrder}]')
+        : '';
+    final orderStr = order.isNotEmpty ? '$order ' : '';
+    stdout.writeln(
+      '        [$itemDone] $orderStr$icon ${item.id}: "${item.title}"',
+    );
+  }
+
+  void _printSideQuests(List<SideQuest> sideQuests) {
+    if (sideQuests.isEmpty) return;
+
+    stdout.writeln('   🌿 Side Quests:');
+    for (final sq in sideQuests) {
+      final statusIcon = switch (sq.status) {
+        SideQuestStatus.completed => '✔ Completed',
+        SideQuestStatus.parked => '🎒 Parked',
+        SideQuestStatus.active => '⚡ Active',
+      };
+      final note = sq.note != null ? ' (${sq.note})' : '';
+      stdout.writeln('     * [$statusIcon] ${sq.id}: "${sq.title}"$note');
     }
-
-    return 0;
   }
 
   Future<int> _handleDispatchAdd(List<String> args) async {
@@ -445,57 +461,76 @@ class SidequestCliRunner {
     int nextOrder,
   ) {
     for (final q in data.quests) {
-      if (q.id == id) {
-        if (q.status == QuestStatus.completed) {
-          return _ItemCompleteResult.alreadyCompleted;
-        }
-        q.status = QuestStatus.completed;
-        return _ItemCompleteResult.completedNoOrder;
-      }
-      for (final sq in q.subQuests) {
-        if (sq.id == id) {
-          if (sq.status == TaskStatus.completed) {
-            return _ItemCompleteResult.alreadyCompleted;
-          }
-          sq.status = TaskStatus.completed;
-          sq.completionOrder = nextOrder;
-          return _ItemCompleteResult.completedWithOrder;
-        }
-        for (final item in sq.items) {
-          if (item.id == id) {
-            if (item.status == TaskStatus.completed) {
-              return _ItemCompleteResult.alreadyCompleted;
-            }
-            item.status = TaskStatus.completed;
-            item.completionOrder = nextOrder;
-            return _ItemCompleteResult.completedWithOrder;
-          }
-        }
-      }
-      for (final sq in q.sideQuests) {
-        if (sq.id == id) {
-          if (sq.status == SideQuestStatus.completed) {
-            return _ItemCompleteResult.alreadyCompleted;
-          }
-          sq.status = SideQuestStatus.completed;
-          sq.completionOrder = nextOrder;
-          return _ItemCompleteResult.completedWithOrder;
-        }
-      }
+      final qResult = _completeQuest(q, id, nextOrder);
+      if (qResult != _ItemCompleteResult.notFound) return qResult;
     }
 
     for (final sq in data.globalSideQuests) {
-      if (sq.id == id) {
-        if (sq.status == SideQuestStatus.completed) {
+      final sqResult = _completeSideQuest(sq, id, nextOrder);
+      if (sqResult != _ItemCompleteResult.notFound) return sqResult;
+    }
+
+    return _ItemCompleteResult.notFound;
+  }
+
+  _ItemCompleteResult _completeQuest(MainQuest q, String id, int nextOrder) {
+    if (q.id == id) {
+      if (q.status == QuestStatus.completed) {
+        return _ItemCompleteResult.alreadyCompleted;
+      }
+      q.status = QuestStatus.completed;
+      return _ItemCompleteResult.completedNoOrder;
+    }
+
+    for (final sq in q.subQuests) {
+      final sqResult = _completeSubQuest(sq, id, nextOrder);
+      if (sqResult != _ItemCompleteResult.notFound) return sqResult;
+    }
+
+    for (final sq in q.sideQuests) {
+      final sqResult = _completeSideQuest(sq, id, nextOrder);
+      if (sqResult != _ItemCompleteResult.notFound) return sqResult;
+    }
+
+    return _ItemCompleteResult.notFound;
+  }
+
+  _ItemCompleteResult _completeSubQuest(SubQuest sq, String id, int nextOrder) {
+    if (sq.id == id) {
+      if (sq.status == TaskStatus.completed) {
+        return _ItemCompleteResult.alreadyCompleted;
+      }
+      sq.status = TaskStatus.completed;
+      sq.completionOrder = nextOrder;
+      return _ItemCompleteResult.completedWithOrder;
+    }
+
+    for (final item in sq.items) {
+      if (item.id == id) {
+        if (item.status == TaskStatus.completed) {
           return _ItemCompleteResult.alreadyCompleted;
         }
-        sq.status = SideQuestStatus.completed;
-        sq.completionOrder = nextOrder;
+        item.status = TaskStatus.completed;
+        item.completionOrder = nextOrder;
         return _ItemCompleteResult.completedWithOrder;
       }
     }
 
     return _ItemCompleteResult.notFound;
+  }
+
+  _ItemCompleteResult _completeSideQuest(
+    SideQuest sq,
+    String id,
+    int nextOrder,
+  ) {
+    if (sq.id != id) return _ItemCompleteResult.notFound;
+    if (sq.status == SideQuestStatus.completed) {
+      return _ItemCompleteResult.alreadyCompleted;
+    }
+    sq.status = SideQuestStatus.completed;
+    sq.completionOrder = nextOrder;
+    return _ItemCompleteResult.completedWithOrder;
   }
 
   Future<int> _handleReopen(List<String> args) async {
@@ -509,44 +544,7 @@ class SidequestCliRunner {
     final notFoundIds = <String>[];
 
     for (final id in ids) {
-      bool found = false;
-      for (final q in data.quests) {
-        if (q.id == id) {
-          q.status = QuestStatus.active;
-          found = true;
-        }
-        for (final sq in q.subQuests) {
-          if (sq.id == id) {
-            sq.status = TaskStatus.inProgress;
-            sq.completionOrder = null;
-            found = true;
-          }
-          for (final item in sq.items) {
-            if (item.id == id) {
-              item.status = TaskStatus.pending;
-              item.completionOrder = null;
-              found = true;
-            }
-          }
-        }
-        for (final sq in q.sideQuests) {
-          if (sq.id == id) {
-            sq.status = SideQuestStatus.active;
-            sq.completionOrder = null;
-            found = true;
-          }
-        }
-      }
-
-      for (final sq in data.globalSideQuests) {
-        if (sq.id == id) {
-          sq.status = SideQuestStatus.active;
-          sq.completionOrder = null;
-          found = true;
-        }
-      }
-
-      if (found) {
+      if (_reopenSingleItem(data, id)) {
         reopenedIds.add(id);
       } else {
         notFoundIds.add(id);
@@ -565,6 +563,51 @@ class SidequestCliRunner {
     return 0;
   }
 
+  bool _reopenSingleItem(SidequestData data, String id) {
+    for (final q in data.quests) {
+      if (_reopenQuest(q, id)) return true;
+    }
+
+    for (final sq in data.globalSideQuests) {
+      if (sq.id == id) {
+        sq.status = SideQuestStatus.active;
+        sq.completionOrder = null;
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  bool _reopenQuest(MainQuest q, String id) {
+    if (q.id == id) {
+      q.status = QuestStatus.active;
+      return true;
+    }
+    for (final sq in q.subQuests) {
+      if (sq.id == id) {
+        sq.status = TaskStatus.inProgress;
+        sq.completionOrder = null;
+        return true;
+      }
+      for (final item in sq.items) {
+        if (item.id == id) {
+          item.status = TaskStatus.pending;
+          item.completionOrder = null;
+          return true;
+        }
+      }
+    }
+    for (final sq in q.sideQuests) {
+      if (sq.id == id) {
+        sq.status = SideQuestStatus.active;
+        sq.completionOrder = null;
+        return true;
+      }
+    }
+    return false;
+  }
+
   Future<int> _handleRemove(List<String> args) async {
     final ids = _extractIds(args);
     if (ids.isEmpty) {
@@ -576,29 +619,7 @@ class SidequestCliRunner {
     final notFoundIds = <String>[];
 
     for (final id in ids) {
-      bool found = false;
-      if (data.quests.any((q) => q.id == id)) {
-        data.quests.removeWhere((q) => q.id == id);
-        found = true;
-      }
-
-      for (final q in data.quests) {
-        if (q.subQuests.any((sq) => sq.id == id)) found = true;
-        q.subQuests.removeWhere((sq) => sq.id == id);
-        for (final sq in q.subQuests) {
-          if (sq.items.any((item) => item.id == id)) found = true;
-          sq.items.removeWhere((item) => item.id == id);
-        }
-        if (q.sideQuests.any((sq) => sq.id == id)) found = true;
-        q.sideQuests.removeWhere((sq) => sq.id == id);
-      }
-
-      if (data.globalSideQuests.any((sq) => sq.id == id)) {
-        data.globalSideQuests.removeWhere((sq) => sq.id == id);
-        found = true;
-      }
-
-      if (found) {
+      if (_removeSingleItem(data, id)) {
         removedIds.add(id);
       } else {
         notFoundIds.add(id);
@@ -615,6 +636,38 @@ class SidequestCliRunner {
       return removedIds.isEmpty ? 1 : 0;
     }
     return 0;
+  }
+
+  bool _removeSingleItem(SidequestData data, String id) {
+    bool found = false;
+    if (data.quests.any((q) => q.id == id)) {
+      data.quests.removeWhere((q) => q.id == id);
+      return true;
+    }
+
+    for (final q in data.quests) {
+      if (q.subQuests.any((sq) => sq.id == id)) {
+        q.subQuests.removeWhere((sq) => sq.id == id);
+        found = true;
+      }
+      for (final sq in q.subQuests) {
+        if (sq.items.any((item) => item.id == id)) {
+          sq.items.removeWhere((item) => item.id == id);
+          found = true;
+        }
+      }
+      if (q.sideQuests.any((sq) => sq.id == id)) {
+        q.sideQuests.removeWhere((sq) => sq.id == id);
+        found = true;
+      }
+    }
+
+    if (data.globalSideQuests.any((sq) => sq.id == id)) {
+      data.globalSideQuests.removeWhere((sq) => sq.id == id);
+      found = true;
+    }
+
+    return found;
   }
 
   Future<int> _handleVcs(List<String> args) async {
@@ -660,70 +713,77 @@ class SidequestCliRunner {
     final data = await _requireData();
 
     if (decoded is List) {
-      for (final op in decoded) {
-        if (op is Map<String, dynamic>) {
-          _applyBatchOp(data, op);
-        }
-      }
+      _applyBatchList(data, decoded);
     } else if (decoded is Map<String, dynamic>) {
-      if (decoded['operations'] is List) {
-        for (final op in decoded['operations'] as List) {
-          if (op is Map<String, dynamic>) {
-            _applyBatchOp(data, op);
-          }
-        }
-      } else {
-        // Legacy batchMap format
-        if (decoded['complete'] is List) {
-          for (final id in decoded['complete'] as List) {
-            final nextOrder = data.lastCompletionOrder + 1;
-            final result = _completeSingleItem(data, id.toString(), nextOrder);
-            if (result == _ItemCompleteResult.completedWithOrder) {
-              data.lastCompletionOrder = nextOrder;
-            }
-          }
-        }
-
-        if (decoded['addSubQuest'] is Map) {
-          final map = decoded['addSubQuest'] as Map<String, dynamic>;
-          final qId = map['quest'] as String? ?? '1';
-          final quest = _findQuest(data, qId);
-          if (quest != null) {
-            final nextSubNumber = _nextSuffixNumber(
-              quest.subQuests.map((sq) => sq.id),
-            );
-            final subId = '$qId.$nextSubNumber';
-            quest.subQuests.add(
-              SubQuest(
-                id: subId,
-                title: map['title'] as String? ?? 'New SubQuest',
-                status: TaskStatus.inProgress,
-              ),
-            );
-          }
-        }
-
-        if (decoded['vcs'] is Map) {
-          final map = decoded['vcs'] as Map<String, dynamic>;
-          final qId = map['quest'] as String? ?? '1';
-          final quest = _findQuest(data, qId);
-          if (quest != null) {
-            final files =
-                (map['files'] as List<dynamic>?)?.cast<String>() ?? const [];
-            quest.vcs = VcsState(
-              stage: VcsStage.fromJson(map['stage'] as String? ?? 'dirty'),
-              branch: map['branch'] as String?,
-              modifiedFiles: files,
-              details: map['details'] as String?,
-            );
-          }
-        }
-      }
+      _applyBatchMap(data, decoded);
     }
 
     await store.save(data);
     stdout.writeln('✔ Executed batch operations');
     return 0;
+  }
+
+  void _applyBatchList(SidequestData data, List<dynamic> list) {
+    for (final op in list) {
+      if (op is Map<String, dynamic>) {
+        _applyBatchOp(data, op);
+      }
+    }
+  }
+
+  void _applyBatchMap(SidequestData data, Map<String, dynamic> map) {
+    if (map['operations'] is List) {
+      _applyBatchList(data, map['operations'] as List);
+      return;
+    }
+    _applyLegacyBatchMap(data, map);
+  }
+
+  void _applyLegacyBatchMap(SidequestData data, Map<String, dynamic> map) {
+    if (map['complete'] is List) {
+      for (final id in map['complete'] as List) {
+        final nextOrder = data.lastCompletionOrder + 1;
+        final result = _completeSingleItem(data, id.toString(), nextOrder);
+        if (result == _ItemCompleteResult.completedWithOrder) {
+          data.lastCompletionOrder = nextOrder;
+        }
+      }
+    }
+
+    if (map['addSubQuest'] is Map) {
+      final sqMap = map['addSubQuest'] as Map<String, dynamic>;
+      final qId = sqMap['quest'] as String? ?? '1';
+      final quest = _findQuest(data, qId);
+      if (quest != null) {
+        final nextSubNumber = _nextSuffixNumber(
+          quest.subQuests.map((sq) => sq.id),
+        );
+        final subId = '$qId.$nextSubNumber';
+        quest.subQuests.add(
+          SubQuest(
+            id: subId,
+            title: sqMap['title'] as String? ?? 'New SubQuest',
+            status: TaskStatus.inProgress,
+          ),
+        );
+      }
+    }
+
+    if (map['vcs'] is Map) {
+      final vcsMap = map['vcs'] as Map<String, dynamic>;
+      final qId = vcsMap['quest'] as String? ?? '1';
+      final quest = _findQuest(data, qId);
+      if (quest != null) {
+        final files =
+            (vcsMap['files'] as List<dynamic>?)?.cast<String>() ?? const [];
+        quest.vcs = VcsState(
+          stage: VcsStage.fromJson(vcsMap['stage'] as String? ?? 'dirty'),
+          branch: vcsMap['branch'] as String?,
+          modifiedFiles: files,
+          details: vcsMap['details'] as String?,
+        );
+      }
+    }
   }
 
   void _applyBatchOp(SidequestData data, Map<String, dynamic> op) {
@@ -733,143 +793,156 @@ class SidequestCliRunner {
       case 'quest_add':
       case 'add_quest':
       case 'quest':
-        final title =
-            op['title']?.toString() ??
-            op['description']?.toString() ??
-            'New Main Quest';
-        final nextQuestNumber =
-            data.quests.map((q) => int.tryParse(q.id) ?? 0).fold(0, max) + 1;
-        data.quests.add(
-          MainQuest(
-            id: '$nextQuestNumber',
-            title: title,
-            status: QuestStatus.active,
-            vcs: const VcsState(stage: VcsStage.dirty),
-          ),
-        );
-        break;
+        _applyBatchQuestAdd(data, op);
       case 'complete':
       case 'done':
       case 'finish':
-        final rawIds = op['ids'] ?? op['id'];
-        final idList = rawIds is List
-            ? rawIds.map((e) => e.toString()).toList()
-            : [rawIds?.toString() ?? ''];
-        for (final id in idList.where((s) => s.isNotEmpty)) {
-          final nextOrder = data.lastCompletionOrder + 1;
-          final result = _completeSingleItem(data, id, nextOrder);
-          if (result == _ItemCompleteResult.completedWithOrder) {
-            data.lastCompletionOrder = nextOrder;
-          }
-        }
-        break;
+        _applyBatchComplete(data, op);
       case 'subquest_add':
       case 'add_subquest':
       case 'subquest':
-        final qId = op['questId']?.toString() ?? op['quest']?.toString() ?? '1';
-        final title =
-            op['title']?.toString() ??
-            op['description']?.toString() ??
-            'SubQuest';
-        final quest = data.quests.where((q) => q.id == qId).firstOrNull;
-        if (quest != null) {
-          final nextSubNumber = _nextSuffixNumber(
-            quest.subQuests.map((sq) => sq.id),
-          );
-          final subId = '$qId.$nextSubNumber';
-          quest.subQuests.add(
-            SubQuest(id: subId, title: title, status: TaskStatus.inProgress),
-          );
-        }
-        break;
+        _applyBatchSubQuestAdd(data, op);
       case 'step_add':
       case 'add_step':
       case 'step':
-        final subId =
-            op['subquestId']?.toString() ?? op['subquest']?.toString() ?? '1.1';
-        final title =
-            op['title']?.toString() ?? op['description']?.toString() ?? 'Step';
-        final sub = _findSubQuest(data, subId);
-        if (sub != null) {
-          final nextNumber = _nextSuffixNumber(sub.items.map((i) => i.id));
-          sub.items.add(
-            TaskItem(
-              id: '$subId.$nextNumber',
-              type: TaskType.step,
-              title: title,
-              status: TaskStatus.pending,
-            ),
-          );
-        }
-        break;
+        _applyBatchStepAdd(data, op);
       case 'blocker_add':
       case 'add_blocker':
       case 'blocker':
-        final subId =
-            op['subquestId']?.toString() ?? op['subquest']?.toString() ?? '1.1';
-        final title =
-            op['title']?.toString() ??
-            op['description']?.toString() ??
-            'Blocker';
-        final sub = _findSubQuest(data, subId);
-        if (sub != null) {
-          final nextNumber = _nextSuffixNumber(sub.items.map((i) => i.id));
-          sub.items.add(
-            TaskItem(
-              id: '$subId.$nextNumber',
-              type: TaskType.blocker,
-              title: title,
-              status: TaskStatus.inProgress,
-            ),
-          );
-        }
-        break;
+        _applyBatchBlockerAdd(data, op);
       case 'sidequest_add':
       case 'add_sidequest':
       case 'sidequest':
-        final title =
-            op['title']?.toString() ??
-            op['description']?.toString() ??
-            'Side Quest';
-        final isGlobal =
-            op['global'] == true ||
-            (op['quest'] == null && data.quests.isEmpty);
-        final isParked = op['parked'] == true;
-        final status = isParked
-            ? SideQuestStatus.parked
-            : SideQuestStatus.active;
-        final note = op['note']?.toString();
-
-        if (isGlobal || op['quest'] == null) {
-          final id = data.generateNextGlobalSideQuestId();
-          data.globalSideQuests.add(
-            SideQuest(id: id, title: title, status: status, note: note),
-          );
-        } else {
-          final qId = op['quest'].toString();
-          final quest = data.quests.where((q) => q.id == qId).firstOrNull;
-          if (quest != null) {
-            final id = data.generateNextSideQuestId(quest);
-            quest.sideQuests.add(
-              SideQuest(id: id, title: title, status: status, note: note),
-            );
-          }
-        }
-        break;
+        _applyBatchSideQuestAdd(data, op);
       case 'vcs':
-        final qId = op['quest']?.toString() ?? '1';
-        final quest = data.quests.where((q) => q.id == qId).firstOrNull;
-        if (quest != null) {
-          final files =
-              (op['files'] as List<dynamic>?)?.cast<String>() ?? const [];
-          quest.vcs = VcsState(
-            stage: VcsStage.fromJson(op['stage']?.toString() ?? 'dirty'),
-            branch: op['branch']?.toString(),
-            modifiedFiles: files,
-            details: op['details']?.toString(),
-          );
-        }
-        break;
+        _applyBatchVcs(data, op);
+    }
+  }
+
+  void _applyBatchQuestAdd(SidequestData data, Map<String, dynamic> op) {
+    final title =
+        op['title']?.toString() ??
+        op['description']?.toString() ??
+        'New Main Quest';
+    final nextQuestNumber =
+        data.quests.map((q) => int.tryParse(q.id) ?? 0).fold(0, max) + 1;
+    data.quests.add(
+      MainQuest(
+        id: '$nextQuestNumber',
+        title: title,
+        status: QuestStatus.active,
+        vcs: const VcsState(stage: VcsStage.dirty),
+      ),
+    );
+  }
+
+  void _applyBatchComplete(SidequestData data, Map<String, dynamic> op) {
+    final rawIds = op['ids'] ?? op['id'];
+    final idList = rawIds is List
+        ? rawIds.map((e) => e.toString()).toList()
+        : [rawIds?.toString() ?? ''];
+    for (final id in idList.where((s) => s.isNotEmpty)) {
+      final nextOrder = data.lastCompletionOrder + 1;
+      final result = _completeSingleItem(data, id, nextOrder);
+      if (result == _ItemCompleteResult.completedWithOrder) {
+        data.lastCompletionOrder = nextOrder;
+      }
+    }
+  }
+
+  void _applyBatchSubQuestAdd(SidequestData data, Map<String, dynamic> op) {
+    final qId = op['questId']?.toString() ?? op['quest']?.toString() ?? '1';
+    final title =
+        op['title']?.toString() ?? op['description']?.toString() ?? 'SubQuest';
+    final quest = data.quests.where((q) => q.id == qId).firstOrNull;
+    if (quest != null) {
+      final nextSubNumber = _nextSuffixNumber(
+        quest.subQuests.map((sq) => sq.id),
+      );
+      final subId = '$qId.$nextSubNumber';
+      quest.subQuests.add(
+        SubQuest(id: subId, title: title, status: TaskStatus.inProgress),
+      );
+    }
+  }
+
+  void _applyBatchStepAdd(SidequestData data, Map<String, dynamic> op) {
+    final subId =
+        op['subquestId']?.toString() ?? op['subquest']?.toString() ?? '1.1';
+    final title =
+        op['title']?.toString() ?? op['description']?.toString() ?? 'Step';
+    final sub = _findSubQuest(data, subId);
+    if (sub != null) {
+      final nextNumber = _nextSuffixNumber(sub.items.map((i) => i.id));
+      sub.items.add(
+        TaskItem(
+          id: '$subId.$nextNumber',
+          type: TaskType.step,
+          title: title,
+          status: TaskStatus.pending,
+        ),
+      );
+    }
+  }
+
+  void _applyBatchBlockerAdd(SidequestData data, Map<String, dynamic> op) {
+    final subId =
+        op['subquestId']?.toString() ?? op['subquest']?.toString() ?? '1.1';
+    final title =
+        op['title']?.toString() ?? op['description']?.toString() ?? 'Blocker';
+    final sub = _findSubQuest(data, subId);
+    if (sub != null) {
+      final nextNumber = _nextSuffixNumber(sub.items.map((i) => i.id));
+      sub.items.add(
+        TaskItem(
+          id: '$subId.$nextNumber',
+          type: TaskType.blocker,
+          title: title,
+          status: TaskStatus.inProgress,
+        ),
+      );
+    }
+  }
+
+  void _applyBatchSideQuestAdd(SidequestData data, Map<String, dynamic> op) {
+    final title =
+        op['title']?.toString() ??
+        op['description']?.toString() ??
+        'Side Quest';
+    final isGlobal =
+        op['global'] == true || (op['quest'] == null && data.quests.isEmpty);
+    final isParked = op['parked'] == true;
+    final status = isParked ? SideQuestStatus.parked : SideQuestStatus.active;
+    final note = op['note']?.toString();
+
+    if (isGlobal || op['quest'] == null) {
+      final id = data.generateNextGlobalSideQuestId();
+      data.globalSideQuests.add(
+        SideQuest(id: id, title: title, status: status, note: note),
+      );
+    } else {
+      final qId = op['quest'].toString();
+      final quest = data.quests.where((q) => q.id == qId).firstOrNull;
+      if (quest != null) {
+        final id = data.generateNextSideQuestId(quest);
+        quest.sideQuests.add(
+          SideQuest(id: id, title: title, status: status, note: note),
+        );
+      }
+    }
+  }
+
+  void _applyBatchVcs(SidequestData data, Map<String, dynamic> op) {
+    final qId = op['quest']?.toString() ?? '1';
+    final quest = data.quests.where((q) => q.id == qId).firstOrNull;
+    if (quest != null) {
+      final files = (op['files'] as List<dynamic>?)?.cast<String>() ?? const [];
+      quest.vcs = VcsState(
+        stage: VcsStage.fromJson(op['stage']?.toString() ?? 'dirty'),
+        branch: op['branch']?.toString(),
+        modifiedFiles: files,
+        details: op['details']?.toString(),
+      );
     }
   }
 

--- a/skills/sidequest/lib/src/cli/command_runner.dart
+++ b/skills/sidequest/lib/src/cli/command_runner.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:math';
 
-import 'package:args/args.dart';
+import 'package:args/command_runner.dart';
 
 import '../models/enums.dart';
 import '../models/sidequest_data.dart';
@@ -16,74 +16,105 @@ enum _ItemCompleteResult {
   notFound,
 }
 
-class SidequestCliRunner {
-  final SessionStore store;
+/// Standard [CommandRunner] for the `sidequest` CLI tool.
+class SidequestCliRunner extends CommandRunner<int> {
+  SessionStore? _store;
 
-  SidequestCliRunner({required this.store});
+  SidequestCliRunner({SessionStore? store})
+    : _store = store,
+      super('sidequest', 'Deterministic session map manager') {
+    argParser.addOption(
+      'dir',
+      help: 'Path to session artifact directory containing sidequest.json',
+    );
 
-  Future<int> run(List<String> args) async {
-    if (args.contains('--help') || args.contains('-h')) {
-      _printUsage();
+    addCommand(StatusCommand(this));
+    addCommand(InitCommand(this));
+    addCommand(QuestCommand(this));
+    addCommand(SubQuestCommand(this));
+    addCommand(StepCommand(this));
+    addCommand(BlockerCommand(this));
+    addCommand(SideQuestCommand(this));
+    addCommand(CompleteCommand(this));
+    addCommand(ReopenCommand(this));
+    addCommand(RemoveCommand(this));
+    addCommand(VcsCommand(this));
+    addCommand(BatchCommand(this));
+    addCommand(RenderCommand(this));
+    addCommand(MergeAuditCommand(this));
+  }
+
+  SessionStore get store => _store ??= SessionStore();
+
+  @override
+  Future<int> run(Iterable<String> args) async {
+    final argsList = args.toList();
+
+    if (argsList.contains('-h') ||
+        argsList.contains('--help') ||
+        (argsList.isNotEmpty && argsList.first == 'help')) {
+      printUsage();
       return 0;
     }
 
-    if (args.isEmpty) {
+    if (argsList.isEmpty) {
       final existing = await store.load();
       if (existing != null && existing.quests.isNotEmpty) {
-        return await _handleStatus();
+        return await StatusCommand(this).run();
       }
-      _printUsage();
+      printUsage();
       return 0;
     }
 
-    final command = args[0];
-    final subArgs = args.sublist(1);
-
     try {
-      switch (command) {
-        case 'help':
-          _printUsage();
-          return 0;
-        case 'status':
-          return await _handleStatus();
-        case 'init':
-          return await _handleInit(subArgs);
-        case 'quest':
-          return await _handleQuest(subArgs);
-        case 'subquest':
-          return await _handleSubQuest(subArgs);
-        case 'step':
-          return await _handleStep(subArgs);
-        case 'blocker':
-          return await _handleBlocker(subArgs);
-        case 'sidequest':
-          return await _handleSideQuest(subArgs);
-        case 'complete':
-          return await _handleComplete(subArgs);
-        case 'reopen':
-          return await _handleReopen(subArgs);
-        case 'remove':
-          return await _handleRemove(subArgs);
-        case 'vcs':
-          return await _handleVcs(subArgs);
-        case 'batch':
-          return await _handleBatch(subArgs);
-        case 'render':
-          return await _handleRender();
-        case 'merge-audit':
-          return await _handleMergeAudit(subArgs);
-        default:
-          stderr.writeln('Error: Unknown command "$command".');
-          _printUsage();
-          return 1;
+      final results = parse(argsList);
+      if (results.wasParsed('dir') && _store == null) {
+        _store = SessionStore(directory: results['dir'] as String);
       }
+      final exitCode = await runCommand(results);
+      return exitCode ?? 0;
+    } on UsageException catch (e) {
+      stderr.writeln(e.message);
+      stderr.writeln();
+      stderr.writeln(e.usage);
+      return 1;
     } catch (e) {
-      stderr.writeln('Error running sidequest command "$command": $e');
+      stderr.writeln('Error: $e');
       return 1;
     }
   }
+}
 
-  Future<int> _handleStatus() async {
+/// Abstract base class for all `sidequest` commands.
+abstract class SidequestCommand extends Command<int> {
+  final SidequestCliRunner runner;
+
+  SidequestCommand(this.runner);
+
+  SessionStore get store => runner.store;
+
+  Future<SidequestData> requireData() async {
+    var data = await store.load();
+    if (data == null) {
+      data = SidequestData.initial(firstQuestTitle: 'Main Quest 1');
+      await store.save(data);
+    }
+    return data;
+  }
+}
+
+/// `sidequest status` command.
+class StatusCommand extends SidequestCommand {
+  @override
+  final String name = 'status';
+
+  @override
+  final String description = 'Print compact 10-line session overview.';
+
+  StatusCommand(super.runner);
+
+  @override
+  Future<int> run() async {
     final data = await store.load();
     if (data == null || data.quests.isEmpty) {
       stdout.writeln(
@@ -114,188 +145,157 @@ class SidequestCliRunner {
 
     return 0;
   }
+}
 
-  void _printVcsStatus(VcsState vcs) {
-    final branch = vcs.branch ?? 'N/A';
-    final files = vcs.modifiedFiles.isEmpty
-        ? 'none'
-        : vcs.modifiedFiles.join(', ');
-    stdout.writeln(
-      '   VCS: ${vcs.stage.badge} | Branch: $branch | Modified: $files',
-    );
-  }
+/// `sidequest init [title]` command.
+class InitCommand extends SidequestCommand {
+  @override
+  final String name = 'init';
 
-  void _printBlockers(List<SubQuest> subQuests) {
-    final blockers = <String>[];
-    for (final sq in subQuests) {
-      for (final item in sq.items) {
-        if (item.status != TaskStatus.completed &&
-            item.type == TaskType.blocker) {
-          blockers.add('👾 Blocker ${item.id}: "${item.title}"');
-        }
-      }
-    }
+  @override
+  final String description = 'Initialize sidequest session map.';
 
-    if (blockers.isNotEmpty) {
-      stdout.writeln('   Blockers:');
-      for (final b in blockers) {
-        stdout.writeln('     * $b');
-      }
-    }
-  }
+  InitCommand(super.runner);
 
-  void _printSubQuests(List<SubQuest> subQuests, int lastCompletionOrder) {
-    if (subQuests.isEmpty) return;
-
-    stdout.writeln('   Sub-Quests & Steps:');
-    for (final sq in subQuests) {
-      final doneStr = sq.status == TaskStatus.completed
-          ? '✔ (Done)'
-          : '⏳ (In Progress)';
-      stdout.writeln('     🛡️  Sub-Quest ${sq.id}: "${sq.title}" $doneStr');
-      for (final item in sq.items) {
-        _printTaskItem(item, lastCompletionOrder);
-      }
-    }
-  }
-
-  void _printTaskItem(TaskItem item, int lastCompletionOrder) {
-    final itemDone = item.status == TaskStatus.completed ? '✔' : ' ';
-    final icon = item.type == TaskType.blocker ? '👾' : '👣';
-    final order = item.completionOrder != null
-        ? (item.completionOrder == lastCompletionOrder
-              ? '[#${item.completionOrder} ⭐]'
-              : '[#${item.completionOrder}]')
-        : '';
-    final orderStr = order.isNotEmpty ? '$order ' : '';
-    stdout.writeln(
-      '        [$itemDone] $orderStr$icon ${item.id}: "${item.title}"',
-    );
-  }
-
-  void _printSideQuests(List<SideQuest> sideQuests) {
-    if (sideQuests.isEmpty) return;
-
-    stdout.writeln('   🌿 Side Quests:');
-    for (final sq in sideQuests) {
-      final statusIcon = switch (sq.status) {
-        SideQuestStatus.completed => '✔ Completed',
-        SideQuestStatus.parked => '🎒 Parked',
-        SideQuestStatus.active => '⚡ Active',
-      };
-      final note = sq.note != null ? ' (${sq.note})' : '';
-      stdout.writeln('     * [$statusIcon] ${sq.id}: "${sq.title}"$note');
-    }
-  }
-
-  Future<int> _handleInit(List<String> args) async {
-    final title = args.isNotEmpty ? args.join(' ') : 'Main Quest 1';
+  @override
+  Future<int> run() async {
+    final title = argResults?.rest.isNotEmpty == true
+        ? argResults!.rest.join(' ')
+        : 'Main Quest 1';
     final data = SidequestData.initial(firstQuestTitle: title);
     await store.save(data);
     stdout.writeln('✔ Initialized sidequest.json & rendered sidequest.md');
     return 0;
   }
+}
 
-  Future<int> _handleQuest(List<String> args) async {
-    if (args.isEmpty) {
-      stderr.writeln('Usage: quest <add|activate|pause> [args]');
-      return 1;
-    }
-    final action = args[0];
-    final data = await _requireData();
+/// `sidequest quest` command.
+class QuestCommand extends SidequestCommand {
+  @override
+  final String name = 'quest';
 
-    switch (action) {
-      case 'add':
-        final title = args.length > 1
-            ? args.sublist(1).join(' ')
-            : 'New Main Quest';
-        final nextQuestNumber =
-            data.quests.map((q) => int.tryParse(q.id) ?? 0).fold(0, max) + 1;
-        final newId = '$nextQuestNumber';
-        data.quests.add(
-          MainQuest(
-            id: newId,
-            title: title,
-            status: QuestStatus.active,
-            vcs: const VcsState(stage: VcsStage.dirty),
-          ),
-        );
-        await store.save(data);
-        stdout.writeln('✔ Added Main Quest $newId: "$title"');
-        return 0;
-      case 'activate':
-        final id = args.length > 1 ? args[1] : '1';
-        final quest = _findQuest(data, id);
-        if (quest == null) return 1;
-        quest.status = QuestStatus.active;
-        await store.save(data);
-        stdout.writeln('✔ Activated Main Quest $id');
-        return 0;
-      case 'pause':
-        final parser = ArgParser()..addOption('reason');
-        final results = parser.parse(args.sublist(1));
-        final id = results.rest.isNotEmpty ? results.rest[0] : '1';
-        final quest = _findQuest(data, id);
-        if (quest == null) return 1;
-        quest.status = QuestStatus.paused;
-        if (results['reason'] != null) {
-          quest.statusNote = results['reason'] as String;
-        }
-        await store.save(data);
-        stdout.writeln('✔ Paused Main Quest $id');
-        return 0;
-      default:
-        stderr.writeln('Error: Unknown quest action "$action"');
-        return 1;
-    }
+  @override
+  final String description = 'Manage main quests.';
+
+  QuestCommand(super.runner) {
+    addSubcommand(QuestAddCommand(runner));
+    addSubcommand(QuestActivateCommand(runner));
+    addSubcommand(QuestPauseCommand(runner));
   }
+}
 
-  int _nextSuffixNumber(Iterable<String> ids) =>
-      ids.map((id) => int.tryParse(id.split('.').last) ?? 0).fold(0, max) + 1;
+class QuestAddCommand extends SidequestCommand {
+  @override
+  final String name = 'add';
 
-  Future<int> _handleTaskItem({
-    required List<String> args,
-    required TaskType type,
-    required String commandName,
-    required String label,
-    required TaskStatus defaultStatus,
-  }) async {
-    final effectiveArgs = args.isNotEmpty && args[0] == 'add'
-        ? args.sublist(1)
-        : args;
+  @override
+  final String description = 'Add a new main quest.';
 
-    if (effectiveArgs.length < 2) {
-      stderr.writeln('Usage: $commandName [add] <subquest-id> <title>');
-      return 1;
-    }
-    final subId = effectiveArgs[0];
-    final title = effectiveArgs.sublist(1).join(' ');
-    final data = await _requireData();
-    final sub = _findSubQuest(data, subId);
-    if (sub == null) return 1;
+  QuestAddCommand(super.runner);
 
-    final nextItemNumber = _nextSuffixNumber(sub.items.map((item) => item.id));
-    final itemId = '$subId.$nextItemNumber';
-    sub.items.add(
-      TaskItem(id: itemId, type: type, title: title, status: defaultStatus),
+  @override
+  Future<int> run() async {
+    final title = argResults?.rest.isNotEmpty == true
+        ? argResults!.rest.join(' ')
+        : 'New Main Quest';
+    final data = await requireData();
+    final nextQuestNumber =
+        data.quests.map((q) => int.tryParse(q.id) ?? 0).fold(0, max) + 1;
+    final newId = '$nextQuestNumber';
+    data.quests.add(
+      MainQuest(
+        id: newId,
+        title: title,
+        status: QuestStatus.active,
+        vcs: const VcsState(stage: VcsStage.dirty),
+      ),
     );
     await store.save(data);
-    stdout.writeln('✔ Added $label $itemId: "$title"');
+    stdout.writeln('✔ Added Main Quest $newId: "$title"');
     return 0;
   }
+}
 
-  Future<int> _handleSubQuest(List<String> args) async {
-    final effectiveArgs = args.isNotEmpty && args[0] == 'add'
-        ? args.sublist(1)
-        : args;
+class QuestActivateCommand extends SidequestCommand {
+  @override
+  final String name = 'activate';
 
-    if (effectiveArgs.length < 2) {
-      stderr.writeln('Usage: subquest [add] <quest-id> <title>');
-      return 1;
+  @override
+  final String description = 'Activate a main quest.';
+
+  QuestActivateCommand(super.runner);
+
+  @override
+  Future<int> run() async {
+    final id = argResults?.rest.firstOrNull ?? '1';
+    final data = await requireData();
+    final quest = _findQuest(data, id);
+    if (quest == null) return 1;
+    quest.status = QuestStatus.active;
+    await store.save(data);
+    stdout.writeln('✔ Activated Main Quest $id');
+    return 0;
+  }
+}
+
+class QuestPauseCommand extends SidequestCommand {
+  @override
+  final String name = 'pause';
+
+  @override
+  final String description = 'Pause a main quest.';
+
+  QuestPauseCommand(super.runner) {
+    argParser.addOption('reason', help: 'Reason for pausing the quest.');
+  }
+
+  @override
+  Future<int> run() async {
+    final id = argResults?.rest.firstOrNull ?? '1';
+    final data = await requireData();
+    final quest = _findQuest(data, id);
+    if (quest == null) return 1;
+    quest.status = QuestStatus.paused;
+    if (argResults?['reason'] != null) {
+      quest.statusNote = argResults!['reason'] as String;
     }
-    final questId = effectiveArgs[0];
-    final title = effectiveArgs.sublist(1).join(' ');
-    final data = await _requireData();
+    await store.save(data);
+    stdout.writeln('✔ Paused Main Quest $id');
+    return 0;
+  }
+}
+
+/// `sidequest subquest` command.
+class SubQuestCommand extends SidequestCommand {
+  @override
+  final String name = 'subquest';
+
+  @override
+  final String description = 'Manage sub-quests.';
+
+  SubQuestCommand(super.runner) {
+    addSubcommand(SubQuestAddCommand(runner));
+  }
+}
+
+class SubQuestAddCommand extends SidequestCommand {
+  @override
+  final String name = 'add';
+
+  @override
+  final String description = 'Add a sub-quest under a main quest.';
+
+  SubQuestAddCommand(super.runner);
+
+  @override
+  Future<int> run() async {
+    final rest = argResults?.rest ?? const [];
+    if (rest.length < 2) {
+      usageException('Usage: subquest add <quest-id> <title>');
+    }
+    final questId = rest[0];
+    final title = rest.sublist(1).join(' ');
+    final data = await requireData();
     final quest = _findQuest(data, questId);
     if (quest == null) return 1;
 
@@ -308,35 +308,139 @@ class SidequestCliRunner {
     stdout.writeln('✔ Added Sub-Quest $subId: "$title"');
     return 0;
   }
+}
 
-  Future<int> _handleStep(List<String> args) => _handleTaskItem(
-    args: args,
-    type: TaskType.step,
-    commandName: 'step',
-    label: 'Step',
-    defaultStatus: TaskStatus.pending,
-  );
+/// `sidequest step` command.
+class StepCommand extends SidequestCommand {
+  @override
+  final String name = 'step';
 
-  Future<int> _handleBlocker(List<String> args) => _handleTaskItem(
-    args: args,
-    type: TaskType.blocker,
-    commandName: 'blocker',
-    label: 'Blocker',
-    defaultStatus: TaskStatus.inProgress,
-  );
+  @override
+  final String description = 'Manage planned steps.';
 
-  Future<int> _handleSideQuest(List<String> args) async {
-    final effectiveArgs = args.isNotEmpty && args[0] == 'add'
-        ? args.sublist(1)
-        : args;
+  StepCommand(super.runner) {
+    addSubcommand(StepAddCommand(runner));
+  }
+}
 
-    final parser = ArgParser()
-      ..addOption('quest')
-      ..addFlag('global', defaultsTo: false)
-      ..addFlag('parked', defaultsTo: false)
-      ..addOption('note');
+class StepAddCommand extends SidequestCommand {
+  @override
+  final String name = 'add';
 
-    final results = parser.parse(effectiveArgs);
+  @override
+  final String description = 'Add a planned step under a sub-quest.';
+
+  StepAddCommand(super.runner);
+
+  @override
+  Future<int> run() async {
+    final rest = argResults?.rest ?? const [];
+    if (rest.length < 2) {
+      usageException('Usage: step add <subquest-id> <title>');
+    }
+    final subId = rest[0];
+    final title = rest.sublist(1).join(' ');
+    final data = await requireData();
+    final sub = _findSubQuest(data, subId);
+    if (sub == null) return 1;
+
+    final nextItemNumber = _nextSuffixNumber(sub.items.map((item) => item.id));
+    final itemId = '$subId.$nextItemNumber';
+    sub.items.add(
+      TaskItem(
+        id: itemId,
+        type: TaskType.step,
+        title: title,
+        status: TaskStatus.pending,
+      ),
+    );
+    await store.save(data);
+    stdout.writeln('✔ Added Step $itemId: "$title"');
+    return 0;
+  }
+}
+
+/// `sidequest blocker` command.
+class BlockerCommand extends SidequestCommand {
+  @override
+  final String name = 'blocker';
+
+  @override
+  final String description = 'Manage unplanned blockers.';
+
+  BlockerCommand(super.runner) {
+    addSubcommand(BlockerAddCommand(runner));
+  }
+}
+
+class BlockerAddCommand extends SidequestCommand {
+  @override
+  final String name = 'add';
+
+  @override
+  final String description = 'Add an unplanned blocker under a sub-quest.';
+
+  BlockerAddCommand(super.runner);
+
+  @override
+  Future<int> run() async {
+    final rest = argResults?.rest ?? const [];
+    if (rest.length < 2) {
+      usageException('Usage: blocker add <subquest-id> <title>');
+    }
+    final subId = rest[0];
+    final title = rest.sublist(1).join(' ');
+    final data = await requireData();
+    final sub = _findSubQuest(data, subId);
+    if (sub == null) return 1;
+
+    final nextItemNumber = _nextSuffixNumber(sub.items.map((item) => item.id));
+    final itemId = '$subId.$nextItemNumber';
+    sub.items.add(
+      TaskItem(
+        id: itemId,
+        type: TaskType.blocker,
+        title: title,
+        status: TaskStatus.inProgress,
+      ),
+    );
+    await store.save(data);
+    stdout.writeln('✔ Added Blocker $itemId: "$title"');
+    return 0;
+  }
+}
+
+/// `sidequest sidequest` command.
+class SideQuestCommand extends SidequestCommand {
+  @override
+  final String name = 'sidequest';
+
+  @override
+  final String description = 'Manage tangents and side quests.';
+
+  SideQuestCommand(super.runner) {
+    addSubcommand(SideQuestAddCommand(runner));
+  }
+}
+
+class SideQuestAddCommand extends SidequestCommand {
+  @override
+  final String name = 'add';
+
+  @override
+  final String description = 'Add a side quest.';
+
+  SideQuestAddCommand(super.runner) {
+    argParser
+      ..addOption('quest', help: 'Scope to a specific main quest ID.')
+      ..addFlag('global', defaultsTo: false, help: 'Scope globally.')
+      ..addFlag('parked', defaultsTo: false, help: 'Start in parked status.')
+      ..addOption('note', help: 'Optional tracking note.');
+  }
+
+  @override
+  Future<int> run() async {
+    final results = argResults!;
     final title = results.rest.isNotEmpty
         ? results.rest.join(' ')
         : 'New Side Quest';
@@ -344,7 +448,7 @@ class SidequestCliRunner {
     final status = isParked ? SideQuestStatus.parked : SideQuestStatus.active;
     final note = results['note'] as String?;
 
-    final data = await _requireData();
+    final data = await requireData();
     final isGlobal =
         (results['global'] as bool) ||
         (results['quest'] == null && data.quests.isEmpty);
@@ -369,20 +473,25 @@ class SidequestCliRunner {
     }
     return 0;
   }
+}
 
-  List<String> _extractIds(List<String> args) => args
-      .expand((arg) => arg.split(','))
-      .map((s) => s.trim())
-      .where((s) => s.isNotEmpty)
-      .toList();
+/// `sidequest complete <id...>` command.
+class CompleteCommand extends SidequestCommand {
+  @override
+  final String name = 'complete';
 
-  Future<int> _handleComplete(List<String> args) async {
-    final ids = _extractIds(args);
+  @override
+  final String description = 'Mark one or more items completed.';
+
+  CompleteCommand(super.runner);
+
+  @override
+  Future<int> run() async {
+    final ids = _extractIds(argResults?.rest ?? const []);
     if (ids.isEmpty) {
-      stderr.writeln('Usage: complete <id> [id2] [id3]...');
-      return 1;
+      usageException('Usage: complete <id> [id2] [id3]...');
     }
-    final data = await _requireData();
+    final data = await requireData();
     final completedIds = <String>[];
     final alreadyCompletedIds = <String>[];
     final notFoundIds = <String>[];
@@ -420,92 +529,25 @@ class SidequestCliRunner {
     }
     return 0;
   }
+}
 
-  _ItemCompleteResult _completeSingleItem(
-    SidequestData data,
-    String id,
-    int nextOrder,
-  ) {
-    for (final q in data.quests) {
-      final qResult = _completeQuest(q, id, nextOrder);
-      if (qResult != _ItemCompleteResult.notFound) return qResult;
-    }
+/// `sidequest reopen <id...>` command.
+class ReopenCommand extends SidequestCommand {
+  @override
+  final String name = 'reopen';
 
-    for (final sq in data.globalSideQuests) {
-      final sqResult = _completeSideQuest(sq, id, nextOrder);
-      if (sqResult != _ItemCompleteResult.notFound) return sqResult;
-    }
+  @override
+  final String description = 'Reopen one or more completed items.';
 
-    return _ItemCompleteResult.notFound;
-  }
+  ReopenCommand(super.runner);
 
-  _ItemCompleteResult _completeQuest(MainQuest q, String id, int nextOrder) {
-    if (q.id == id) {
-      if (q.status == QuestStatus.completed) {
-        return _ItemCompleteResult.alreadyCompleted;
-      }
-      q.status = QuestStatus.completed;
-      return _ItemCompleteResult.completedNoOrder;
-    }
-
-    for (final sq in q.subQuests) {
-      final sqResult = _completeSubQuest(sq, id, nextOrder);
-      if (sqResult != _ItemCompleteResult.notFound) return sqResult;
-    }
-
-    for (final sq in q.sideQuests) {
-      final sqResult = _completeSideQuest(sq, id, nextOrder);
-      if (sqResult != _ItemCompleteResult.notFound) return sqResult;
-    }
-
-    return _ItemCompleteResult.notFound;
-  }
-
-  _ItemCompleteResult _completeSubQuest(SubQuest sq, String id, int nextOrder) {
-    if (sq.id == id) {
-      if (sq.status == TaskStatus.completed) {
-        return _ItemCompleteResult.alreadyCompleted;
-      }
-      sq.status = TaskStatus.completed;
-      sq.completionOrder = nextOrder;
-      return _ItemCompleteResult.completedWithOrder;
-    }
-
-    for (final item in sq.items) {
-      if (item.id == id) {
-        if (item.status == TaskStatus.completed) {
-          return _ItemCompleteResult.alreadyCompleted;
-        }
-        item.status = TaskStatus.completed;
-        item.completionOrder = nextOrder;
-        return _ItemCompleteResult.completedWithOrder;
-      }
-    }
-
-    return _ItemCompleteResult.notFound;
-  }
-
-  _ItemCompleteResult _completeSideQuest(
-    SideQuest sq,
-    String id,
-    int nextOrder,
-  ) {
-    if (sq.id != id) return _ItemCompleteResult.notFound;
-    if (sq.status == SideQuestStatus.completed) {
-      return _ItemCompleteResult.alreadyCompleted;
-    }
-    sq.status = SideQuestStatus.completed;
-    sq.completionOrder = nextOrder;
-    return _ItemCompleteResult.completedWithOrder;
-  }
-
-  Future<int> _handleReopen(List<String> args) async {
-    final ids = _extractIds(args);
+  @override
+  Future<int> run() async {
+    final ids = _extractIds(argResults?.rest ?? const []);
     if (ids.isEmpty) {
-      stderr.writeln('Usage: reopen <id> [id2]...');
-      return 1;
+      usageException('Usage: reopen <id> [id2]...');
     }
-    final data = await _requireData();
+    final data = await requireData();
     final reopenedIds = <String>[];
     final notFoundIds = <String>[];
 
@@ -528,59 +570,25 @@ class SidequestCliRunner {
     }
     return 0;
   }
+}
 
-  bool _reopenSingleItem(SidequestData data, String id) {
-    for (final q in data.quests) {
-      if (_reopenQuest(q, id)) return true;
-    }
+/// `sidequest remove <id...>` command.
+class RemoveCommand extends SidequestCommand {
+  @override
+  final String name = 'remove';
 
-    for (final sq in data.globalSideQuests) {
-      if (sq.id == id) {
-        sq.status = SideQuestStatus.active;
-        sq.completionOrder = null;
-        return true;
-      }
-    }
+  @override
+  final String description = 'Remove one or more items.';
 
-    return false;
-  }
+  RemoveCommand(super.runner);
 
-  bool _reopenQuest(MainQuest q, String id) {
-    if (q.id == id) {
-      q.status = QuestStatus.active;
-      return true;
-    }
-    for (final sq in q.subQuests) {
-      if (sq.id == id) {
-        sq.status = TaskStatus.inProgress;
-        sq.completionOrder = null;
-        return true;
-      }
-      for (final item in sq.items) {
-        if (item.id == id) {
-          item.status = TaskStatus.pending;
-          item.completionOrder = null;
-          return true;
-        }
-      }
-    }
-    for (final sq in q.sideQuests) {
-      if (sq.id == id) {
-        sq.status = SideQuestStatus.active;
-        sq.completionOrder = null;
-        return true;
-      }
-    }
-    return false;
-  }
-
-  Future<int> _handleRemove(List<String> args) async {
-    final ids = _extractIds(args);
+  @override
+  Future<int> run() async {
+    final ids = _extractIds(argResults?.rest ?? const []);
     if (ids.isEmpty) {
-      stderr.writeln('Usage: remove <id> [id2]...');
-      return 1;
+      usageException('Usage: remove <id> [id2]...');
     }
-    final data = await _requireData();
+    final data = await requireData();
     final removedIds = <String>[];
     final notFoundIds = <String>[];
 
@@ -603,49 +611,29 @@ class SidequestCliRunner {
     }
     return 0;
   }
+}
 
-  bool _removeSingleItem(SidequestData data, String id) {
-    bool found = false;
-    if (data.quests.any((q) => q.id == id)) {
-      data.quests.removeWhere((q) => q.id == id);
-      return true;
-    }
+/// `sidequest vcs <qId>` command.
+class VcsCommand extends SidequestCommand {
+  @override
+  final String name = 'vcs';
 
-    for (final q in data.quests) {
-      if (q.subQuests.any((sq) => sq.id == id)) {
-        q.subQuests.removeWhere((sq) => sq.id == id);
-        found = true;
-      }
-      for (final sq in q.subQuests) {
-        if (sq.items.any((item) => item.id == id)) {
-          sq.items.removeWhere((item) => item.id == id);
-          found = true;
-        }
-      }
-      if (q.sideQuests.any((sq) => sq.id == id)) {
-        q.sideQuests.removeWhere((sq) => sq.id == id);
-        found = true;
-      }
-    }
+  @override
+  final String description = 'Update VCS state for a main quest.';
 
-    if (data.globalSideQuests.any((sq) => sq.id == id)) {
-      data.globalSideQuests.removeWhere((sq) => sq.id == id);
-      found = true;
-    }
-
-    return found;
-  }
-
-  Future<int> _handleVcs(List<String> args) async {
-    final parser = ArgParser()
+  VcsCommand(super.runner) {
+    argParser
       ..addOption('stage', defaultsTo: 'dirty')
       ..addOption('branch')
       ..addOption('files')
       ..addOption('details');
+  }
 
-    final results = parser.parse(args);
+  @override
+  Future<int> run() async {
+    final results = argResults!;
     final qId = results.rest.isNotEmpty ? results.rest[0] : '1';
-    final data = await _requireData();
+    final data = await requireData();
     final quest = _findQuest(data, qId);
     if (quest == null) return 1;
 
@@ -669,14 +657,26 @@ class SidequestCliRunner {
     stdout.writeln('✔ Updated VCS state for Main Quest $qId');
     return 0;
   }
+}
 
-  Future<int> _handleBatch(List<String> args) async {
-    if (args.isEmpty) {
-      stderr.writeln('Usage: batch <json-string>');
-      return 1;
+/// `sidequest batch <json>` command.
+class BatchCommand extends SidequestCommand {
+  @override
+  final String name = 'batch';
+
+  @override
+  final String description = 'Execute multiple mutations in a single call.';
+
+  BatchCommand(super.runner);
+
+  @override
+  Future<int> run() async {
+    final rest = argResults?.rest ?? const [];
+    if (rest.isEmpty) {
+      usageException('Usage: batch <json-string>');
     }
-    final decoded = jsonDecode(args[0]);
-    final data = await _requireData();
+    final decoded = jsonDecode(rest[0]);
+    final data = await requireData();
 
     if (decoded is List) {
       _applyBatchList(data, decoded);
@@ -688,219 +688,20 @@ class SidequestCliRunner {
     stdout.writeln('✔ Executed batch operations');
     return 0;
   }
+}
 
-  void _applyBatchList(SidequestData data, List<dynamic> list) {
-    for (final op in list) {
-      if (op is Map<String, dynamic>) {
-        _applyBatchOp(data, op);
-      }
-    }
-  }
+/// `sidequest render` command.
+class RenderCommand extends SidequestCommand {
+  @override
+  final String name = 'render';
 
-  void _applyBatchMap(SidequestData data, Map<String, dynamic> map) {
-    if (map['operations'] is List) {
-      _applyBatchList(data, map['operations'] as List);
-      return;
-    }
-    _applyLegacyBatchMap(data, map);
-  }
+  @override
+  final String description = 'Re-render sidequest.md from sidequest.json.';
 
-  void _applyLegacyBatchMap(SidequestData data, Map<String, dynamic> map) {
-    if (map['complete'] is List) {
-      for (final id in map['complete'] as List) {
-        final nextOrder = data.lastCompletionOrder + 1;
-        final result = _completeSingleItem(data, id.toString(), nextOrder);
-        if (result == _ItemCompleteResult.completedWithOrder) {
-          data.lastCompletionOrder = nextOrder;
-        }
-      }
-    }
+  RenderCommand(super.runner);
 
-    if (map['addSubQuest'] is Map) {
-      final sqMap = map['addSubQuest'] as Map<String, dynamic>;
-      final qId = sqMap['quest'] as String? ?? '1';
-      final quest = _findQuest(data, qId);
-      if (quest != null) {
-        final nextSubNumber = _nextSuffixNumber(
-          quest.subQuests.map((sq) => sq.id),
-        );
-        final subId = '$qId.$nextSubNumber';
-        quest.subQuests.add(
-          SubQuest(
-            id: subId,
-            title: sqMap['title'] as String? ?? 'New SubQuest',
-            status: TaskStatus.inProgress,
-          ),
-        );
-      }
-    }
-
-    if (map['vcs'] is Map) {
-      final vcsMap = map['vcs'] as Map<String, dynamic>;
-      final qId = vcsMap['quest'] as String? ?? '1';
-      final quest = _findQuest(data, qId);
-      if (quest != null) {
-        final files =
-            (vcsMap['files'] as List<dynamic>?)?.cast<String>() ?? const [];
-        quest.vcs = VcsState(
-          stage: VcsStage.fromJson(vcsMap['stage'] as String? ?? 'dirty'),
-          branch: vcsMap['branch'] as String?,
-          modifiedFiles: files,
-          details: vcsMap['details'] as String?,
-        );
-      }
-    }
-  }
-
-  void _applyBatchOp(SidequestData data, Map<String, dynamic> op) {
-    final type = (op['type'] as String? ?? '').toLowerCase();
-
-    switch (type) {
-      case 'quest_add':
-        _applyBatchQuestAdd(data, op);
-      case 'complete':
-        _applyBatchComplete(data, op);
-      case 'subquest_add':
-        _applyBatchSubQuestAdd(data, op);
-      case 'step_add':
-        _applyBatchStepAdd(data, op);
-      case 'blocker_add':
-        _applyBatchBlockerAdd(data, op);
-      case 'sidequest_add':
-        _applyBatchSideQuestAdd(data, op);
-      case 'vcs':
-        _applyBatchVcs(data, op);
-    }
-  }
-
-  void _applyBatchQuestAdd(SidequestData data, Map<String, dynamic> op) {
-    final title =
-        op['title']?.toString() ??
-        op['description']?.toString() ??
-        'New Main Quest';
-    final nextQuestNumber =
-        data.quests.map((q) => int.tryParse(q.id) ?? 0).fold(0, max) + 1;
-    data.quests.add(
-      MainQuest(
-        id: '$nextQuestNumber',
-        title: title,
-        status: QuestStatus.active,
-        vcs: const VcsState(stage: VcsStage.dirty),
-      ),
-    );
-  }
-
-  void _applyBatchComplete(SidequestData data, Map<String, dynamic> op) {
-    final rawIds = op['ids'] ?? op['id'];
-    final idList = rawIds is List
-        ? rawIds.map((e) => e.toString()).toList()
-        : [rawIds?.toString() ?? ''];
-    for (final id in idList.where((s) => s.isNotEmpty)) {
-      final nextOrder = data.lastCompletionOrder + 1;
-      final result = _completeSingleItem(data, id, nextOrder);
-      if (result == _ItemCompleteResult.completedWithOrder) {
-        data.lastCompletionOrder = nextOrder;
-      }
-    }
-  }
-
-  void _applyBatchSubQuestAdd(SidequestData data, Map<String, dynamic> op) {
-    final qId = op['questId']?.toString() ?? op['quest']?.toString() ?? '1';
-    final title =
-        op['title']?.toString() ?? op['description']?.toString() ?? 'SubQuest';
-    final quest = data.quests.where((q) => q.id == qId).firstOrNull;
-    if (quest != null) {
-      final nextSubNumber = _nextSuffixNumber(
-        quest.subQuests.map((sq) => sq.id),
-      );
-      final subId = '$qId.$nextSubNumber';
-      quest.subQuests.add(
-        SubQuest(id: subId, title: title, status: TaskStatus.inProgress),
-      );
-    }
-  }
-
-  void _applyBatchStepAdd(SidequestData data, Map<String, dynamic> op) {
-    final subId =
-        op['subquestId']?.toString() ?? op['subquest']?.toString() ?? '1.1';
-    final title =
-        op['title']?.toString() ?? op['description']?.toString() ?? 'Step';
-    final sub = _findSubQuest(data, subId);
-    if (sub != null) {
-      final nextNumber = _nextSuffixNumber(sub.items.map((i) => i.id));
-      sub.items.add(
-        TaskItem(
-          id: '$subId.$nextNumber',
-          type: TaskType.step,
-          title: title,
-          status: TaskStatus.pending,
-        ),
-      );
-    }
-  }
-
-  void _applyBatchBlockerAdd(SidequestData data, Map<String, dynamic> op) {
-    final subId =
-        op['subquestId']?.toString() ?? op['subquest']?.toString() ?? '1.1';
-    final title =
-        op['title']?.toString() ?? op['description']?.toString() ?? 'Blocker';
-    final sub = _findSubQuest(data, subId);
-    if (sub != null) {
-      final nextNumber = _nextSuffixNumber(sub.items.map((i) => i.id));
-      sub.items.add(
-        TaskItem(
-          id: '$subId.$nextNumber',
-          type: TaskType.blocker,
-          title: title,
-          status: TaskStatus.inProgress,
-        ),
-      );
-    }
-  }
-
-  void _applyBatchSideQuestAdd(SidequestData data, Map<String, dynamic> op) {
-    final title =
-        op['title']?.toString() ??
-        op['description']?.toString() ??
-        'Side Quest';
-    final isGlobal =
-        op['global'] == true || (op['quest'] == null && data.quests.isEmpty);
-    final isParked = op['parked'] == true;
-    final status = isParked ? SideQuestStatus.parked : SideQuestStatus.active;
-    final note = op['note']?.toString();
-
-    if (isGlobal || op['quest'] == null) {
-      final id = data.generateNextGlobalSideQuestId();
-      data.globalSideQuests.add(
-        SideQuest(id: id, title: title, status: status, note: note),
-      );
-    } else {
-      final qId = op['quest'].toString();
-      final quest = data.quests.where((q) => q.id == qId).firstOrNull;
-      if (quest != null) {
-        final id = data.generateNextSideQuestId(quest);
-        quest.sideQuests.add(
-          SideQuest(id: id, title: title, status: status, note: note),
-        );
-      }
-    }
-  }
-
-  void _applyBatchVcs(SidequestData data, Map<String, dynamic> op) {
-    final qId = op['quest']?.toString() ?? '1';
-    final quest = data.quests.where((q) => q.id == qId).firstOrNull;
-    if (quest != null) {
-      final files = (op['files'] as List<dynamic>?)?.cast<String>() ?? const [];
-      quest.vcs = VcsState(
-        stage: VcsStage.fromJson(op['stage']?.toString() ?? 'dirty'),
-        branch: op['branch']?.toString(),
-        modifiedFiles: files,
-        details: op['details']?.toString(),
-      );
-    }
-  }
-
-  Future<int> _handleRender() async {
+  @override
+  Future<int> run() async {
     final data = await store.load();
     if (data == null) {
       stderr.writeln('Error: sidequest.json not found in ${store.directory}');
@@ -910,10 +711,23 @@ class SidequestCliRunner {
     stdout.writeln('✔ Rendered sidequest.md');
     return 0;
   }
+}
 
-  Future<int> _handleMergeAudit(List<String> args) async {
-    final parser = ArgParser()..addOption('input');
-    final results = parser.parse(args);
+/// `sidequest merge-audit` command.
+class MergeAuditCommand extends SidequestCommand {
+  @override
+  final String name = 'merge-audit';
+
+  @override
+  final String description = 'Merge audited delta JSON into session map.';
+
+  MergeAuditCommand(super.runner) {
+    argParser.addOption('input', help: 'Path to audited delta JSON file.');
+  }
+
+  @override
+  Future<int> run() async {
+    final results = argResults!;
     final inputPath = (results['input'] as String?) ?? results.rest.firstOrNull;
     if (inputPath == null || !await File(inputPath).exists()) {
       stderr.writeln('Error: Missing or invalid --input file for merge-audit');
@@ -928,86 +742,491 @@ class SidequestCliRunner {
     stdout.writeln('✔ Merged audit delta and rendered sidequest.md');
     return 0;
   }
+}
 
-  Future<SidequestData> _requireData() async {
-    var data = await store.load();
-    if (data == null) {
-      data = SidequestData.initial(firstQuestTitle: 'Main Quest 1');
-      await store.save(data);
-    }
-    return data;
-  }
+// ---------------------------------------------------------------------------
+// Pure domain helper functions (Extracted for low cognitive complexity)
+// ---------------------------------------------------------------------------
 
-  MainQuest? _findQuest(SidequestData data, String id) {
-    final q = data.quests.where((e) => e.id == id).firstOrNull;
-    if (q == null) stderr.writeln('Error: Main Quest "$id" not found.');
-    return q;
-  }
+void _printVcsStatus(VcsState vcs) {
+  final branch = vcs.branch ?? 'N/A';
+  final files = vcs.modifiedFiles.isEmpty
+      ? 'none'
+      : vcs.modifiedFiles.join(', ');
+  stdout.writeln(
+    '   VCS: ${vcs.stage.badge} | Branch: $branch | Modified: $files',
+  );
+}
 
-  SubQuest? _findSubQuest(SidequestData data, String subId) {
-    for (final q in data.quests) {
-      for (final sq in q.subQuests) {
-        if (sq.id == subId) return sq;
+void _printBlockers(List<SubQuest> subQuests) {
+  final blockers = <String>[];
+  for (final sq in subQuests) {
+    for (final item in sq.items) {
+      if (item.status != TaskStatus.completed &&
+          item.type == TaskType.blocker) {
+        blockers.add('👾 Blocker ${item.id}: "${item.title}"');
       }
     }
-    stderr.writeln('Error: Sub-Quest "$subId" not found.');
-    return null;
   }
 
-  void _recalculateMaxCompletionOrder(SidequestData data) {
-    int maxOrder = 0;
-    for (final q in data.quests) {
-      for (final sq in q.subQuests) {
-        if (sq.completionOrder != null) {
-          maxOrder = max(maxOrder, sq.completionOrder!);
-        }
-        for (final item in sq.items) {
-          if (item.completionOrder != null) {
-            maxOrder = max(maxOrder, item.completionOrder!);
-          }
-        }
+  if (blockers.isNotEmpty) {
+    stdout.writeln('   Blockers:');
+    for (final b in blockers) {
+      stdout.writeln('     * $b');
+    }
+  }
+}
+
+void _printSubQuests(List<SubQuest> subQuests, int lastCompletionOrder) {
+  if (subQuests.isEmpty) return;
+
+  stdout.writeln('   Sub-Quests & Steps:');
+  for (final sq in subQuests) {
+    final doneStr = sq.status == TaskStatus.completed
+        ? '✔ (Done)'
+        : '⏳ (In Progress)';
+    stdout.writeln('     🛡️  Sub-Quest ${sq.id}: "${sq.title}" $doneStr');
+    for (final item in sq.items) {
+      _printTaskItem(item, lastCompletionOrder);
+    }
+  }
+}
+
+void _printTaskItem(TaskItem item, int lastCompletionOrder) {
+  final itemDone = item.status == TaskStatus.completed ? '✔' : ' ';
+  final icon = item.type == TaskType.blocker ? '👾' : '👣';
+  final order = item.completionOrder != null
+      ? (item.completionOrder == lastCompletionOrder
+            ? '[#${item.completionOrder} ⭐]'
+            : '[#${item.completionOrder}]')
+      : '';
+  final orderStr = order.isNotEmpty ? '$order ' : '';
+  stdout.writeln(
+    '        [$itemDone] $orderStr$icon ${item.id}: "${item.title}"',
+  );
+}
+
+void _printSideQuests(List<SideQuest> sideQuests) {
+  if (sideQuests.isEmpty) return;
+
+  stdout.writeln('   🌿 Side Quests:');
+  for (final sq in sideQuests) {
+    final statusIcon = switch (sq.status) {
+      SideQuestStatus.completed => '✔ Completed',
+      SideQuestStatus.parked => '🎒 Parked',
+      SideQuestStatus.active => '⚡ Active',
+    };
+    final note = sq.note != null ? ' (${sq.note})' : '';
+    stdout.writeln('     * [$statusIcon] ${sq.id}: "${sq.title}"$note');
+  }
+}
+
+List<String> _extractIds(List<String> args) => args
+    .expand((arg) => arg.split(','))
+    .map((s) => s.trim())
+    .where((s) => s.isNotEmpty)
+    .toList();
+
+_ItemCompleteResult _completeSingleItem(
+  SidequestData data,
+  String id,
+  int nextOrder,
+) {
+  for (final q in data.quests) {
+    final qResult = _completeQuest(q, id, nextOrder);
+    if (qResult != _ItemCompleteResult.notFound) return qResult;
+  }
+
+  for (final sq in data.globalSideQuests) {
+    final sqResult = _completeSideQuest(sq, id, nextOrder);
+    if (sqResult != _ItemCompleteResult.notFound) return sqResult;
+  }
+
+  return _ItemCompleteResult.notFound;
+}
+
+_ItemCompleteResult _completeQuest(MainQuest q, String id, int nextOrder) {
+  if (q.id == id) {
+    if (q.status == QuestStatus.completed) {
+      return _ItemCompleteResult.alreadyCompleted;
+    }
+    q.status = QuestStatus.completed;
+    return _ItemCompleteResult.completedNoOrder;
+  }
+
+  for (final sq in q.subQuests) {
+    final sqResult = _completeSubQuest(sq, id, nextOrder);
+    if (sqResult != _ItemCompleteResult.notFound) return sqResult;
+  }
+
+  for (final sq in q.sideQuests) {
+    final sqResult = _completeSideQuest(sq, id, nextOrder);
+    if (sqResult != _ItemCompleteResult.notFound) return sqResult;
+  }
+
+  return _ItemCompleteResult.notFound;
+}
+
+_ItemCompleteResult _completeSubQuest(SubQuest sq, String id, int nextOrder) {
+  if (sq.id == id) {
+    if (sq.status == TaskStatus.completed) {
+      return _ItemCompleteResult.alreadyCompleted;
+    }
+    sq.status = TaskStatus.completed;
+    sq.completionOrder = nextOrder;
+    return _ItemCompleteResult.completedWithOrder;
+  }
+
+  for (final item in sq.items) {
+    if (item.id == id) {
+      if (item.status == TaskStatus.completed) {
+        return _ItemCompleteResult.alreadyCompleted;
       }
-      for (final sq in q.sideQuests) {
-        if (sq.completionOrder != null) {
-          maxOrder = max(maxOrder, sq.completionOrder!);
+      item.status = TaskStatus.completed;
+      item.completionOrder = nextOrder;
+      return _ItemCompleteResult.completedWithOrder;
+    }
+  }
+
+  return _ItemCompleteResult.notFound;
+}
+
+_ItemCompleteResult _completeSideQuest(SideQuest sq, String id, int nextOrder) {
+  if (sq.id != id) return _ItemCompleteResult.notFound;
+  if (sq.status == SideQuestStatus.completed) {
+    return _ItemCompleteResult.alreadyCompleted;
+  }
+  sq.status = SideQuestStatus.completed;
+  sq.completionOrder = nextOrder;
+  return _ItemCompleteResult.completedWithOrder;
+}
+
+bool _reopenSingleItem(SidequestData data, String id) {
+  for (final q in data.quests) {
+    if (_reopenQuest(q, id)) return true;
+  }
+
+  for (final sq in data.globalSideQuests) {
+    if (sq.id == id) {
+      sq.status = SideQuestStatus.active;
+      sq.completionOrder = null;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+bool _reopenQuest(MainQuest q, String id) {
+  if (q.id == id) {
+    q.status = QuestStatus.active;
+    return true;
+  }
+  for (final sq in q.subQuests) {
+    if (sq.id == id) {
+      sq.status = TaskStatus.inProgress;
+      sq.completionOrder = null;
+      return true;
+    }
+    for (final item in sq.items) {
+      if (item.id == id) {
+        item.status = TaskStatus.pending;
+        item.completionOrder = null;
+        return true;
+      }
+    }
+  }
+  for (final sq in q.sideQuests) {
+    if (sq.id == id) {
+      sq.status = SideQuestStatus.active;
+      sq.completionOrder = null;
+      return true;
+    }
+  }
+  return false;
+}
+
+bool _removeSingleItem(SidequestData data, String id) {
+  bool found = false;
+  if (data.quests.any((q) => q.id == id)) {
+    data.quests.removeWhere((q) => q.id == id);
+    return true;
+  }
+
+  for (final q in data.quests) {
+    if (q.subQuests.any((sq) => sq.id == id)) {
+      q.subQuests.removeWhere((sq) => sq.id == id);
+      found = true;
+    }
+    for (final sq in q.subQuests) {
+      if (sq.items.any((item) => item.id == id)) {
+        sq.items.removeWhere((item) => item.id == id);
+        found = true;
+      }
+    }
+    if (q.sideQuests.any((sq) => sq.id == id)) {
+      q.sideQuests.removeWhere((sq) => sq.id == id);
+      found = true;
+    }
+  }
+
+  if (data.globalSideQuests.any((sq) => sq.id == id)) {
+    data.globalSideQuests.removeWhere((sq) => sq.id == id);
+    found = true;
+  }
+
+  return found;
+}
+
+void _applyBatchList(SidequestData data, List<dynamic> list) {
+  for (final op in list) {
+    if (op is Map<String, dynamic>) {
+      _applyBatchOp(data, op);
+    }
+  }
+}
+
+void _applyBatchMap(SidequestData data, Map<String, dynamic> map) {
+  if (map['operations'] is List) {
+    _applyBatchList(data, map['operations'] as List);
+    return;
+  }
+  _applyLegacyBatchMap(data, map);
+}
+
+void _applyLegacyBatchMap(SidequestData data, Map<String, dynamic> map) {
+  if (map['complete'] is List) {
+    for (final id in map['complete'] as List) {
+      final nextOrder = data.lastCompletionOrder + 1;
+      final result = _completeSingleItem(data, id.toString(), nextOrder);
+      if (result == _ItemCompleteResult.completedWithOrder) {
+        data.lastCompletionOrder = nextOrder;
+      }
+    }
+  }
+
+  if (map['addSubQuest'] is Map) {
+    final sqMap = map['addSubQuest'] as Map<String, dynamic>;
+    final qId = sqMap['quest'] as String? ?? '1';
+    final quest = _findQuest(data, qId);
+    if (quest != null) {
+      final nextSubNumber = _nextSuffixNumber(
+        quest.subQuests.map((sq) => sq.id),
+      );
+      final subId = '$qId.$nextSubNumber';
+      quest.subQuests.add(
+        SubQuest(
+          id: subId,
+          title: sqMap['title'] as String? ?? 'New SubQuest',
+          status: TaskStatus.inProgress,
+        ),
+      );
+    }
+  }
+
+  if (map['vcs'] is Map) {
+    final vcsMap = map['vcs'] as Map<String, dynamic>;
+    final qId = vcsMap['quest'] as String? ?? '1';
+    final quest = _findQuest(data, qId);
+    if (quest != null) {
+      final files =
+          (vcsMap['files'] as List<dynamic>?)?.cast<String>() ?? const [];
+      quest.vcs = VcsState(
+        stage: VcsStage.fromJson(vcsMap['stage'] as String? ?? 'dirty'),
+        branch: vcsMap['branch'] as String?,
+        modifiedFiles: files,
+        details: vcsMap['details'] as String?,
+      );
+    }
+  }
+}
+
+void _applyBatchOp(SidequestData data, Map<String, dynamic> op) {
+  final type = (op['type'] as String? ?? '').toLowerCase();
+
+  switch (type) {
+    case 'quest_add':
+      _applyBatchQuestAdd(data, op);
+    case 'complete':
+      _applyBatchComplete(data, op);
+    case 'subquest_add':
+      _applyBatchSubQuestAdd(data, op);
+    case 'step_add':
+      _applyBatchStepAdd(data, op);
+    case 'blocker_add':
+      _applyBatchBlockerAdd(data, op);
+    case 'sidequest_add':
+      _applyBatchSideQuestAdd(data, op);
+    case 'vcs':
+      _applyBatchVcs(data, op);
+  }
+}
+
+void _applyBatchQuestAdd(SidequestData data, Map<String, dynamic> op) {
+  final title =
+      op['title']?.toString() ??
+      op['description']?.toString() ??
+      'New Main Quest';
+  final nextQuestNumber =
+      data.quests.map((q) => int.tryParse(q.id) ?? 0).fold(0, max) + 1;
+  data.quests.add(
+    MainQuest(
+      id: '$nextQuestNumber',
+      title: title,
+      status: QuestStatus.active,
+      vcs: const VcsState(stage: VcsStage.dirty),
+    ),
+  );
+}
+
+void _applyBatchComplete(SidequestData data, Map<String, dynamic> op) {
+  final rawIds = op['ids'] ?? op['id'];
+  final idList = rawIds is List
+      ? rawIds.map((e) => e.toString()).toList()
+      : [rawIds?.toString() ?? ''];
+  for (final id in idList.where((s) => s.isNotEmpty)) {
+    final nextOrder = data.lastCompletionOrder + 1;
+    final result = _completeSingleItem(data, id, nextOrder);
+    if (result == _ItemCompleteResult.completedWithOrder) {
+      data.lastCompletionOrder = nextOrder;
+    }
+  }
+}
+
+void _applyBatchSubQuestAdd(SidequestData data, Map<String, dynamic> op) {
+  final qId = op['questId']?.toString() ?? op['quest']?.toString() ?? '1';
+  final title =
+      op['title']?.toString() ?? op['description']?.toString() ?? 'SubQuest';
+  final quest = data.quests.where((q) => q.id == qId).firstOrNull;
+  if (quest != null) {
+    final nextSubNumber = _nextSuffixNumber(quest.subQuests.map((sq) => sq.id));
+    final subId = '$qId.$nextSubNumber';
+    quest.subQuests.add(
+      SubQuest(id: subId, title: title, status: TaskStatus.inProgress),
+    );
+  }
+}
+
+void _applyBatchStepAdd(SidequestData data, Map<String, dynamic> op) {
+  final subId =
+      op['subquestId']?.toString() ?? op['subquest']?.toString() ?? '1.1';
+  final title =
+      op['title']?.toString() ?? op['description']?.toString() ?? 'Step';
+  final sub = _findSubQuest(data, subId);
+  if (sub != null) {
+    final nextNumber = _nextSuffixNumber(sub.items.map((i) => i.id));
+    sub.items.add(
+      TaskItem(
+        id: '$subId.$nextNumber',
+        type: TaskType.step,
+        title: title,
+        status: TaskStatus.pending,
+      ),
+    );
+  }
+}
+
+void _applyBatchBlockerAdd(SidequestData data, Map<String, dynamic> op) {
+  final subId =
+      op['subquestId']?.toString() ?? op['subquest']?.toString() ?? '1.1';
+  final title =
+      op['title']?.toString() ?? op['description']?.toString() ?? 'Blocker';
+  final sub = _findSubQuest(data, subId);
+  if (sub != null) {
+    final nextNumber = _nextSuffixNumber(sub.items.map((i) => i.id));
+    sub.items.add(
+      TaskItem(
+        id: '$subId.$nextNumber',
+        type: TaskType.blocker,
+        title: title,
+        status: TaskStatus.inProgress,
+      ),
+    );
+  }
+}
+
+void _applyBatchSideQuestAdd(SidequestData data, Map<String, dynamic> op) {
+  final title =
+      op['title']?.toString() ?? op['description']?.toString() ?? 'Side Quest';
+  final isGlobal =
+      op['global'] == true || (op['quest'] == null && data.quests.isEmpty);
+  final isParked = op['parked'] == true;
+  final status = isParked ? SideQuestStatus.parked : SideQuestStatus.active;
+  final note = op['note']?.toString();
+
+  if (isGlobal || op['quest'] == null) {
+    final id = data.generateNextGlobalSideQuestId();
+    data.globalSideQuests.add(
+      SideQuest(id: id, title: title, status: status, note: note),
+    );
+  } else {
+    final qId = op['quest'].toString();
+    final quest = data.quests.where((q) => q.id == qId).firstOrNull;
+    if (quest != null) {
+      final id = data.generateNextSideQuestId(quest);
+      quest.sideQuests.add(
+        SideQuest(id: id, title: title, status: status, note: note),
+      );
+    }
+  }
+}
+
+void _applyBatchVcs(SidequestData data, Map<String, dynamic> op) {
+  final qId = op['quest']?.toString() ?? '1';
+  final quest = data.quests.where((q) => q.id == qId).firstOrNull;
+  if (quest != null) {
+    final files = (op['files'] as List<dynamic>?)?.cast<String>() ?? const [];
+    quest.vcs = VcsState(
+      stage: VcsStage.fromJson(op['stage']?.toString() ?? 'dirty'),
+      branch: op['branch']?.toString(),
+      modifiedFiles: files,
+      details: op['details']?.toString(),
+    );
+  }
+}
+
+MainQuest? _findQuest(SidequestData data, String id) {
+  final q = data.quests.where((e) => e.id == id).firstOrNull;
+  if (q == null) stderr.writeln('Error: Main Quest "$id" not found.');
+  return q;
+}
+
+SubQuest? _findSubQuest(SidequestData data, String subId) {
+  for (final q in data.quests) {
+    for (final sq in q.subQuests) {
+      if (sq.id == subId) return sq;
+    }
+  }
+  stderr.writeln('Error: Sub-Quest "$subId" not found.');
+  return null;
+}
+
+int _nextSuffixNumber(Iterable<String> ids) =>
+    ids.map((id) => int.tryParse(id.split('.').last) ?? 0).fold(0, max) + 1;
+
+void _recalculateMaxCompletionOrder(SidequestData data) {
+  int maxOrder = 0;
+  for (final q in data.quests) {
+    for (final sq in q.subQuests) {
+      if (sq.completionOrder != null) {
+        maxOrder = max(maxOrder, sq.completionOrder!);
+      }
+      for (final item in sq.items) {
+        if (item.completionOrder != null) {
+          maxOrder = max(maxOrder, item.completionOrder!);
         }
       }
     }
-    for (final sq in data.globalSideQuests) {
+    for (final sq in q.sideQuests) {
       if (sq.completionOrder != null) {
         maxOrder = max(maxOrder, sq.completionOrder!);
       }
     }
-    data.lastCompletionOrder = maxOrder;
   }
-
-  void _printUsage() {
-    stdout.writeln('''
-sidequest CLI - Deterministic session map manager
-
-Usage:
-  sidequest [command] [args] [--dir=path]
-
-Global Options:
-  --dir=<path>            Path to session artifact directory containing sidequest.json
-
-Inspection:
-  status                  Print compact 10-line session overview (default if state exists)
-
-Mutations:
-  init [title]            Initialize sidequest session map (default: "Main Quest 1")
-  quest add <title>       Add a new main quest
-  subquest add <qId> <t>  Add a sub-quest under main quest <qId>
-  step add <subId> <t>    Add a planned step under sub-quest <subId>
-  blocker add <subId> <t> Add an unplanned blocker under sub-quest <subId>
-  sidequest add <t>       Add a side quest (--quest=<qId>, --global, --parked, --note=<n>)
-  complete <id...>        Mark one or more items completed
-  reopen <id...>          Reopen one or more completed items
-  remove <id...>          Remove one or more items
-  vcs <qId>               Update VCS state (--stage=dirty|local_commit|uploaded|merged|clean)
-  batch <json>            Execute multiple mutations in a single call
-  render                  Re-render sidequest.md from sidequest.json
-  merge-audit --input=<f> Merge audited delta JSON into session map
-  help, --help, -h        Show this help message''');
+  for (final sq in data.globalSideQuests) {
+    if (sq.completionOrder != null) {
+      maxOrder = max(maxOrder, sq.completionOrder!);
+    }
   }
+  data.lastCompletionOrder = maxOrder;
 }

--- a/skills/sidequest/lib/src/cli/command_runner.dart
+++ b/skills/sidequest/lib/src/cli/command_runner.dart
@@ -45,9 +45,6 @@ class SidequestCliRunner {
           _printUsage();
           return 0;
         case 'status':
-        case 'show':
-        case 'summary':
-        case 'list':
           return await _handleStatus();
         case 'init':
           return await _handleInit(subArgs);
@@ -61,18 +58,11 @@ class SidequestCliRunner {
           return await _handleBlocker(subArgs);
         case 'sidequest':
           return await _handleSideQuest(subArgs);
-        case 'add':
-          return await _handleDispatchAdd(subArgs);
         case 'complete':
-        case 'done':
-        case 'finish':
-        case 'resolve':
           return await _handleComplete(subArgs);
         case 'reopen':
           return await _handleReopen(subArgs);
         case 'remove':
-        case 'delete':
-        case 'rm':
           return await _handleRemove(subArgs);
         case 'vcs':
           return await _handleVcs(subArgs);
@@ -195,30 +185,6 @@ class SidequestCliRunner {
       };
       final note = sq.note != null ? ' (${sq.note})' : '';
       stdout.writeln('     * [$statusIcon] ${sq.id}: "${sq.title}"$note');
-    }
-  }
-
-  Future<int> _handleDispatchAdd(List<String> args) async {
-    if (args.isEmpty) {
-      return await _handleSideQuest(['add']);
-    }
-    final target = args[0];
-    final rest = args.sublist(1);
-
-    switch (target) {
-      case 'quest':
-        return await _handleQuest(['add', ...rest]);
-      case 'subquest':
-        return await _handleSubQuest(['add', ...rest]);
-      case 'step':
-        return await _handleStep(['add', ...rest]);
-      case 'blocker':
-        return await _handleBlocker(['add', ...rest]);
-      case 'sidequest':
-        return await _handleSideQuest(['add', ...rest]);
-      default:
-        // Default treat "add <title>" as adding a sidequest
-        return await _handleSideQuest(['add', ...args]);
     }
   }
 
@@ -791,28 +757,16 @@ class SidequestCliRunner {
 
     switch (type) {
       case 'quest_add':
-      case 'add_quest':
-      case 'quest':
         _applyBatchQuestAdd(data, op);
       case 'complete':
-      case 'done':
-      case 'finish':
         _applyBatchComplete(data, op);
       case 'subquest_add':
-      case 'add_subquest':
-      case 'subquest':
         _applyBatchSubQuestAdd(data, op);
       case 'step_add':
-      case 'add_step':
-      case 'step':
         _applyBatchStepAdd(data, op);
       case 'blocker_add':
-      case 'add_blocker':
-      case 'blocker':
         _applyBatchBlockerAdd(data, op);
       case 'sidequest_add':
-      case 'add_sidequest':
-      case 'sidequest':
         _applyBatchSideQuestAdd(data, op);
       case 'vcs':
         _applyBatchVcs(data, op);
@@ -1038,7 +992,7 @@ Global Options:
   --dir=<path>            Path to session artifact directory containing sidequest.json
 
 Inspection:
-  status, show, summary   Print compact 10-line session overview (default if state exists)
+  status                  Print compact 10-line session overview (default if state exists)
 
 Mutations:
   init [title]            Initialize sidequest session map (default: "Main Quest 1")
@@ -1047,9 +1001,9 @@ Mutations:
   step add <subId> <t>    Add a planned step under sub-quest <subId>
   blocker add <subId> <t> Add an unplanned blocker under sub-quest <subId>
   sidequest add <t>       Add a side quest (--quest=<qId>, --global, --parked, --note=<n>)
-  complete <id...>        Mark one or more items completed (alias: done, finish, resolve)
+  complete <id...>        Mark one or more items completed
   reopen <id...>          Reopen one or more completed items
-  remove <id...>          Remove one or more items (alias: delete, rm)
+  remove <id...>          Remove one or more items
   vcs <qId>               Update VCS state (--stage=dirty|local_commit|uploaded|merged|clean)
   batch <json>            Execute multiple mutations in a single call
   render                  Re-render sidequest.md from sidequest.json

--- a/skills/sidequest/lib/src/cli/command_runner.dart
+++ b/skills/sidequest/lib/src/cli/command_runner.dart
@@ -9,7 +9,12 @@ import '../models/sidequest_data.dart';
 import '../models/vcs_state.dart';
 import '../storage/session_store.dart';
 
-enum _ItemCompleteResult { completed, alreadyCompleted, notFound }
+enum _ItemCompleteResult {
+  completedWithOrder,
+  completedNoOrder,
+  alreadyCompleted,
+  notFound,
+}
 
 class SidequestCliRunner {
   final SessionStore store;
@@ -403,8 +408,10 @@ class SidequestCliRunner {
     for (final id in ids) {
       final nextOrder = data.lastCompletionOrder + 1;
       final result = _completeSingleItem(data, id, nextOrder);
-      if (result == _ItemCompleteResult.completed) {
+      if (result == _ItemCompleteResult.completedWithOrder) {
         data.lastCompletionOrder = nextOrder;
+        completedIds.add(id);
+      } else if (result == _ItemCompleteResult.completedNoOrder) {
         completedIds.add(id);
       } else if (result == _ItemCompleteResult.alreadyCompleted) {
         alreadyCompletedIds.add(id);
@@ -415,8 +422,11 @@ class SidequestCliRunner {
 
     if (completedIds.isNotEmpty) {
       await store.save(data);
+      final orderSuffix = data.lastCompletionOrder > 0
+          ? ' (Order [#${data.lastCompletionOrder} ⭐])'
+          : '';
       stdout.writeln(
-        '✔ Completed item(s): ${completedIds.join(", ")} (Order [#${data.lastCompletionOrder} ⭐])',
+        '✔ Completed item(s): ${completedIds.join(", ")}$orderSuffix',
       );
     }
     if (alreadyCompletedIds.isNotEmpty) {
@@ -440,7 +450,7 @@ class SidequestCliRunner {
           return _ItemCompleteResult.alreadyCompleted;
         }
         q.status = QuestStatus.completed;
-        return _ItemCompleteResult.completed;
+        return _ItemCompleteResult.completedNoOrder;
       }
       for (final sq in q.subQuests) {
         if (sq.id == id) {
@@ -449,7 +459,7 @@ class SidequestCliRunner {
           }
           sq.status = TaskStatus.completed;
           sq.completionOrder = nextOrder;
-          return _ItemCompleteResult.completed;
+          return _ItemCompleteResult.completedWithOrder;
         }
         for (final item in sq.items) {
           if (item.id == id) {
@@ -458,7 +468,7 @@ class SidequestCliRunner {
             }
             item.status = TaskStatus.completed;
             item.completionOrder = nextOrder;
-            return _ItemCompleteResult.completed;
+            return _ItemCompleteResult.completedWithOrder;
           }
         }
       }
@@ -469,7 +479,7 @@ class SidequestCliRunner {
           }
           sq.status = SideQuestStatus.completed;
           sq.completionOrder = nextOrder;
-          return _ItemCompleteResult.completed;
+          return _ItemCompleteResult.completedWithOrder;
         }
       }
     }
@@ -481,7 +491,7 @@ class SidequestCliRunner {
         }
         sq.status = SideQuestStatus.completed;
         sq.completionOrder = nextOrder;
-        return _ItemCompleteResult.completed;
+        return _ItemCompleteResult.completedWithOrder;
       }
     }
 
@@ -667,13 +677,8 @@ class SidequestCliRunner {
         if (decoded['complete'] is List) {
           for (final id in decoded['complete'] as List) {
             final nextOrder = data.lastCompletionOrder + 1;
-            final updated = _setItemStatus(
-              data,
-              id.toString(),
-              TaskStatus.completed,
-              nextOrder,
-            );
-            if (updated) {
+            final result = _completeSingleItem(data, id.toString(), nextOrder);
+            if (result == _ItemCompleteResult.completedWithOrder) {
               data.lastCompletionOrder = nextOrder;
             }
           }
@@ -725,6 +730,24 @@ class SidequestCliRunner {
     final type = (op['type'] as String? ?? '').toLowerCase();
 
     switch (type) {
+      case 'quest_add':
+      case 'add_quest':
+      case 'quest':
+        final title =
+            op['title']?.toString() ??
+            op['description']?.toString() ??
+            'New Main Quest';
+        final nextQuestNumber =
+            data.quests.map((q) => int.tryParse(q.id) ?? 0).fold(0, max) + 1;
+        data.quests.add(
+          MainQuest(
+            id: '$nextQuestNumber',
+            title: title,
+            status: QuestStatus.active,
+            vcs: const VcsState(stage: VcsStage.dirty),
+          ),
+        );
+        break;
       case 'complete':
       case 'done':
       case 'finish':
@@ -734,13 +757,8 @@ class SidequestCliRunner {
             : [rawIds?.toString() ?? ''];
         for (final id in idList.where((s) => s.isNotEmpty)) {
           final nextOrder = data.lastCompletionOrder + 1;
-          final updated = _setItemStatus(
-            data,
-            id,
-            TaskStatus.completed,
-            nextOrder,
-          );
-          if (updated) {
+          final result = _completeSingleItem(data, id, nextOrder);
+          if (result == _ItemCompleteResult.completedWithOrder) {
             data.lastCompletionOrder = nextOrder;
           }
         }
@@ -869,7 +887,7 @@ class SidequestCliRunner {
   Future<int> _handleMergeAudit(List<String> args) async {
     final parser = ArgParser()..addOption('input');
     final results = parser.parse(args);
-    final inputPath = results['input'] as String?;
+    final inputPath = (results['input'] as String?) ?? results.rest.firstOrNull;
     if (inputPath == null || !await File(inputPath).exists()) {
       stderr.writeln('Error: Missing or invalid --input file for merge-audit');
       return 1;
@@ -907,49 +925,6 @@ class SidequestCliRunner {
     }
     stderr.writeln('Error: Sub-Quest "$subId" not found.');
     return null;
-  }
-
-  bool _setItemStatus(
-    SidequestData data,
-    String id,
-    TaskStatus status,
-    int order,
-  ) {
-    for (final q in data.quests) {
-      if (q.id == id) {
-        q.status = QuestStatus.completed;
-        return true;
-      }
-      for (final sq in q.subQuests) {
-        if (sq.id == id) {
-          sq.status = status;
-          sq.completionOrder = order;
-          return true;
-        }
-        for (final item in sq.items) {
-          if (item.id == id) {
-            item.status = status;
-            item.completionOrder = order;
-            return true;
-          }
-        }
-      }
-      for (final sq in q.sideQuests) {
-        if (sq.id == id) {
-          sq.status = SideQuestStatus.completed;
-          sq.completionOrder = order;
-          return true;
-        }
-      }
-    }
-    for (final sq in data.globalSideQuests) {
-      if (sq.id == id) {
-        sq.status = SideQuestStatus.completed;
-        sq.completionOrder = order;
-        return true;
-      }
-    }
-    return false;
   }
 
   void _recalculateMaxCompletionOrder(SidequestData data) {

--- a/skills/sidequest/lib/src/storage/session_store.dart
+++ b/skills/sidequest/lib/src/storage/session_store.dart
@@ -9,24 +9,60 @@ import '../models/sidequest_data.dart';
 class SessionStore {
   final String directory;
 
-  SessionStore({String? directory}) : directory = resolveDirectory(directory);
+  SessionStore({
+    String? directory,
+    Map<String, String>? environment,
+    String? currentDirectory,
+  }) : directory = resolveDirectory(
+         directory,
+         environment: environment,
+         currentDirectory: currentDirectory,
+       );
 
-  static String resolveDirectory(String? explicit) {
+  static String resolveDirectory(
+    String? explicit, {
+    Map<String, String>? environment,
+    String? currentDirectory,
+  }) {
     if (explicit != null && explicit.trim().isNotEmpty) {
       return explicit.trim();
     }
-    final envVars = [
+
+    final env = environment ?? Platform.environment;
+    final cwd = currentDirectory ?? Directory.current.path;
+
+    final directEnvVars = [
       'JETSKI_ARTIFACT_DIR',
-      'GEMINI_ARTIFACT_DIR',
       'CLAUDE_ARTIFACT_DIR',
+      'GEMINI_ARTIFACT_DIR',
+      'SIDEQUEST_DIR',
     ];
-    for (final key in envVars) {
-      final val = Platform.environment[key];
+    for (final key in directEnvVars) {
+      final val = env[key];
       if (val != null && val.trim().isNotEmpty) {
         return val.trim();
       }
     }
-    return '.';
+
+    final convId = env['ANTIGRAVITY_CONVERSATION_ID'];
+    if (convId != null && convId.trim().isNotEmpty) {
+      final home = env['HOME'] ?? env['USERPROFILE'] ?? '';
+      if (home.isNotEmpty) {
+        return p.join(home, '.gemini', 'jetski', 'brain', convId.trim());
+      }
+    }
+
+    final dotSidequest = p.join(cwd, '.sidequest');
+    if (Directory(dotSidequest).existsSync() ||
+        File(p.join(dotSidequest, 'sidequest.json')).existsSync()) {
+      return dotSidequest;
+    }
+
+    if (File(p.join(cwd, 'sidequest.json')).existsSync()) {
+      return cwd;
+    }
+
+    return cwd;
   }
 
   File get jsonFile => File(p.join(directory, 'sidequest.json'));

--- a/skills/sidequest/lib/src/storage/session_store.dart
+++ b/skills/sidequest/lib/src/storage/session_store.dart
@@ -32,10 +32,10 @@ class SessionStore {
     final cwd = currentDirectory ?? Directory.current.path;
 
     final directEnvVars = [
+      'SIDEQUEST_DIR',
       'JETSKI_ARTIFACT_DIR',
       'CLAUDE_ARTIFACT_DIR',
       'GEMINI_ARTIFACT_DIR',
-      'SIDEQUEST_DIR',
     ];
     for (final key in directEnvVars) {
       final val = env[key];

--- a/tool/test/sidequest_test.dart
+++ b/tool/test/sidequest_test.dart
@@ -424,7 +424,7 @@ void main() {
       },
     );
 
-    test('supports variadic multi-item completion with synonyms', () async {
+    test('supports variadic multi-item completion', () async {
       final runner = SidequestCliRunner(store: store);
 
       // Add subquest and multiple steps
@@ -433,9 +433,9 @@ void main() {
       await runner.run(['step', 'add', '1.1', 'Step 2']);
       await runner.run(['step', 'add', '1.1', 'Step 3']);
 
-      // Complete multiple items in one single command using synonym "done"
+      // Complete multiple items in one single canonical command
       final exitCode = await runner.run([
-        'done',
+        'complete',
         '1.1.1',
         '1.1.2,1.1.3',
         '1.1',
@@ -467,31 +467,17 @@ void main() {
       ).equals(TaskStatus.pending);
     });
 
-    test(
-      'supports verb-dispatch synonyms: add quest, add subquest, add step',
-      () async {
-        final runner = SidequestCliRunner(store: store);
+    test('rejects non-canonical alias commands', () async {
+      final runner = SidequestCliRunner(store: store);
 
-        // add quest
-        await runner.run(['add', 'quest', 'Dispatched Main Quest 2']);
-        // add subquest
-        await runner.run(['add', 'subquest', '2', 'Dispatched SubQuest 2.1']);
-        // add step
-        await runner.run(['add', 'step', '2.1', 'Dispatched Step 2.1.1']);
-        // add blocker
-        await runner.run(['add', 'blocker', '2.1', 'Dispatched Blocker 2.1.2']);
-
-        final data = (await store.load())!;
-        check(data.quests.length).equals(2);
-        check(data.quests[1].title).equals('Dispatched Main Quest 2');
-        check(data.quests[1].subQuests.length).equals(1);
-        check(data.quests[1].subQuests[0].items.length).equals(2);
-        check(data.quests[1].subQuests[0].items[0].type).equals(TaskType.step);
-        check(
-          data.quests[1].subQuests[0].items[1].type,
-        ).equals(TaskType.blocker);
-      },
-    );
+      // Non-canonical synonyms must fail
+      check(await runner.run(['show'])).equals(1);
+      check(await runner.run(['summary'])).equals(1);
+      check(await runner.run(['done', '1.1'])).equals(1);
+      check(await runner.run(['finish', '1.1'])).equals(1);
+      check(await runner.run(['delete', '1.1'])).equals(1);
+      check(await runner.run(['add', 'quest', 'Invalid'])).equals(1);
+    });
 
     test(
       'handles status command and empty invocation with existing state',
@@ -501,9 +487,8 @@ void main() {
         await runner.run(['subquest', 'add', '1', 'Active SubQuest']);
         await runner.run(['step', 'add', '1.1', 'Active Step']);
 
-        // Running status command
+        // Running canonical status command
         check(await runner.run(['status'])).equals(0);
-        check(await runner.run(['show'])).equals(0);
 
         // Running bare command when state exists
         check(await runner.run([])).equals(0);

--- a/tool/test/sidequest_test.dart
+++ b/tool/test/sidequest_test.dart
@@ -288,6 +288,55 @@ void main() {
         check(loaded!.quests.first.title).equals('Initial Task');
       },
     );
+
+    test('resolves directory across multi-tier discovery hierarchy', () {
+      // 1. Explicit override
+      check(
+        SessionStore.resolveDirectory('/explicit/dir', environment: {}),
+      ).equals('/explicit/dir');
+
+      // 2. Direct environment variables
+      check(
+        SessionStore.resolveDirectory(
+          null,
+          environment: {'SIDEQUEST_DIR': '/env/sidequest'},
+        ),
+      ).equals('/env/sidequest');
+
+      check(
+        SessionStore.resolveDirectory(
+          null,
+          environment: {'CLAUDE_ARTIFACT_DIR': '/env/claude'},
+        ),
+      ).equals('/env/claude');
+
+      check(
+        SessionStore.resolveDirectory(
+          null,
+          environment: {'GEMINI_ARTIFACT_DIR': '/env/gemini'},
+        ),
+      ).equals('/env/gemini');
+
+      // 3. Antigravity / Jetski conversation ID
+      check(
+        SessionStore.resolveDirectory(
+          null,
+          environment: {
+            'HOME': '/usr/home/testuser',
+            'ANTIGRAVITY_CONVERSATION_ID': 'abc-123-xyz',
+          },
+        ),
+      ).equals('/usr/home/testuser/.gemini/jetski/brain/abc-123-xyz');
+
+      // 4. Default fallback to cwd
+      check(
+        SessionStore.resolveDirectory(
+          null,
+          environment: {},
+          currentDirectory: '/workspace/project',
+        ),
+      ).equals('/workspace/project');
+    });
   });
 
   group('CLI Mutations & Workflow Operations', () {
@@ -349,6 +398,92 @@ void main() {
       },
     );
 
+    test('supports variadic multi-item completion with synonyms', () async {
+      final runner = SidequestCliRunner(store: store);
+
+      // Add subquest and multiple steps
+      await runner.run(['subquest', 'add', '1', 'Multi-step SubQuest']);
+      await runner.run(['step', 'add', '1.1', 'Step 1']);
+      await runner.run(['step', 'add', '1.1', 'Step 2']);
+      await runner.run(['step', 'add', '1.1', 'Step 3']);
+
+      // Complete multiple items in one single command using synonym "done"
+      final exitCode = await runner.run([
+        'done',
+        '1.1.1',
+        '1.1.2,1.1.3',
+        '1.1',
+      ]);
+      check(exitCode).equals(0);
+
+      final data = (await store.load())!;
+      check(data.lastCompletionOrder).equals(4);
+      check(
+        data.quests[0].subQuests[0].items[0].status,
+      ).equals(TaskStatus.completed);
+      check(
+        data.quests[0].subQuests[0].items[1].status,
+      ).equals(TaskStatus.completed);
+      check(
+        data.quests[0].subQuests[0].items[2].status,
+      ).equals(TaskStatus.completed);
+      check(data.quests[0].subQuests[0].status).equals(TaskStatus.completed);
+      check(data.quests[0].subQuests[0].completionOrder).equals(4);
+
+      // Reopen multiple items in one command
+      await runner.run(['reopen', '1.1.1', '1.1.2']);
+      final reopenedData = (await store.load())!;
+      check(
+        reopenedData.quests[0].subQuests[0].items[0].status,
+      ).equals(TaskStatus.pending);
+      check(
+        reopenedData.quests[0].subQuests[0].items[1].status,
+      ).equals(TaskStatus.pending);
+    });
+
+    test(
+      'supports verb-dispatch synonyms: add quest, add subquest, add step',
+      () async {
+        final runner = SidequestCliRunner(store: store);
+
+        // add quest
+        await runner.run(['add', 'quest', 'Dispatched Main Quest 2']);
+        // add subquest
+        await runner.run(['add', 'subquest', '2', 'Dispatched SubQuest 2.1']);
+        // add step
+        await runner.run(['add', 'step', '2.1', 'Dispatched Step 2.1.1']);
+        // add blocker
+        await runner.run(['add', 'blocker', '2.1', 'Dispatched Blocker 2.1.2']);
+
+        final data = (await store.load())!;
+        check(data.quests.length).equals(2);
+        check(data.quests[1].title).equals('Dispatched Main Quest 2');
+        check(data.quests[1].subQuests.length).equals(1);
+        check(data.quests[1].subQuests[0].items.length).equals(2);
+        check(data.quests[1].subQuests[0].items[0].type).equals(TaskType.step);
+        check(
+          data.quests[1].subQuests[0].items[1].type,
+        ).equals(TaskType.blocker);
+      },
+    );
+
+    test(
+      'handles status command and empty invocation with existing state',
+      () async {
+        final runner = SidequestCliRunner(store: store);
+
+        await runner.run(['subquest', 'add', '1', 'Active SubQuest']);
+        await runner.run(['step', 'add', '1.1', 'Active Step']);
+
+        // Running status command
+        check(await runner.run(['status'])).equals(0);
+        check(await runner.run(['show'])).equals(0);
+
+        // Running bare command when state exists
+        check(await runner.run([])).equals(0);
+      },
+    );
+
     test('completes, reopens, and removes MainQuest and SideQuests', () async {
       final runner = SidequestCliRunner(store: store);
 
@@ -389,30 +524,59 @@ void main() {
       check(data.quests.length).equals(1);
     });
 
-    test('executes batch mutations atomically', () async {
+    test(
+      'executes batch mutations with operations list and legacy formats',
+      () async {
+        final runner = SidequestCliRunner(store: store);
+
+        // 1. Operations list format
+        final batchListJson = jsonEncode([
+          {'type': 'subquest_add', 'questId': '1', 'title': 'Batch SubQuest 1'},
+          {'type': 'step_add', 'subquestId': '1.1', 'title': 'Step 1.1.1'},
+          {
+            'type': 'blocker_add',
+            'subquestId': '1.1',
+            'title': 'Blocker 1.1.2',
+          },
+          {
+            'type': 'complete',
+            'ids': ['1.1.1'],
+          },
+          {
+            'type': 'vcs',
+            'quest': '1',
+            'stage': 'dirty',
+            'branch': 'feat/batch',
+            'files': ['lib/test.dart'],
+          },
+        ]);
+
+        await runner.run(['batch', batchListJson]);
+        var data = (await store.load())!;
+        check(data.quests[0].subQuests.length).equals(1);
+        check(data.quests[0].subQuests[0].items.length).equals(2);
+        check(
+          data.quests[0].subQuests[0].items[0].status,
+        ).equals(TaskStatus.completed);
+        check(data.quests[0].vcs?.branch).equals('feat/batch');
+
+        // 2. Legacy format
+        final legacyJson = jsonEncode({
+          'addSubQuest': {'quest': '1', 'title': 'Legacy SubQuest'},
+          'complete': ['1.1.2'],
+        });
+        await runner.run(['batch', legacyJson]);
+        data = (await store.load())!;
+        check(data.quests[0].subQuests.length).equals(2);
+        check(
+          data.quests[0].subQuests[0].items[1].status,
+        ).equals(TaskStatus.completed);
+      },
+    );
+
+    test('returns exit code 0 for help arguments', () async {
       final runner = SidequestCliRunner(store: store);
 
-      final batchJson = jsonEncode({
-        'addSubQuest': {'quest': '1', 'title': 'Batch SubQuest'},
-        'vcs': {
-          'quest': '1',
-          'stage': 'dirty',
-          'branch': 'feat/test',
-          'files': ['lib/a.dart'],
-        },
-      });
-
-      await runner.run(['batch', batchJson]);
-      final data = (await store.load())!;
-      check(data.quests[0].subQuests.length).equals(1);
-      check(data.quests[0].vcs?.stage).equals(VcsStage.dirty);
-      check(data.quests[0].vcs?.branch).equals('feat/test');
-    });
-
-    test('returns exit code 0 for help arguments and empty input', () async {
-      final runner = SidequestCliRunner(store: store);
-
-      check(await runner.run([])).equals(0);
       check(await runner.run(['--help'])).equals(0);
       check(await runner.run(['-h'])).equals(0);
       check(await runner.run(['help'])).equals(0);

--- a/tool/test/sidequest_test.dart
+++ b/tool/test/sidequest_test.dart
@@ -289,19 +289,30 @@ void main() {
       },
     );
 
-    test('resolves directory across multi-tier discovery hierarchy', () {
+    test('resolves directory across multi-tier discovery hierarchy', () async {
       // 1. Explicit override
       check(
         SessionStore.resolveDirectory('/explicit/dir', environment: {}),
       ).equals('/explicit/dir');
 
-      // 2. Direct environment variables
+      // 2. Direct environment variables (SIDEQUEST_DIR takes precedence over others)
       check(
         SessionStore.resolveDirectory(
           null,
-          environment: {'SIDEQUEST_DIR': '/env/sidequest'},
+          environment: {
+            'SIDEQUEST_DIR': '/env/sidequest',
+            'JETSKI_ARTIFACT_DIR': '/env/jetski',
+            'CLAUDE_ARTIFACT_DIR': '/env/claude',
+          },
         ),
       ).equals('/env/sidequest');
+
+      check(
+        SessionStore.resolveDirectory(
+          null,
+          environment: {'JETSKI_ARTIFACT_DIR': '/env/jetski'},
+        ),
+      ).equals('/env/jetski');
 
       check(
         SessionStore.resolveDirectory(
@@ -328,7 +339,22 @@ void main() {
         ),
       ).equals('/usr/home/testuser/.gemini/jetski/brain/abc-123-xyz');
 
-      // 4. Default fallback to cwd
+      // 4. .sidequest folder in cwd
+      final testCwd = await Directory.systemTemp.createTemp('sidequest_cwd_');
+      final dotSidequest = Directory(p.join(testCwd.path, '.sidequest'));
+      await dotSidequest.create();
+
+      check(
+        SessionStore.resolveDirectory(
+          null,
+          environment: {},
+          currentDirectory: testCwd.path,
+        ),
+      ).equals(dotSidequest.path);
+
+      await testCwd.delete(recursive: true);
+
+      // 5. Default fallback to cwd
       check(
         SessionStore.resolveDirectory(
           null,
@@ -502,10 +528,11 @@ void main() {
       check(data.globalSideQuests[0].completionOrder).equals(1);
       check(data.lastCompletionOrder).equals(1);
 
-      // Complete MainQuest 1
+      // Complete MainQuest 1 (MainQuest does not carry completionOrder and should NOT advance lastCompletionOrder)
       await runner.run(['complete', '1']);
       data = (await store.load())!;
       check(data.quests[0].status).equals(QuestStatus.completed);
+      check(data.lastCompletionOrder).equals(1);
 
       // Reopen Global SideQuest G1
       await runner.run(['reopen', 'G1']);
@@ -529,8 +556,9 @@ void main() {
       () async {
         final runner = SidequestCliRunner(store: store);
 
-        // 1. Operations list format
+        // 1. Operations list format including quest_add
         final batchListJson = jsonEncode([
+          {'type': 'quest_add', 'title': 'Batch Main Quest 2'},
           {'type': 'subquest_add', 'questId': '1', 'title': 'Batch SubQuest 1'},
           {'type': 'step_add', 'subquestId': '1.1', 'title': 'Step 1.1.1'},
           {
@@ -553,6 +581,8 @@ void main() {
 
         await runner.run(['batch', batchListJson]);
         var data = (await store.load())!;
+        check(data.quests.length).equals(2);
+        check(data.quests[1].title).equals('Batch Main Quest 2');
         check(data.quests[0].subQuests.length).equals(1);
         check(data.quests[0].subQuests[0].items.length).equals(2);
         check(
@@ -573,6 +603,50 @@ void main() {
         ).equals(TaskStatus.completed);
       },
     );
+
+    test('updates VCS state via CLI and handles unknown items', () async {
+      final runner = SidequestCliRunner(store: store);
+
+      // VCS update
+      final vcsCode = await runner.run([
+        'vcs',
+        '1',
+        '--stage=local_commit',
+        '--branch=feat/vcs-test',
+        '--files=lib/a.dart,lib/b.dart',
+        '--details=Ready for review',
+      ]);
+      check(vcsCode).equals(0);
+
+      final data = (await store.load())!;
+      check(data.quests[0].vcs?.stage).equals(VcsStage.localCommit);
+      check(data.quests[0].vcs?.branch).equals('feat/vcs-test');
+      check(
+        data.quests[0].vcs!.modifiedFiles,
+      ).deepEquals(['lib/a.dart', 'lib/b.dart']);
+      check(data.quests[0].vcs?.details).equals('Ready for review');
+
+      // Unknown ID complete returns 1
+      final missingCode = await runner.run(['complete', 'non_existent_id']);
+      check(missingCode).equals(1);
+    });
+
+    test('merges audit payload using positional or option argument', () async {
+      final runner = SidequestCliRunner(store: store);
+
+      final auditPayload = SidequestData.initial(
+        firstQuestTitle: 'Audited Main Quest',
+      );
+      final payloadFile = File(p.join(tempDir.path, 'audit_payload.json'));
+      await payloadFile.writeAsString(auditPayload.toJsonString());
+
+      // Merge with positional arg
+      final code = await runner.run(['merge-audit', payloadFile.path]);
+      check(code).equals(0);
+
+      final data = (await store.load())!;
+      check(data.quests.first.title).equals('Audited Main Quest');
+    });
 
     test('returns exit code 0 for help arguments', () async {
       final runner = SidequestCliRunner(store: store);


### PR DESCRIPTION
- Auto-resolve session directory via ANTIGRAVITY_CONVERSATION_ID, CLAUDE_ARTIFACT_DIR, GEMINI_ARTIFACT_DIR, SIDEQUEST_DIR, or .sidequest/
- Migrate CLI command runner to standard package:args/command_runner.dart with discrete subcommands
- Add compact 10-line `status` command (and default execution when state exists)
- Add variadic multi-item completion, reopen, and removal (e.g. `sidequest complete 1.1 1.2 1.3`)
- Enforce strict canonical command verbs with zero aliases (status, complete, reopen, remove, quest add, subquest add, step add, blocker add, sidequest add)
- Support operations list batch execution (`batch '[{"type":"step_add",...}]'`)
- Streamline SKILL.md instructions to eliminate first-run friction
- Add 62 unit and integration tests covering multi-tier discovery, variadic mutations, batch execution, and alias rejection