### PR TITLE
Migrate tool to published skills_lint package (^0.5.1)

### DIFF
--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -11,18 +11,14 @@ dependencies:
   path: ^1.9.0
 
 dev_dependencies:
+  checks: ^0.3.0
   deslop_duplication_audit:
     path: ../skills/deslop-duplication-audit
   github_post:
     path: ../skills/github-post
+  logging: ^1.3.0
   sidequest:
     path: ../skills/sidequest
+  skills_lint: ^0.5.1
   test: ^1.24.0
-  checks: ^0.3.0
-  logging: ^1.3.0
   test_process: ^2.1.1
-  dart_skills_lint:
-    git:
-      url: https://github.com/flutter/skills
-      path: tool/dart_skills_lint
-      ref: a037a4a343f9ebdb4aac44588d411f3d760a2c79

--- a/tool/skills_lint.yaml
+++ b/tool/skills_lint.yaml
@@ -1,4 +1,4 @@
-dart_skills_lint:
+skills_lint:
   rules:
     check-relative-paths: error
     check-absolute-paths: error

--- a/tool/test/validate_skills_test.dart
+++ b/tool/test/validate_skills_test.dart
@@ -1,13 +1,14 @@
 import 'dart:io';
-import 'package:dart_skills_lint/dart_skills_lint.dart';
+
 import 'package:logging/logging.dart';
+import 'package:skills_lint/skills_lint.dart';
 import 'package:test/test.dart';
 import 'package:test_process/test_process.dart';
 
 final String _configFilePath =
     Directory.current.path.split(Platform.pathSeparator).last == 'tool'
-    ? 'dart_skills_lint.yaml'
-    : 'tool/dart_skills_lint.yaml';
+    ? 'skills_lint.yaml'
+    : 'tool/skills_lint.yaml';
 
 final String _skillsDirPath =
     Directory.current.path.split(Platform.pathSeparator).last == 'tool'


### PR DESCRIPTION
Agent authored description is correct. skills_lint is the new name of the package at google/skills_lint.dart 
- @reidbaker 

Agent authored description
---
Migrates the \`tool\` skill validation setup from the legacy \`dart_skills_lint\` repository dependency to the official published [\`skills_lint: ^0.5.1\`](https://pub.dev/packages/skills_lint) package on pub.dev.

### Summary of Changes
- Updated \`tool/pubspec.yaml\` to depend on \`skills_lint: ^0.5.1\`.
- Renamed \`tool/dart_skills_lint.yaml\` to \`tool/skills_lint.yaml\` and updated the root configuration key.
- Updated \`tool/test/validate_skills_test.dart\` imports and configuration filename.
- Verified with \`dart pub get\`, \`dart analyze --fatal-infos\`, and \`dart test\` (all 73 tests passed cleanly).