### PR TITLE
fix(sidequest): prevent premature dirty vcs state on quest creation

### DIFF
--- a/skills/sidequest/lib/src/cli/command_runner.dart
+++ b/skills/sidequest/lib/src/cli/command_runner.dart
@@ -203,12 +203,7 @@ class QuestAddCommand extends SidequestCommand {
         data.quests.map((q) => int.tryParse(q.id) ?? 0).fold(0, max) + 1;
     final newId = '$nextQuestNumber';
     data.quests.add(
-      MainQuest(
-        id: newId,
-        title: title,
-        status: QuestStatus.active,
-        vcs: const VcsState(stage: VcsStage.dirty),
-      ),
+      MainQuest(id: newId, title: title, status: QuestStatus.active, vcs: null),
     );
     await store.save(data);
     stdout.writeln('✔ Added Main Quest $newId: "$title"');

--- a/skills/sidequest/lib/src/cli/command_runner.dart
+++ b/skills/sidequest/lib/src/cli/command_runner.dart
@@ -1069,7 +1069,9 @@ void _applyBatchQuestAdd(SidequestData data, Map<String, dynamic> op) {
       id: '$nextQuestNumber',
       title: title,
       status: QuestStatus.active,
-      vcs: const VcsState(stage: VcsStage.dirty),
+      vcs: op['vcs'] != null
+          ? VcsState.fromJson(op['vcs'] as Map<String, dynamic>)
+          : null,
     ),
   );
 }

--- a/skills/sidequest/lib/src/emitter/markdown_emitter.dart
+++ b/skills/sidequest/lib/src/emitter/markdown_emitter.dart
@@ -33,6 +33,7 @@ class MarkdownEmitter {
     final dirtyLines = <String>[];
 
     for (final sq in data.globalSideQuests) {
+      if (sq.status == SideQuestStatus.completed) continue;
       final vcs = sq.vcs;
       if (vcs != null && _isVcsDirty(vcs)) {
         final statusLabel = switch (sq.status) {
@@ -45,12 +46,14 @@ class MarkdownEmitter {
     }
 
     for (final quest in data.quests) {
+      if (quest.status == QuestStatus.completed) continue;
       final vcs = quest.vcs;
       if (vcs != null && _isVcsDirty(vcs)) {
         dirtyLines.add(_formatDirtyLine('Main Quest ${quest.id}', vcs));
       }
 
       for (final sq in quest.sideQuests) {
+        if (sq.status == SideQuestStatus.completed) continue;
         final sqVcs = sq.vcs;
         if (sqVcs != null && _isVcsDirty(sqVcs)) {
           final statusLabel = switch (sq.status) {

--- a/skills/sidequest/lib/src/models/sidequest_data.dart
+++ b/skills/sidequest/lib/src/models/sidequest_data.dart
@@ -231,7 +231,7 @@ class SidequestData {
           id: '1',
           title: firstQuestTitle,
           status: QuestStatus.active,
-          vcs: const VcsState(stage: VcsStage.dirty),
+          vcs: null,
         ),
       ],
     );

--- a/tool/test/sidequest_test.dart
+++ b/tool/test/sidequest_test.dart
@@ -252,6 +252,59 @@ void main() {
       final markdown = MarkdownEmitter.emit(data);
       check(markdown).not((c) => c.contains('> [!CAUTION]'));
     });
+
+    test('omits CAUTION header when quests have null vcs', () {
+      final data = SidequestData(
+        version: 1,
+        quests: [
+          MainQuest(
+            id: '1',
+            title: 'Fresh Quest',
+            status: QuestStatus.active,
+            vcs: null,
+          ),
+        ],
+      );
+
+      final markdown = MarkdownEmitter.emit(data);
+      check(markdown).not((c) => c.contains('> [!CAUTION]'));
+    });
+
+    test('omits CAUTION header for completed quests even if vcs was dirty', () {
+      final data = SidequestData(
+        version: 1,
+        quests: [
+          MainQuest(
+            id: '1',
+            title: 'Completed Quest with Stale Dirty State',
+            status: QuestStatus.completed,
+            vcs: const VcsState(
+              stage: VcsStage.dirty,
+              modifiedFiles: ['lib/stale.dart'],
+            ),
+            sideQuests: [
+              SideQuest(
+                id: 'S1',
+                title: 'Completed Side Quest with Stale Dirty State',
+                status: SideQuestStatus.completed,
+                vcs: const VcsState(stage: VcsStage.dirty),
+              ),
+            ],
+          ),
+        ],
+        globalSideQuests: [
+          SideQuest(
+            id: 'G1',
+            title: 'Completed Global Side Quest with Stale Dirty State',
+            status: SideQuestStatus.completed,
+            vcs: const VcsState(stage: VcsStage.dirty),
+          ),
+        ],
+      );
+
+      final markdown = MarkdownEmitter.emit(data);
+      check(markdown).not((c) => c.contains('> [!CAUTION]'));
+    });
   });
 
   group('SessionStore & Atomic Persistence', () {


### PR DESCRIPTION
- Initialize new quests with vcs=null instead of defaulting to VcsStage.dirty
- Update MarkdownEmitter._renderCautionHeader to ignore completed quests and completed side quests
- Add regression unit tests verifying that fresh and completed quests omit the CAUTION header
