### PR TITLE
feat: add evaluation framework and refine top skill contracts

### DIFF
--- a/evals/code_quality_rubric.json
+++ b/evals/code_quality_rubric.json
@@ -1,0 +1,42 @@
+{
+  "evals": [
+    {
+      "id": "compilation_and_health",
+      "expected_repo_state": [
+        "The generated code compiles with zero syntax errors.",
+        "Static analysis passes cleanly ('dart analyze --fatal-infos' returns zero errors or warnings).",
+        "Existing and newly added unit, widget, or integration tests execute and pass successfully."
+      ]
+    },
+    {
+      "id": "effective_dart_and_idioms",
+      "expected_repo_state": [
+        "Follows Effective Dart style guidelines as enforced by standard 'core' and 'recommended' linter rules.",
+        "Leverages Dart 3 idioms such as switch expressions and exhaustive pattern matching when conditional logic branches on algebraic types.",
+        "Avoids anti-patterns such as unnecessary dynamic types, raw Strings instead of string interpolation, or unhandled Futures."
+      ]
+    },
+    {
+      "id": "cross_platform_compatibility",
+      "expected_repo_state": [
+        "File paths and CLI path parameters use platform-agnostic formatters (package:path or forward slashes '/').",
+        "CLI commands and shell invocation scripts use cross-platform compatible syntax.",
+        "Avoids hardcoded platform-specific environment paths (such as C:\\ or /usr/local/bin directly)."
+      ]
+    },
+    {
+      "id": "directory_and_placement_hygiene",
+      "expected_repo_state": [
+        "Source code must be placed in 'lib/', tests in 'test/', and executable scripts in 'bin/' or 'tool/'.",
+        "No temporary scratch files or orphaned directories are left behind after execution."
+      ]
+    },
+    {
+      "id": "lint_cheating",
+      "expected_repo_state": [
+        "No lint configurations (e.g., analysis_options.yaml or its rules) are removed or disabled.",
+        "No file-level Dart ignores (e.g., // ignore_for_file:) are added to any Dart files."
+      ]
+    }
+  ]
+}

--- a/skills/clarify-confirm-continue/SKILL.md
+++ b/skills/clarify-confirm-continue/SKILL.md
@@ -110,11 +110,11 @@ Configure the `options` array with:
 - **If "Open in artifact"**: Use `write_to_file` to save the structured summary
   and execution plan as a markdown artifact (`.md` file) in the session's
   artifact directory. Configure the file to request interactive
-  approval/feedback (e.g., set `RequestFeedback: true` in Antigravity's
-  `ArtifactMetadata` to render a 'Proceed' button). If the harness does not
-  support interactive gates, instruct the user in chat to review the file and
-  reply 'Proceed' when they are ready. Stop calling tools and go idle to await
-  reactive wakeup.
+  approval/feedback (e.g., set `ArtifactMetadata` with `UserFacing: true`,
+  `RequestFeedback: true`, and a concise `Summary` to render an interactive
+  'Proceed' button). If the harness does not support interactive gates,
+  instruct the user in chat to review the file and reply 'Proceed' when they are
+  ready. Stop calling tools and go idle to await reactive wakeup.
 - **If "No, adjust in chat" or Custom Write-In**: Apply user feedback, adjust
   the scope or plan accordingly, and re-confirm if substantial changes were
   made.

--- a/skills/clarify-confirm-continue/evals/evals.json
+++ b/skills/clarify-confirm-continue/evals/evals.json
@@ -1,0 +1,32 @@
+{
+  "repo_criteria": [
+    "evals/code_quality_rubric.json"
+  ],
+  "evals": [
+    {
+      "id": "ccc_task_1",
+      "prompt": "Evaluate clarify-confirm-continue handling of Fake Dilemmas. Request a trivial linting fix and ensure it executes standard best practices autonomously without prompting for genuine decision forks.",
+      "expected_chat_output": [
+        "The task is completed directly without invoking an ask_question gate for fake dilemmas like 'Should I format code?'"
+      ],
+      "expected_repo_state": [
+        "The workspace lints are fixed.",
+        "No unexpected files or intermediate artifacts are created from fake forks."
+      ],
+      "agent_config": "bare-agent"
+    },
+    {
+      "id": "ccc_task_2",
+      "prompt": "Test clarify-confirm-continue with an ambiguous instruction 'update the README'. The agent should fact-check, identify genuine decision forks on technical depth, and use ask_question.",
+      "expected_chat_output": [
+        "The ask_question tool is called with a single readiness gate containing the markdown structured summary directly inside its question argument.",
+        "The question includes '🎯 Goals', '🛡️ Non-Goals', '📌 Settled Decisions', and '🛠️ Execution Plan'."
+      ],
+      "expected_repo_state": [
+        "No files are modified before explicit approval.",
+        "If 'Open in artifact' is selected, a .md artifact exists containing the execution summary."
+      ],
+      "agent_config": "bare-agent"
+    }
+  ]
+}

--- a/skills/github-pr-triage/SKILL.md
+++ b/skills/github-pr-triage/SKILL.md
@@ -193,7 +193,7 @@ key_features:
        `git add <files>` or `git add .` if no untracked scratch files exist)
        and create a descriptive commit.
      - If pushing is selected, run `git push`.
-     - If replying and resolving is selected, execute the `gh api` commands
+     - If replying and resolving is selected, execute the `triage.dart resolve` commands
        using the patterns listed below.
 
 ## Replying and Resolving Comments
@@ -203,12 +203,14 @@ For every addressed review thread, you MUST execute thread resolution (thread re
 Use the `resolve` subcommand in `triage.dart` to programmatically reply to comments and resolve threads without shell-escaping issues:
 
 ```bash
-# Reply to a comment and resolve its thread:
-dart run <path-to-github-pr-triage-skill>/bin/triage.dart resolve <thread_graphql_id> <comment_database_id> "<your reply body>"
+# Reply to a comment and resolve its thread (pass --dir if outside target repo):
+dart run <path-to-github-pr-triage-skill>/bin/triage.dart resolve --dir <path-to-target-repository> <thread_graphql_id> <comment_database_id> "<your reply body>"
 
 # Or resolve a thread without posting a reply:
-dart run <path-to-github-pr-triage-skill>/bin/triage.dart resolve <thread_graphql_id>
+dart run <path-to-github-pr-triage-skill>/bin/triage.dart resolve --dir <path-to-target-repository> <thread_graphql_id>
 ```
+
+*Note: `<thread_graphql_id>` is the GraphQL node ID (e.g., `PRRT_...`) and `<comment_database_id>` is the numeric database ID (e.g., `3438780787`), exactly as output in `raw_triage_output.md`.*
 
 
 ## Constraints

--- a/skills/github-pr-triage/evals/evals.json
+++ b/skills/github-pr-triage/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "repo_criteria": [
+    "evals/code_quality_rubric.json"
+  ],
+  "evals": [
+    {
+      "id": "pr_triage_task_1",
+      "prompt": "Run github-pr-triage on a PR with review comments. Assess its triage capabilities.",
+      "expected_chat_output": [
+        "Agent outputs a raw_triage_output.md initially, identifies reviewer comments and builds a triage plan.",
+        "Generates pr_triage_report.md before applying fixes.",
+        "A unified completion menu is presented if the working tree has uncommitted fixes."
+      ],
+      "expected_repo_state": [
+        "raw_triage_output.md is present in artifacts.",
+        "pr_triage_report.md is generated containing Thread/Comment IDs.",
+        "Local changes match the agreed fixes.",
+        "No commit --amend or git push -f operations are executed."
+      ],
+      "agent_config": "bare-agent"
+    }
+  ]
+}

--- a/skills/just-brainstorm/evals/evals.json
+++ b/skills/just-brainstorm/evals/evals.json
@@ -1,0 +1,21 @@
+{
+  "repo_criteria": [
+    "evals/code_quality_rubric.json"
+  ],
+  "evals": [
+    {
+      "id": "just_brainstorm_1",
+      "prompt": "Just brainstorming here - what if we migrated our auth module to use Spanner instead of Bigtable?",
+      "expected_chat_output": [
+        "Generates the brainstorming output to a Markdown artifact.",
+        "Does not make any code changes."
+      ],
+      "expected_repo_state": [
+        "A .md artifact is created containing pros/cons and tradeoffs.",
+        "The artifact uses RequestFeedback: false.",
+        "No original project files are modified or overwritten."
+      ],
+      "agent_config": "bare-agent"
+    }
+  ]
+}

--- a/skills/new-worktree/SKILL.md
+++ b/skills/new-worktree/SKILL.md
@@ -63,16 +63,21 @@ When creating a worktree, observe strict placement and naming rules:
 1. **Verify Pre-Flight Boundaries**: Confirm location under `~/github`, confirm
    Git repository status, and ensure the repo is not the Dart SDK. Do not require
    a clean working directory; worktrees allow branching safely from a dirty tree.
-2. **Fetch Latest Remote State**: Run `git fetch origin` to ensure local tracking
-   branches are up to date. Always base new branches on the latest public default
-   branch (`origin/main`, `origin/master`, or `origin/HEAD`).
+2. **Fetch Latest Remote State & Resolve Base Branch**: Run `git fetch origin` to ensure
+   local tracking branches are up to date. Dynamically resolve the remote default
+   branch (`origin/HEAD`, `origin/main`, or `origin/master`):
+   ```bash
+   TARGET_BASE=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null || (git show-ref --verify --quiet refs/remotes/origin/main && echo "origin/main") || echo "origin/master")
+   ```
 3. **Formulate Target Names**: Determine `{branch_name}` and sibling directory
    path `{sibling_worktree_path}` based on naming rules.
-4. **Execute Worktree Creation**:
+4. **Collision Pre-Flight & Stale Worktree Pruning**:
+   - Check if `{sibling_worktree_path}` or local `{branch_name}` already exists.
+   - If previous worktrees were removed manually, run `git worktree prune` to clear stale metadata.
+5. **Execute Worktree Creation**:
    ```bash
-   git worktree add -b {branch_name} {sibling_worktree_path} origin/main
+   git worktree add -b {branch_name} {sibling_worktree_path} ${TARGET_BASE}
    ```
-   *(Substitute `origin/master` or `origin/HEAD` if appropriate for the repo).*
-5. **Output Clickable Link**: Provide the user with a clickable link to the new
+6. **Output Clickable Link**: Provide the user with a clickable link to the new
    worktree using the precise scheme `[link text](file:///absolute/path/to/worktree)`.
    Never wrap link text or syntax in backticks.

--- a/skills/new-worktree/evals/evals.json
+++ b/skills/new-worktree/evals/evals.json
@@ -1,0 +1,31 @@
+{
+  "repo_criteria": [
+    "evals/code_quality_rubric.json"
+  ],
+  "evals": [
+    {
+      "id": "new_worktree_task_1",
+      "prompt": "Invoke new-worktree to fix flutter issue #999 within ~/github/flutter.",
+      "expected_chat_output": [
+        "Produces a clickable link formatted exactly as [link text](file:///absolute/path/to/worktree)."
+      ],
+      "expected_repo_state": [
+        "A sibling worktree directory `~/github/_flutter-issue-999` is created.",
+        "The branch `issue-999` is created off of origin/master or origin/main."
+      ],
+      "agent_config": "bare-agent"
+    },
+    {
+      "id": "new_worktree_task_2",
+      "prompt": "Attempt to invoke new-worktree inside ~/github/dart-sdk and inside a non-github directory like ~/.dotfiles.",
+      "expected_chat_output": [
+        "Hard block triggered for Dart SDK with clarification ask.",
+        "Hard block triggered for non-github folder with a warning."
+      ],
+      "expected_repo_state": [
+        "No worktrees or branches are created."
+      ],
+      "agent_config": "bare-agent"
+    }
+  ]
+}

--- a/skills/quick-question/evals/evals.json
+++ b/skills/quick-question/evals/evals.json
@@ -1,0 +1,22 @@
+{
+  "repo_criteria": [
+    "evals/code_quality_rubric.json"
+  ],
+  "evals": [
+    {
+      "id": "quick_question_1",
+      "prompt": "qq why does flutter use dart?",
+      "expected_chat_output": [
+        "Provides a brief TL;DR directly in chat.",
+        "Uses bullet points instead of a markdown table.",
+        "Does NOT ask questions via ask_question.",
+        "Does NOT create a .md artifact."
+      ],
+      "expected_repo_state": [
+        "No artifact files are written to disk.",
+        "No codebase modifications occur."
+      ],
+      "agent_config": "bare-agent"
+    }
+  ]
+}

--- a/skills/sidequest/SKILL.md
+++ b/skills/sidequest/SKILL.md
@@ -62,20 +62,23 @@ Execute `sidequest` (or `dart run <path-to-skill>/bin/sidequest.dart`):
 # 1. Inspect Current State (Outputs compact overview to stdout)
 sidequest status
 
-# 2. Add Quests, Sub-Quests, Steps, Blockers (Auto-initializes if not present)
-sidequest quest add "Title"
+# 2. Initialize or Add Quests, Sub-Quests, Steps, Blockers
+sidequest init "Title"
 sidequest subquest add 1 "UI Implementation"
 sidequest step add 1.1 "Draft UI widget"
 sidequest blocker add 1.1 "Broken build dependency"
 sidequest sidequest add "Tangent item" [--global] [--parked] [--note="..."]
 
-# 3. Complete One or Multiple Items (Atomic disk write & star update)
+# 3. Batch Operations (Atomic multi-item execution in a single call)
+sidequest batch '[{"op":"subquest_add","quest_id":"1","title":"Backend"},{"op":"step_add","subquest_id":"1.2","title":"API client"}]'
+
+# 4. Complete One or Multiple Items (Atomic disk write & star update)
 sidequest complete 1.1.1 1.1.2 1.1
 
-# 4. Update VCS Lifecycle
+# 5. Update VCS Lifecycle
 sidequest vcs 1 --stage=dirty|local_commit|uploaded|merged|clean [--branch=B] [--files=F]
 
-# 5. Reopen or Remove
+# 6. Reopen or Remove
 sidequest reopen 1.1
 sidequest remove 1.1.2
 ```

--- a/skills/sidequest/evals/evals.json
+++ b/skills/sidequest/evals/evals.json
@@ -1,0 +1,22 @@
+{
+  "repo_criteria": [
+    "evals/code_quality_rubric.json"
+  ],
+  "evals": [
+    {
+      "id": "sidequest_task_1",
+      "prompt": "Start a new sidequest mapping. Add a main quest and complete two steps.",
+      "expected_chat_output": [
+        "Outputs a brief, punchy chat summary.",
+        "Places the clickable link to the generated artifact at the very BOTTOM of the chat reply with an emoji anchor."
+      ],
+      "expected_repo_state": [
+        "Creates sidequest.json and sidequest.md in the artifact directory.",
+        "sidequest.json maintains the deterministic state model.",
+        "sidequest.md visual hierarchy uses [#N ⭐] tags for latest completion.",
+        "No manual text modifications of sidequest.json occurred (only via CLI)."
+      ],
+      "agent_config": "bare-agent"
+    }
+  ]
+}

--- a/tool/test/skills_evals_test.dart
+++ b/tool/test/skills_evals_test.dart
@@ -1,0 +1,214 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+Directory _getRepoRoot() {
+  return Directory.current.path.endsWith('tool')
+      ? Directory.current.parent
+      : Directory.current;
+}
+
+List<File> _findEvalsFiles(Directory baseDir) {
+  if (!baseDir.existsSync()) {
+    return [];
+  }
+  return baseDir.listSync(recursive: true).whereType<File>().where((File f) {
+    final String name = p.basename(f.path);
+    return name == 'evals.json' || name.endsWith('_evals.json');
+  }).toList();
+}
+
+void _verifyStructuralConsistency(List<File> files, String itemsKey) {
+  Set<String>? expectedRootKeys;
+  String? expectedRootKeysFilePath;
+  Set<String>? expectedItemKeys;
+  String? expectedItemFilePath;
+
+  for (final file in files) {
+    final Object? decoded = jsonDecode(file.readAsStringSync());
+    final Map<String, dynamic> decodedMap = switch (decoded) {
+      final Map<String, dynamic> map => map,
+      _ => fail('${file.path} must be a JSON map.'),
+    };
+    final Set<String> rootKeys = decodedMap.keys.toSet();
+    if (expectedRootKeys == null) {
+      expectedRootKeys = rootKeys;
+      expectedRootKeysFilePath = file.path;
+    } else {
+      expect(
+        rootKeys,
+        equals(expectedRootKeys),
+        reason:
+            '${file.path} root keys do not match consistency pattern. '
+            'Expected keys to match the first processed file ($expectedRootKeysFilePath).',
+      );
+    }
+
+    final Object? itemsRaw = decodedMap[itemsKey];
+    final List<dynamic> itemsList = switch (itemsRaw) {
+      final List<dynamic> list => list,
+      _ => fail('$itemsKey key in ${file.path} must be a List.'),
+    };
+    for (final Object? item in itemsList) {
+      final Map<String, dynamic> itemMap = switch (item) {
+        final Map<String, dynamic> map => map,
+        _ => fail('Item in $itemsKey list in ${file.path} must be a JSON map.'),
+      };
+      final Set<String> itemKeys = itemMap.keys.toSet();
+      if (expectedItemKeys == null) {
+        expectedItemKeys = itemKeys;
+        expectedItemFilePath = file.path;
+      } else {
+        expect(
+          itemKeys,
+          equals(expectedItemKeys),
+          reason:
+              'Item in ${file.path} keys do not match consistency pattern. '
+              'Expected item keys to match the first processed file ($expectedItemFilePath).',
+        );
+      }
+    }
+  }
+}
+
+void main() {
+  group('Evals structure consistency', () {
+    test(
+      'all evals.json files across skills share consistent structure and keys',
+      () {
+        final repoRoot = _getRepoRoot();
+        final List<File> evalsFiles = [
+          ..._findEvalsFiles(Directory(p.join(repoRoot.path, 'skills'))),
+          ..._findEvalsFiles(Directory(p.join(repoRoot.path, 'evals'))),
+        ]..sort((a, b) => a.path.compareTo(b.path));
+
+        expect(
+          evalsFiles,
+          isNotEmpty,
+          reason:
+              'Should find at least one evals.json file in skills or evals.',
+        );
+
+        _verifyStructuralConsistency(evalsFiles, 'evals');
+      },
+    );
+
+    test('all published skills with evals have an evals.json file', () {
+      final repoRoot = _getRepoRoot();
+      final skillsDir = Directory(p.join(repoRoot.path, 'skills'));
+      if (!skillsDir.existsSync()) {
+        return;
+      }
+
+      final List<Directory> skillDirsWithEvals = skillsDir
+          .listSync()
+          .whereType<Directory>()
+          .where((dir) => Directory(p.join(dir.path, 'evals')).existsSync())
+          .toList();
+
+      expect(
+        skillDirsWithEvals,
+        isNotEmpty,
+        reason: 'Expected at least one published skill to define evals.',
+      );
+
+      for (final skillDir in skillDirsWithEvals) {
+        final evalsFile = File(p.join(skillDir.path, 'evals', 'evals.json'));
+        expect(
+          evalsFile.existsSync(),
+          isTrue,
+          reason:
+              'Published skill "${p.basename(skillDir.path)}" has an evals directory but is missing an evals.json file at ${evalsFile.path}',
+        );
+      }
+    });
+
+    test(
+      'all referenced rubrics in evals.json exist and have valid structure',
+      () {
+        final repoRoot = _getRepoRoot();
+        final List<File> evalsFiles = [
+          ..._findEvalsFiles(Directory(p.join(repoRoot.path, 'skills'))),
+          ..._findEvalsFiles(Directory(p.join(repoRoot.path, 'evals'))),
+        ];
+
+        expect(evalsFiles, isNotEmpty);
+
+        for (final file in evalsFiles) {
+          final Object? decoded = jsonDecode(file.readAsStringSync());
+          final Map<String, dynamic> decodedMap = switch (decoded) {
+            final Map<String, dynamic> map => map,
+            _ => fail('${file.path} must be a JSON map.'),
+          };
+
+          final Object? repoCriteriaRaw = decodedMap['repo_criteria'];
+          if (repoCriteriaRaw == null) {
+            continue;
+          }
+
+          final List<dynamic> repoCriteriaList = switch (repoCriteriaRaw) {
+            final List<dynamic> list => list,
+            _ => fail('repo_criteria in ${file.path} must be a List.'),
+          };
+
+          for (final Object? rubricPath in repoCriteriaList) {
+            expect(rubricPath, isA<String>());
+            final rubricFile = File(
+              p.join(repoRoot.path, rubricPath as String),
+            );
+            expect(
+              rubricFile.existsSync(),
+              isTrue,
+              reason:
+                  'Referenced rubric "$rubricPath" in ${file.path} does not exist at ${rubricFile.path}',
+            );
+
+            final Object? rubricDecoded = jsonDecode(
+              rubricFile.readAsStringSync(),
+            );
+            final Map<String, dynamic> rubricMap = switch (rubricDecoded) {
+              final Map<String, dynamic> map => map,
+              _ => fail('${rubricFile.path} must be a JSON map.'),
+            };
+            expect(
+              rubricMap['evals'],
+              isA<List<dynamic>>(),
+              reason: '${rubricFile.path} must contain an "evals" array.',
+            );
+          }
+        }
+      },
+    );
+
+    test(
+      'all rubric JSON files in evals/ share consistent structure and keys',
+      () {
+        final repoRoot = _getRepoRoot();
+        final rubricsDir = Directory(p.join(repoRoot.path, 'evals'));
+        if (!rubricsDir.existsSync()) {
+          return;
+        }
+
+        final List<File> rubricFiles =
+            rubricsDir
+                .listSync()
+                .whereType<File>()
+                .where(
+                  (File f) =>
+                      f.path.endsWith('.json') &&
+                      !f.path.endsWith('_evals.json'),
+                )
+                .toList()
+              ..sort((a, b) => a.path.compareTo(b.path));
+
+        if (rubricFiles.isEmpty) {
+          return;
+        }
+
+        _verifyStructuralConsistency(rubricFiles, 'evals');
+      },
+    );
+  });
+}

--- a/tool/test/skills_evals_test.dart
+++ b/tool/test/skills_evals_test.dart
@@ -198,7 +198,8 @@ void main() {
                 .where(
                   (File f) =>
                       f.path.endsWith('.json') &&
-                      !f.path.endsWith('_evals.json'),
+                      !f.path.endsWith('_evals.json') &&
+                      p.basename(f.path) != 'evals.json',
                 )
                 .toList()
               ..sort((a, b) => a.path.compareTo(b.path));


### PR DESCRIPTION
### Rationale
Establishes the automated skill evaluation framework and baseline test suites for top-performing skills in the repository. Refines skill contracts based on dynamic evaluation findings to eliminate execution friction and ambiguity.

### Summary of Changes
- **Universal Quality Rubric**: Added `evals/code_quality_rubric.json` matching the standard schema from `dash_skills` and `skills_lint`.
- **Structural Consistency Test**: Added `tool/test/skills_evals_test.dart` to validate uniform schemas and valid rubric references across all `evals.json` suites.
- **Skill Evaluation Datasets**: Authored `evals/evals.json` benchmark suites for `sidequest`, `new-worktree`, `github-pr-triage`, `clarify-confirm-continue`, `quick-question`, and `just-brainstorm`.
- **Skill Contract Refinements**:
  - `sidequest`: Updated Step 2 to use `sidequest init "Title"` to prevent placeholder collisions, and added `sidequest batch` multi-operation examples under Mode A.
  - `new-worktree`: Added dynamic remote default branch detection and `git worktree prune` instructions for recovering from manually deleted worktree directories.
  - `github-pr-triage`: Added `--dir <path>` parameter to `triage.dart resolve` code examples and updated Step 8 to reference `triage.dart resolve` instead of raw `gh api`.
  - `clarify-confirm-continue`: Specified `UserFacing: true`, `RequestFeedback: true`, and `Summary` in Phase 3 artifact metadata instructions.

### Verification
- Executed `dart test` in `tool/` with 77/77 tests passing.
- Verified path hygiene, trailing whitespace, and formatting via `dart_skills_lint`.
- Executed static analysis (`dart analyze --fatal-infos`) with 0 errors/warnings across `tool/` and `skills/`.

Fixes #96
Fixes #97
Fixes #98
