### PR TITLE
feat(dart-cleanup): automate catalog generation, env audit, and commit tracking

### DIFF
--- a/skills/dart-cleanup/SKILL.md
+++ b/skills/dart-cleanup/SKILL.md
@@ -69,6 +69,16 @@ output:
 ## 📋 Skill Catalog & Path Priority
 
 <!-- DART_CLEANUP_CATALOG_START -->
+### Required Local Repositories
+
+<!-- mdformat off(prevent table wrapping) -->
+| Repository | Local Directory | Synced Commit |
+| :--- | :--- | :--- |
+| [`dart-lang/skills`](https://github.com/dart-lang/skills) | `~/github/skills` | [`26b2dcc`](https://github.com/dart-lang/skills/commit/26b2dcc5654cbbc3b2ec56ea94719469bc8bae9e) |
+| [`kevmoo/analytica.dart`](https://github.com/kevmoo/analytica.dart) | `~/github/kevmoo/analytica.dart` | [`1bba4de`](https://github.com/kevmoo/analytica.dart/commit/1bba4de81a526b3805561227fb1adeed4e3feb45) |
+| [`kevmoo/dash_skills`](https://github.com/kevmoo/dash_skills) | `~/github/kevmoo/dash_skills` | [`949bd00`](https://github.com/kevmoo/dash_skills/commit/949bd00b69fc8449c535aeb4f4970c7ec5e21b49) |
+<!-- mdformat on -->
+
 ### A. Refactoring & Code Quality
 * **`dart-build-cli-app`**: CLI entrypoint structure, argument parsing
   (`package:args`), cross-platform scripts, exit codes, and compilation.

--- a/skills/dart-cleanup/SKILL.md
+++ b/skills/dart-cleanup/SKILL.md
@@ -68,99 +68,101 @@ output:
 
 ## 📋 Skill Catalog & Path Priority
 
+<!-- DART_CLEANUP_CATALOG_START -->
 ### A. Refactoring & Code Quality
+* **`dart-build-cli-app`**: CLI entrypoint structure, argument parsing
+  (`package:args`), cross-platform scripts, exit codes, and compilation.
+  * *Path*: `~/github/skills/skills/dart-build-cli-app/SKILL.md`
 * **`dart-cognitive-complexity`**: Reduces cognitive complexity, nested loops,
   and deep conditionals via pattern matching & guard clauses. Includes a gated
   Tier 3 method-object reference for extreme cases.
-  * *Path*: [SKILL.md](file://~/github/kevmoo/analytica.dart/skills/dart-cognitive-complexity/SKILL.md)
-* **`dart-undead`**: Audits, triages, and safely remediates unreachable and
-  dead declarations in Dart and Flutter codebases using deterministic
-  reachability analysis (`pkg:undead`).
-  * *Path*: [SKILL.md](file://~/github/kevmoo/analytica.dart/skills/dart-undead/SKILL.md)
+  * *Path*: `~/github/kevmoo/analytica.dart/skills/dart-cognitive-complexity/SKILL.md`
 * **`dart-dedupe`**: Detects, audits, and safely remediates structural code
   duplication across Dart and Flutter repositories using the standalone Dedupe
   engine (`pkg:dedupe`) and empirical test gating.
-  * *Path*: [SKILL.md](file://~/github/kevmoo/analytica.dart/skills/dart-dedupe/SKILL.md)
-* **`dart-use-path-package`**: Cross-platform file and directory path
-  manipulation, segment splitting, and extension extraction using
-  `package:path` and `package:file`.
-  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-use-path-package/SKILL.md)
-* **`dart-build-cli-app`**: CLI entrypoint structure, argument parsing
-  (`package:args`), cross-platform scripts, exit codes, and compilation.
-  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-build-cli-app/SKILL.md)
-* **`dart-run-static-analysis`**: Executes `dart analyze` to catch issues and
-  `dart fix --apply` to automatically resolve mechanical lint warnings.
-  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-run-static-analysis/SKILL.md)
+  * *Path*: `~/github/kevmoo/analytica.dart/skills/dart-dedupe/SKILL.md`
 * **`dart-fix-runtime-errors`**: Resolves runtime errors, inspects active stack
   traces via `get_runtime_errors` and LSP, and verifies with hot reload.
-  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-fix-runtime-errors/SKILL.md)
+  * *Path*: `~/github/skills/skills/dart-fix-runtime-errors/SKILL.md`
+* **`dart-run-static-analysis`**: Executes `dart analyze` to catch issues and
+  `dart fix --apply` to automatically resolve mechanical lint warnings.
+  * *Path*: `~/github/skills/skills/dart-run-static-analysis/SKILL.md`
+* **`dart-undead`**: Audits, triages, and safely remediates unreachable and dead
+  declarations in Dart and Flutter codebases using deterministic reachability
+  analysis (`pkg:undead`).
+  * *Path*: `~/github/kevmoo/analytica.dart/skills/dart-undead/SKILL.md`
+* **`dart-use-path-package`**: Cross-platform file and directory path
+  manipulation, segment splitting, and extension extraction using `package:path`
+  and `package:file`.
+  * *Path*: `~/github/skills/skills/dart-use-path-package/SKILL.md`
 * **`profile-dart-code`**: Profiles Dart CLI applications using the VM Service
   protocol to capture CPU samples and pinpoint performance bottlenecks.
-  * *Path*: [SKILL.md](file://~/github/kevmoo/dash_skills/skills/profile-dart-code/SKILL.md)
+  * *Path*: `~/github/kevmoo/dash_skills/skills/profile-dart-code/SKILL.md`
 
 ### B. Language Modernization & Syntax
-* **`dart-use-pattern-matching`**: Applies Dart 3 pattern matching, switch
-  expressions, and destructuring to validate schemas and simplify control flow.
-  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-use-pattern-matching/SKILL.md)
-* **`dart-use-primary-constructors`**: Adopts primary constructor syntax,
-  empty-body semicolon syntax, in-body initializers, and concise forms.
-  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-use-primary-constructors/SKILL.md)
-* **`dart-modern-features`**: Records, pattern matching, switch expressions,
-  extension types, and class modifiers (`interface`, `base`, `sealed`, `final`).
-  * *Path*: [SKILL.md](file://~/github/kevmoo/dash_skills/skills/dart-modern-features/SKILL.md)
 * **`dart-best-practices`**: Effective Dart guidelines, class design, null
   safety, and idiomatic style conventions.
-  * *Path*: [SKILL.md](file://~/github/kevmoo/dash_skills/skills/dart-best-practices/SKILL.md)
-* **`dart-multiline-strings`**: Converts consecutive print statements and
-  string concatenations into clean triple-quoted multiline strings.
-  * *Path*: [SKILL.md](file://~/github/kevmoo/dash_skills/skills/dart-multiline-strings/SKILL.md)
+  * *Path*: `~/github/kevmoo/dash_skills/skills/dart-best-practices/SKILL.md`
 * **`dart-long-lines`**: Formats and refactors code to adhere to the 80-column
   line limit (`lines_longer_than_80_chars`).
-  * *Path*: [SKILL.md](file://~/github/kevmoo/dash_skills/skills/dart-long-lines/SKILL.md)
+  * *Path*: `~/github/kevmoo/dash_skills/skills/dart-long-lines/SKILL.md`
+* **`dart-modern-features`**: Records, pattern matching, switch expressions,
+  extension types, and class modifiers (`interface`, `base`, `sealed`, `final`).
+  * *Path*: `~/github/kevmoo/dash_skills/skills/dart-modern-features/SKILL.md`
+* **`dart-multiline-strings`**: Converts consecutive print statements and string
+  concatenations into clean triple-quoted multiline strings.
+  * *Path*: `~/github/kevmoo/dash_skills/skills/dart-multiline-strings/SKILL.md`
+* **`dart-use-pattern-matching`**: Applies Dart 3 pattern matching, switch
+  expressions, and destructuring to validate schemas and simplify control flow.
+  * *Path*: `~/github/skills/skills/dart-use-pattern-matching/SKILL.md`
+* **`dart-use-primary-constructors`**: Adopts primary constructor syntax,
+  empty-body semicolon syntax, in-body initializers, and concise forms.
+  * *Path*: `~/github/skills/skills/dart-use-primary-constructors/SKILL.md`
 
 ### C. Testing & Assertions
-* **`dart-migrate-to-checks-package`**: Migrates legacy `expect(a, equals(b))`
-  matchers from `package:matcher` to fluent `package:checks` syntax.
-  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-migrate-to-checks-package/SKILL.md)
 * **`dart-add-unit-test`**: Writes and organizes unit tests for functions,
   methods, and classes using `package:test` with clean structure.
-  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-add-unit-test/SKILL.md)
-* **`dart-generate-test-mocks`**: Defines and generates mock objects for
-  external dependencies using `package:mockito` and `build_runner`.
-  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-generate-test-mocks/SKILL.md)
-* **`dart-test-fundamentals`**: Core `package:test` practices, test grouping,
-  `setUp`/`tearDown` lifecycles, and `dart_test.yaml` configuration.
-  * *Path*: [SKILL.md](file://~/github/kevmoo/dash_skills/skills/dart-test-fundamentals/SKILL.md)
-* **`dart-matcher-best-practices`**: Best practices, custom matchers, and async
-  matcher patterns for legacy `package:matcher` assertions.
-  * *Path*: [SKILL.md](file://~/github/kevmoo/dash_skills/skills/dart-matcher-best-practices/SKILL.md)
+  * *Path*: `~/github/skills/skills/dart-add-unit-test/SKILL.md`
 * **`dart-collect-coverage`**: Collects test coverage using `package:coverage`
   and generates LCOV reports.
-  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-collect-coverage/SKILL.md)
+  * *Path*: `~/github/skills/skills/dart-collect-coverage/SKILL.md`
+* **`dart-generate-test-mocks`**: Defines and generates mock objects for
+  external dependencies using `package:mockito` and `build_runner`.
+  * *Path*: `~/github/skills/skills/dart-generate-test-mocks/SKILL.md`
+* **`dart-matcher-best-practices`**: Best practices, custom matchers, and async
+  matcher patterns for legacy `package:matcher` assertions.
+  * *Path*: `~/github/kevmoo/dash_skills/skills/dart-matcher-best-practices/SKILL.md`
+* **`dart-migrate-to-checks-package`**: Migrates legacy `expect(a, equals(b))`
+  matchers from `package:matcher` to fluent `package:checks` syntax.
+  * *Path*: `~/github/skills/skills/dart-migrate-to-checks-package/SKILL.md`
 * **`dart-test-coverage`**: Inspects, analyzes, and improves test coverage
   across a Dart package, locating missed lines.
-  * *Path*: [SKILL.md](file://~/github/kevmoo/dash_skills/skills/dart-test-coverage/SKILL.md)
+  * *Path*: `~/github/kevmoo/dash_skills/skills/dart-test-coverage/SKILL.md`
+* **`dart-test-fundamentals`**: Core `package:test` practices, test grouping,
+  `setUp`/`tearDown` lifecycles, and `dart_test.yaml` configuration.
+  * *Path*: `~/github/kevmoo/dash_skills/skills/dart-test-fundamentals/SKILL.md`
 
 ### D. Documentation, Packaging & Native Interop
-* **`dart-write-documentation`**: Effective Dart `///` doc comment
-  conventions, API documentation rules, and reference linking.
-  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-write-documentation/SKILL.md)
-* **`dart-use-doc-examples`**: Injects external code examples into Dartdoc via
-  `{@example}` directives and filters with `#region` tags.
-  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-use-doc-examples/SKILL.md)
 * **`dart-doc-validation`**: Validates doc comments using `dart doc` to catch
   broken or unresolved references and macros.
-  * *Path*: [SKILL.md](file://~/github/kevmoo/dash_skills/skills/dart-doc-validation/SKILL.md)
-* **`dart-use-ffigen`**: Automatically generates C/Objective-C/Swift FFI
-  bindings using `package:ffigen` instead of hand-crafting `dart:ffi`.
-  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-use-ffigen/SKILL.md)
-* **`dart-setup-ffi-assets`**: Compiles and packages C/C++ native assets using
-  Dart's Native Assets hook system (`hook/build.dart` and `hook/link.dart`).
-  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-setup-ffi-assets/SKILL.md)
-* **`dart-resolve-package-conflicts`**: Resolves package dependency version
-  conflicts when `pub get` fails due to incompatible constraints.
-  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-resolve-package-conflicts/SKILL.md)
+  * *Path*: `~/github/kevmoo/dash_skills/skills/dart-doc-validation/SKILL.md`
 * **`dart-package-maintenance`**: Best practices for package maintenance,
   versioning, changelog curation, and publishing workflows.
-  * *Path*: [SKILL.md](file://~/github/kevmoo/dash_skills/skills/dart-package-maintenance/SKILL.md)
+  * *Path*: `~/github/kevmoo/dash_skills/skills/dart-package-maintenance/SKILL.md`
+* **`dart-resolve-package-conflicts`**: Resolves package dependency version
+  conflicts when `pub get` fails due to incompatible constraints.
+  * *Path*: `~/github/skills/skills/dart-resolve-package-conflicts/SKILL.md`
+* **`dart-setup-ffi-assets`**: Compiles and packages C/C++ native assets using
+  Dart's Native Assets hook system (`hook/build.dart` and `hook/link.dart`).
+  * *Path*: `~/github/skills/skills/dart-setup-ffi-assets/SKILL.md`
+* **`dart-use-doc-examples`**: Injects external code examples into Dartdoc via
+  `{@example}` directives and filters with `#region` tags.
+  * *Path*: `~/github/skills/skills/dart-use-doc-examples/SKILL.md`
+* **`dart-use-ffigen`**: Automatically generates C/Objective-C/Swift FFI
+  bindings using `package:ffigen` instead of hand-crafting `dart:ffi`.
+  * *Path*: `~/github/skills/skills/dart-use-ffigen/SKILL.md`
+* **`dart-write-documentation`**: Effective Dart `///` doc comment conventions,
+  API documentation rules, and reference linking.
+  * *Path*: `~/github/skills/skills/dart-write-documentation/SKILL.md`
+<!-- DART_CLEANUP_CATALOG_END -->
 

--- a/skills/dart-cleanup/SKILL.md
+++ b/skills/dart-cleanup/SKILL.md
@@ -1,18 +1,26 @@
 ---
 name: dart-cleanup
 description: >-
-  Orchestrates specialized Dart refactoring, code quality, testing, and modern language features on demand. Use when cleaning up, modernizing, refactoring, or optimizing Dart code. Don't use for non-Dart projects or general codebase search.
+  Orchestrates specialized Dart refactoring, code quality, testing, and modern
+  language features on demand. Use when cleaning up, modernizing, refactoring,
+  or optimizing Dart code. Don't use for non-Dart projects or general codebase
+  search.
 author: kevmoo
 target_environment: personal
-compatibility: "Requires local checkouts in ~/github/kevmoo and ~/github/dart-lang"
+compatibility: "Requires local checkouts in ~/github/kevmoo and ~/github/skills"
 ---
 
 # 🎯 Dart Cleanup & Refactoring Router
 
 > [!NOTE]
-> **Personal Environment Router**: This skill is optimized for `@kevmoo`'s local development environment and assumes specialized skills are checked out under `~/github/kevmoo/` and `~/github/dart-lang/`. Other users should clone the required repositories or adapt the catalog paths in [Skill Catalog](#-skill-catalog) to match their local layout.
+> **Personal Environment Router**: This skill is optimized for `@kevmoo`'s
+> local development environment and assumes specialized skills are checked out
+> under `~/github/kevmoo/` and `~/github/skills/`. Other users should clone the
+> required repositories or adapt the catalog paths in
+> [Skill Catalog](#-skill-catalog) to match their local layout.
 
-Orchestrates specialized Dart workflows from local GitHub checkouts without pre-loading heavy individual skills into static prompt memory.
+Orchestrates specialized Dart workflows from local GitHub checkouts without
+pre-loading heavy individual skills into static prompt memory.
 
 ---
 
@@ -20,61 +28,139 @@ Orchestrates specialized Dart workflows from local GitHub checkouts without pre-
 
 ### 1. Intent Evaluation & Confidence Matching (Strict Single-Skill Target)
 
-When invoked with text (e.g. `/dart-cleanup convert expect matchers to checks`), evaluate the input against the [Skill Catalog](#-skill-catalog) using this 3-tier confidence decision tree:
+When invoked with text (e.g. `/dart-cleanup convert expect matchers to checks`),
+evaluate the input against the [Skill Catalog](#-skill-catalog) using this
+3-tier confidence decision tree:
 
 * **Tier 1: Unambiguous Clear Match (High Confidence / 90%+ sure)**
-  * Exactly 1 skill in the catalog clearly maps to the requested transformation.
+  * Exactly 1 skill in the catalog clearly maps to the requested
+    transformation.
   * *Action*:
     1. Check for the target `SKILL.md` at its candidate path in `~/github/`.
-    2. If missing, output the [Missing Checkout Safety Net](#missing-checkout-safety-net).
-    3. If present, call `view_file` on the target `SKILL.md`, hydrate its untruncated instructions into active context, and execute the refactoring immediately.
+    2. If missing, output the
+       [Missing Checkout Safety Net](#missing-checkout-safety-net).
+    3. If present, call `view_file` on the target `SKILL.md`, hydrate its
+       untruncated instructions into active context, and execute the
+       refactoring immediately.
 * **Tier 2: Uncertain / Close Match (Medium Confidence)**
   * A skill seems close or relevant, but there is ambiguity.
   * *Action*: Stop and ask the user for confirmation before hydrating:
-    > *"I think you might mean **`<skill-name>`** ([SKILL.md](file:///path/to/SKILL.md)). Would you like me to load and run this workflow?"*
+    > *"I think you might mean **`<skill-name>`**"*
+    > *([SKILL.md](file:///path/to/SKILL.md)). Would you like me to load and*
+    > *run this workflow?"*
 * **Tier 3: No Clear Match or Bare Invocation (Low Confidence / Empty Input)**
-  * No skill matches the prompt, or `/dart-cleanup` was invoked with no arguments.
+  * No skill matches the prompt, or `/dart-cleanup` was invoked with no
+    arguments.
   * *Action*: Output:
-    > *"I couldn't find an unambiguous skill match for your request. Here is the catalog of available specialized Dart skills:"*
-    Render the categorized [Skill Catalog](#-skill-catalog) with clickable `file://` links so the user can choose.
+    > *"I couldn't find an unambiguous skill match for your request. Here is*
+    > *the catalog of available specialized Dart skills:"*
+    Render the categorized [Skill Catalog](#-skill-catalog) with clickable
+    `file://` links so the user can choose.
 
 ### 2. Missing Checkout Safety Net
-If a target `SKILL.md` is selected but missing from the local filesystem, output:
-> ⚠️ **Missing local checkout**: Target skill `<skill-name>` was not found at `~/github/...`. Please ensure `https://github.com/<org>/<repo>` is cloned into `~/github/`.
+If a target `SKILL.md` is selected but missing from the local filesystem,
+output:
+> ⚠️ **Missing local checkout**: Target skill `<skill-name>` was not found at
+> `~/github/...`. Please ensure `https://github.com/<org>/<repo>` is cloned into
+> `~/github/`.
 
 ---
 
 ## 📋 Skill Catalog & Path Priority
 
 ### A. Refactoring & Code Quality
-* **`dart-cognitive-complexity`**: Reduces cognitive complexity, nested loops, and deep conditionals via pattern matching & guard clauses. Includes a gated Tier 3 method-object reference for extreme cases.
+* **`dart-cognitive-complexity`**: Reduces cognitive complexity, nested loops,
+  and deep conditionals via pattern matching & guard clauses. Includes a gated
+  Tier 3 method-object reference for extreme cases.
   * *Path*: [SKILL.md](file://~/github/kevmoo/analytica.dart/skills/dart-cognitive-complexity/SKILL.md)
-* **`dart-undead`**: Audits, triages, and safely remediates unreachable and dead declarations in Dart and Flutter codebases using deterministic reachability analysis (`pkg:undead`).
+* **`dart-undead`**: Audits, triages, and safely remediates unreachable and
+  dead declarations in Dart and Flutter codebases using deterministic
+  reachability analysis (`pkg:undead`).
   * *Path*: [SKILL.md](file://~/github/kevmoo/analytica.dart/skills/dart-undead/SKILL.md)
-* **`dart-dedupe`**: Detects, audits, and safely remediates structural code duplication across Dart and Flutter repositories using the standalone Dedupe engine (`pkg:dedupe`) and empirical test gating.
+* **`dart-dedupe`**: Detects, audits, and safely remediates structural code
+  duplication across Dart and Flutter repositories using the standalone Dedupe
+  engine (`pkg:dedupe`) and empirical test gating.
   * *Path*: [SKILL.md](file://~/github/kevmoo/analytica.dart/skills/dart-dedupe/SKILL.md)
-* **`dart-build-cli-app`**: CLI entrypoint structure, argument parsing, cross-platform scripts, exit codes.
-  * *Path*: [SKILL.md](file://~/github/dart-lang/skills/skills/dart-build-cli-app/SKILL.md)
+* **`dart-use-path-package`**: Cross-platform file and directory path
+  manipulation, segment splitting, and extension extraction using
+  `package:path` and `package:file`.
+  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-use-path-package/SKILL.md)
+* **`dart-build-cli-app`**: CLI entrypoint structure, argument parsing
+  (`package:args`), cross-platform scripts, exit codes, and compilation.
+  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-build-cli-app/SKILL.md)
+* **`dart-run-static-analysis`**: Executes `dart analyze` to catch issues and
+  `dart fix --apply` to automatically resolve mechanical lint warnings.
+  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-run-static-analysis/SKILL.md)
+* **`dart-fix-runtime-errors`**: Resolves runtime errors, inspects active stack
+  traces via `get_runtime_errors` and LSP, and verifies with hot reload.
+  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-fix-runtime-errors/SKILL.md)
+* **`profile-dart-code`**: Profiles Dart CLI applications using the VM Service
+  protocol to capture CPU samples and pinpoint performance bottlenecks.
+  * *Path*: [SKILL.md](file://~/github/kevmoo/dash_skills/skills/profile-dart-code/SKILL.md)
 
-### B. Language Modernization & Formatting
-* **`dart-best-practices`**: Effective Dart guidelines, class design, null safety, and general style.
-  * *Path*: [SKILL.md](file://~/github/kevmoo/dash_skills/skills/dart-best-practices/SKILL.md)
-* **`dart-modern-features`**: Records, pattern matching, switch expressions, extension types, class modifiers.
+### B. Language Modernization & Syntax
+* **`dart-use-pattern-matching`**: Applies Dart 3 pattern matching, switch
+  expressions, and destructuring to validate schemas and simplify control flow.
+  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-use-pattern-matching/SKILL.md)
+* **`dart-use-primary-constructors`**: Adopts primary constructor syntax,
+  empty-body semicolon syntax, in-body initializers, and concise forms.
+  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-use-primary-constructors/SKILL.md)
+* **`dart-modern-features`**: Records, pattern matching, switch expressions,
+  extension types, and class modifiers (`interface`, `base`, `sealed`, `final`).
   * *Path*: [SKILL.md](file://~/github/kevmoo/dash_skills/skills/dart-modern-features/SKILL.md)
-* **`dart-multiline-strings`**: Converts consecutive print statements & string concatenations into triple-quoted strings.
+* **`dart-best-practices`**: Effective Dart guidelines, class design, null
+  safety, and idiomatic style conventions.
+  * *Path*: [SKILL.md](file://~/github/kevmoo/dash_skills/skills/dart-best-practices/SKILL.md)
+* **`dart-multiline-strings`**: Converts consecutive print statements and
+  string concatenations into clean triple-quoted multiline strings.
   * *Path*: [SKILL.md](file://~/github/kevmoo/dash_skills/skills/dart-multiline-strings/SKILL.md)
-* **`dart-long-lines`**: Formats code to adhere to the 80-column line limit (`lines_longer_than_80_chars`).
+* **`dart-long-lines`**: Formats and refactors code to adhere to the 80-column
+  line limit (`lines_longer_than_80_chars`).
   * *Path*: [SKILL.md](file://~/github/kevmoo/dash_skills/skills/dart-long-lines/SKILL.md)
 
 ### C. Testing & Assertions
-* **`dart-migrate-to-checks-package`**: Converts legacy `expect(a, equals(b))` matchers to modern `package:checks` syntax (`check(a).equals(b)`).
-  * *Path*: [SKILL.md](file://~/github/dart-lang/skills/skills/dart-migrate-to-checks-package/SKILL.md)
-* **`dart-use-pattern-matching`**: Refactors complex conditionals and destructuring to idiomatic Dart 3 pattern matching.
-  * *Path*: [SKILL.md](file://~/github/dart-lang/skills/skills/dart-use-pattern-matching/SKILL.md)
-* **`dart-test-fundamentals`**: Core `package:test` practices, grouping, `setUp`/`tearDown` lifecycles, and `dart_test.yaml`.
+* **`dart-migrate-to-checks-package`**: Migrates legacy `expect(a, equals(b))`
+  matchers from `package:matcher` to fluent `package:checks` syntax.
+  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-migrate-to-checks-package/SKILL.md)
+* **`dart-add-unit-test`**: Writes and organizes unit tests for functions,
+  methods, and classes using `package:test` with clean structure.
+  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-add-unit-test/SKILL.md)
+* **`dart-generate-test-mocks`**: Defines and generates mock objects for
+  external dependencies using `package:mockito` and `build_runner`.
+  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-generate-test-mocks/SKILL.md)
+* **`dart-test-fundamentals`**: Core `package:test` practices, test grouping,
+  `setUp`/`tearDown` lifecycles, and `dart_test.yaml` configuration.
   * *Path*: [SKILL.md](file://~/github/kevmoo/dash_skills/skills/dart-test-fundamentals/SKILL.md)
-* **`dart-matcher-best-practices`**: Best practices for legacy `package:matcher` assertions.
+* **`dart-matcher-best-practices`**: Best practices, custom matchers, and async
+  matcher patterns for legacy `package:matcher` assertions.
   * *Path*: [SKILL.md](file://~/github/kevmoo/dash_skills/skills/dart-matcher-best-practices/SKILL.md)
-* **`dart-collect-coverage`**: Collecting coverage using `package:coverage` and creating LCOV reports.
-  * *Path*: [SKILL.md](file://~/github/dart-lang/skills/skills/dart-collect-coverage/SKILL.md)
+* **`dart-collect-coverage`**: Collects test coverage using `package:coverage`
+  and generates LCOV reports.
+  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-collect-coverage/SKILL.md)
+* **`dart-test-coverage`**: Inspects, analyzes, and improves test coverage
+  across a Dart package, locating missed lines.
+  * *Path*: [SKILL.md](file://~/github/kevmoo/dash_skills/skills/dart-test-coverage/SKILL.md)
+
+### D. Documentation, Packaging & Native Interop
+* **`dart-write-documentation`**: Effective Dart `///` doc comment
+  conventions, API documentation rules, and reference linking.
+  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-write-documentation/SKILL.md)
+* **`dart-use-doc-examples`**: Injects external code examples into Dartdoc via
+  `{@example}` directives and filters with `#region` tags.
+  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-use-doc-examples/SKILL.md)
+* **`dart-doc-validation`**: Validates doc comments using `dart doc` to catch
+  broken or unresolved references and macros.
+  * *Path*: [SKILL.md](file://~/github/kevmoo/dash_skills/skills/dart-doc-validation/SKILL.md)
+* **`dart-use-ffigen`**: Automatically generates C/Objective-C/Swift FFI
+  bindings using `package:ffigen` instead of hand-crafting `dart:ffi`.
+  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-use-ffigen/SKILL.md)
+* **`dart-setup-ffi-assets`**: Compiles and packages C/C++ native assets using
+  Dart's Native Assets hook system (`hook/build.dart` and `hook/link.dart`).
+  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-setup-ffi-assets/SKILL.md)
+* **`dart-resolve-package-conflicts`**: Resolves package dependency version
+  conflicts when `pub get` fails due to incompatible constraints.
+  * *Path*: [SKILL.md](file://~/github/skills/skills/dart-resolve-package-conflicts/SKILL.md)
+* **`dart-package-maintenance`**: Best practices for package maintenance,
+  versioning, changelog curation, and publishing workflows.
+  * *Path*: [SKILL.md](file://~/github/kevmoo/dash_skills/skills/dart-package-maintenance/SKILL.md)
 

--- a/tool/bin/generate_cleanup_catalog.dart
+++ b/tool/bin/generate_cleanup_catalog.dart
@@ -113,15 +113,24 @@ int _run(List<String> arguments) {
     if (envIssues.any(
       (i) =>
           i.contains('⚠️ [UNCATALOGED SKILL]') ||
-          i.contains('⚠️ [MISSING SKILL]'),
+          i.contains('⚠️ [MISSING SKILL]') ||
+          i.contains('⚠️ [MISMATCHED REPO REMOTE]') ||
+          i.contains('⚠️ [NOT A GIT REPO]'),
     )) {
       return ExitCode.config.code;
     }
     return ExitCode.success.code;
   }
 
+  // If in write mode, capture latest commit SHA and dates if available
+  if (writeMode) {
+    _syncRepositoryCommits(repositories);
+    const encoder = JsonEncoder.withIndent('  ');
+    catalogJsonFile.writeAsStringSync('${encoder.convert(catalogData)}\n');
+  }
+
   // Validate catalog data structure and sorting
-  final validationErrors = validateCatalogStructure(categories);
+  final validationErrors = validateCatalogStructure(categories, repositories);
   if (validationErrors.isNotEmpty) {
     stderr.writeln('Catalog validation errors:');
     for (final err in validationErrors) {
@@ -183,7 +192,7 @@ int _run(List<String> arguments) {
   if (writeMode) {
     targetSkillFile.writeAsStringSync(updatedContent);
     stdout.writeln(
-      'Successfully updated skills/dart-cleanup/SKILL.md with latest catalog!',
+      'Successfully updated skills/dart-cleanup/SKILL.md and catalog JSON with latest catalog!',
     );
   } else {
     stdout
@@ -195,6 +204,41 @@ int _run(List<String> arguments) {
       );
   }
   return ExitCode.success.code;
+}
+
+void _syncRepositoryCommits(Map<String, dynamic> repositories) {
+  final home = Platform.environment['HOME'] ?? '';
+  for (final entry in repositories.entries) {
+    final repoConfig = entry.value as Map<String, dynamic>;
+    final rawPath = repoConfig['path'] as String? ?? '';
+    final resolvedPath = rawPath.replaceFirst('~', home);
+    final repoDir = Directory(resolvedPath);
+
+    if (!repoDir.existsSync()) continue;
+
+    final shaResult = Process.runSync('git', [
+      'rev-parse',
+      'HEAD',
+    ], workingDirectory: resolvedPath);
+    if (shaResult.exitCode == 0) {
+      final sha = shaResult.stdout.toString().trim();
+      if (sha.isNotEmpty) {
+        repoConfig['commitSha'] = sha;
+      }
+    }
+
+    final dateResult = Process.runSync('git', [
+      'log',
+      '-1',
+      '--format=%cI',
+    ], workingDirectory: resolvedPath);
+    if (dateResult.exitCode == 0) {
+      final date = dateResult.stdout.toString().trim();
+      if (date.isNotEmpty) {
+        repoConfig['commitDate'] = date;
+      }
+    }
+  }
 }
 
 List<String> checkLocalEnvironment(
@@ -237,6 +281,40 @@ List<String> checkLocalEnvironment(
       continue;
     }
 
+    // Verify directory is a git repository
+    final gitCheck = Process.runSync('git', [
+      'rev-parse',
+      '--is-inside-work-tree',
+    ], workingDirectory: resolvedPath);
+    if (gitCheck.exitCode != 0) {
+      issues.add(
+        '⚠️ [NOT A GIT REPO] Directory at $resolvedPath is not a git repository.\n'
+        '   Fix: Ensure a valid git clone of $cloneUrl is placed at $resolvedPath\n',
+      );
+      continue;
+    }
+
+    // Verify git remote origin aligns with cloneUrl
+    final remoteCheck = Process.runSync('git', [
+      'config',
+      '--get',
+      'remote.origin.url',
+    ], workingDirectory: resolvedPath);
+    if (remoteCheck.exitCode == 0) {
+      final actualUrl = remoteCheck.stdout.toString().trim();
+      final actualSlug = parseRepoSlugFromUrl(actualUrl);
+      final expectedSlug = parseRepoSlugFromUrl(cloneUrl);
+      if (actualSlug != null &&
+          expectedSlug != null &&
+          actualSlug != expectedSlug) {
+        issues.add(
+          '⚠️ [MISMATCHED REPO REMOTE] Directory "$resolvedPath" points to remote "$actualUrl" ($actualSlug),\n'
+          '   expected "$cloneUrl" ($expectedSlug).\n'
+          '   Fix: Ensure the correct repository is checked out at $resolvedPath\n',
+        );
+      }
+    }
+
     final skillsDir = Directory(p.join(repoDir.path, 'skills'));
     if (!skillsDir.existsSync()) {
       continue;
@@ -276,9 +354,33 @@ List<String> checkLocalEnvironment(
   return issues;
 }
 
-List<String> validateCatalogStructure(List<dynamic> categories) {
+List<String> validateCatalogStructure(
+  List<dynamic> categories,
+  Map<String, dynamic> repositories,
+) {
   final errors = <String>[];
   final seenSkills = <String>{};
+
+  for (final entry in repositories.entries) {
+    final key = entry.key;
+    final config = entry.value;
+    if (config is! Map<String, dynamic>) {
+      errors.add('Repository "$key" configuration must be a JSON object.');
+      continue;
+    }
+    final rawPath = config['path'] as String? ?? '';
+    final cloneUrl = config['cloneUrl'] as String? ?? '';
+    if (rawPath.isEmpty) {
+      errors.add('Repository "$key" missing "path".');
+    }
+    if (cloneUrl.isEmpty) {
+      errors.add('Repository "$key" missing "cloneUrl".');
+    } else if (parseRepoSlugFromUrl(cloneUrl) == null) {
+      errors.add(
+        'Repository "$key" cloneUrl "$cloneUrl" is not a valid GitHub URL.',
+      );
+    }
+  }
 
   for (final cat in categories) {
     if (cat is! Map<String, dynamic>) {
@@ -300,9 +402,15 @@ List<String> validateCatalogStructure(List<dynamic> categories) {
         continue;
       }
       final name = s['name'] as String? ?? '';
+      final repo = s['repo'] as String? ?? '';
       if (name.isEmpty) {
         errors.add('Skill missing name in category "$catName"');
         continue;
+      }
+      if (!repositories.containsKey(repo)) {
+        errors.add(
+          'Skill "$name" references unknown repository key "$repo" in category "$catName".',
+        );
       }
       if (seenSkills.contains(name)) {
         errors.add('Duplicate skill "$name" found across categories.');
@@ -326,6 +434,43 @@ String generateCatalogMarkdown(
   Map<String, dynamic> repositories,
 ) {
   final buffer = StringBuffer();
+
+  // 1. Required Local Repositories table
+  buffer.writeln('### Required Local Repositories');
+  buffer.writeln();
+  buffer.writeln('<!-- mdformat off(prevent table wrapping) -->');
+  buffer.writeln('| Repository | Local Directory | Synced Commit |');
+  buffer.writeln('| :--- | :--- | :--- |');
+
+  final sortedEntries = repositories.entries.toList()
+    ..sort((a, b) {
+      final slugA =
+          parseRepoSlugFromUrl(a.value['cloneUrl'] as String? ?? '') ?? a.key;
+      final slugB =
+          parseRepoSlugFromUrl(b.value['cloneUrl'] as String? ?? '') ?? b.key;
+      return slugA.compareTo(slugB);
+    });
+
+  for (final entry in sortedEntries) {
+    final config = entry.value as Map<String, dynamic>;
+    final cloneUrl = config['cloneUrl'] as String? ?? '';
+    final rawPath = config['path'] as String? ?? '';
+    final slug = parseRepoSlugFromUrl(cloneUrl) ?? entry.key;
+    final commitSha = config['commitSha'] as String?;
+
+    final webUrl = 'https://github.com/$slug';
+    final repoLink = '[`$slug`]($webUrl)';
+    final commitLink = commitSha != null && commitSha.length >= 7
+        ? '[`${commitSha.substring(0, 7)}`]($webUrl/commit/$commitSha)'
+        : '*(unpinned)*';
+
+    buffer.writeln('| $repoLink | `$rawPath` | $commitLink |');
+  }
+
+  buffer.writeln('<!-- mdformat on -->');
+  buffer.writeln();
+
+  // 2. Categorized Skills
   const letters = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
 
   for (var i = 0; i < categories.length; i++) {
@@ -403,6 +548,33 @@ String _wrapProse(
     lines.add(currentLine);
   }
   return lines.join('\n');
+}
+
+String? parseRepoSlugFromUrl(String rawUrl) {
+  var url = rawUrl.trim();
+  if (!url.contains('://') && url.contains('@') && url.contains(':')) {
+    url = 'ssh://${url.replaceFirst(':', '/')}';
+  }
+
+  final uri = Uri.tryParse(url);
+  if (uri == null || uri.host.toLowerCase() != 'github.com') {
+    return null;
+  }
+
+  if (uri.pathSegments.where((s) => s.isNotEmpty).toList() case [
+    final owner,
+    var repo,
+    ...,
+  ]) {
+    if (repo.endsWith('.git')) {
+      repo = repo.substring(0, repo.length - 4);
+    }
+    if (owner.isNotEmpty && repo.isNotEmpty) {
+      return '$owner/$repo';
+    }
+  }
+
+  return null;
 }
 
 Directory? _findRepoRoot(Directory startDir) {

--- a/tool/bin/generate_cleanup_catalog.dart
+++ b/tool/bin/generate_cleanup_catalog.dart
@@ -110,13 +110,7 @@ int _run(List<String> arguments) {
   }
 
   if (checkEnvMode) {
-    if (envIssues.any(
-      (i) =>
-          i.contains('⚠️ [UNCATALOGED SKILL]') ||
-          i.contains('⚠️ [MISSING SKILL]') ||
-          i.contains('⚠️ [MISMATCHED REPO REMOTE]') ||
-          i.contains('⚠️ [NOT A GIT REPO]'),
-    )) {
+    if (envIssues.any((i) => i.isFatal)) {
       return ExitCode.config.code;
     }
     return ExitCode.success.code;
@@ -241,11 +235,43 @@ void _syncRepositoryCommits(Map<String, dynamic> repositories) {
   }
 }
 
-List<String> checkLocalEnvironment(
+enum EnvIssueType {
+  missingRepo('MISSING REPO', isFatal: false),
+  notGitRepo('NOT A GIT REPO', isFatal: true),
+  mismatchedRemote('MISMATCHED REPO REMOTE', isFatal: true),
+  uncatalogedSkill('UNCATALOGED SKILL', isFatal: true),
+  missingSkill('MISSING SKILL', isFatal: true);
+
+  const EnvIssueType(this.tag, {required this.isFatal});
+
+  final String tag;
+  final bool isFatal;
+}
+
+class EnvIssue {
+  const EnvIssue(this.type, this.message, {this.fix});
+
+  final EnvIssueType type;
+  final String message;
+  final String? fix;
+
+  bool get isFatal => type.isFatal;
+
+  @override
+  String toString() {
+    final buffer = StringBuffer('⚠️ [${type.tag}] $message\n');
+    if (fix != null) {
+      buffer.writeln('   Fix: $fix');
+    }
+    return buffer.toString();
+  }
+}
+
+List<EnvIssue> checkLocalEnvironment(
   Map<String, dynamic> repositories,
   List<dynamic> categories,
 ) {
-  final issues = <String>[];
+  final issues = <EnvIssue>[];
   final home = Platform.environment['HOME'] ?? '';
   final allConfiguredSkills = <String, String>{}; // skill -> repoKey
 
@@ -274,9 +300,11 @@ List<String> checkLocalEnvironment(
 
     if (!repoDir.existsSync()) {
       issues.add(
-        '⚠️ [MISSING REPO] Repository "$repoKey" not found at $resolvedPath\n'
-        '   Fix: Clone it via:\n'
-        '   git clone $cloneUrl $resolvedPath\n',
+        EnvIssue(
+          EnvIssueType.missingRepo,
+          'Repository "$repoKey" not found at $resolvedPath',
+          fix: 'Clone it via:\n   git clone $cloneUrl $resolvedPath',
+        ),
       );
       continue;
     }
@@ -288,8 +316,12 @@ List<String> checkLocalEnvironment(
     ], workingDirectory: resolvedPath);
     if (gitCheck.exitCode != 0) {
       issues.add(
-        '⚠️ [NOT A GIT REPO] Directory at $resolvedPath is not a git repository.\n'
-        '   Fix: Ensure a valid git clone of $cloneUrl is placed at $resolvedPath\n',
+        EnvIssue(
+          EnvIssueType.notGitRepo,
+          'Directory at $resolvedPath is not a git repository.',
+          fix:
+              'Ensure a valid git clone of $cloneUrl is placed at $resolvedPath',
+        ),
       );
       continue;
     }
@@ -308,9 +340,13 @@ List<String> checkLocalEnvironment(
           expectedSlug != null &&
           actualSlug != expectedSlug) {
         issues.add(
-          '⚠️ [MISMATCHED REPO REMOTE] Directory "$resolvedPath" points to remote "$actualUrl" ($actualSlug),\n'
-          '   expected "$cloneUrl" ($expectedSlug).\n'
-          '   Fix: Ensure the correct repository is checked out at $resolvedPath\n',
+          EnvIssue(
+            EnvIssueType.mismatchedRemote,
+            'Directory "$resolvedPath" points to remote "$actualUrl" ($actualSlug),\n'
+            '   expected "$cloneUrl" ($expectedSlug).',
+            fix:
+                'Ensure the correct repository is checked out at $resolvedPath',
+          ),
         );
       }
     }
@@ -330,8 +366,12 @@ List<String> checkLocalEnvironment(
 
         if (!allConfiguredSkills.containsKey(skillName)) {
           issues.add(
-            '⚠️ [UNCATALOGED SKILL] Found skill "$skillName" in "$repoKey" not listed in tool/data/dart_cleanup_catalog.json.\n'
-            '   Fix: Add "$skillName" to a category in tool/data/dart_cleanup_catalog.json with a summary.\n',
+            EnvIssue(
+              EnvIssueType.uncatalogedSkill,
+              'Found skill "$skillName" in "$repoKey" not listed in tool/data/dart_cleanup_catalog.json.',
+              fix:
+                  'Add "$skillName" to a category in tool/data/dart_cleanup_catalog.json with a summary.',
+            ),
           );
         }
       }
@@ -343,8 +383,12 @@ List<String> checkLocalEnvironment(
         final skillName = skillEntry.key;
         if (!onDiskSkills.contains(skillName)) {
           issues.add(
-            '⚠️ [MISSING SKILL] Skill "$skillName" configured for "$repoKey" was not found on disk at ${p.join(skillsDir.path, skillName, 'SKILL.md')}\n'
-            '   Fix: Verify the skill exists in the repo or remove it from tool/data/dart_cleanup_catalog.json.\n',
+            EnvIssue(
+              EnvIssueType.missingSkill,
+              'Skill "$skillName" configured for "$repoKey" was not found on disk at ${p.join(skillsDir.path, skillName, 'SKILL.md')}',
+              fix:
+                  'Verify the skill exists in the repo or remove it from tool/data/dart_cleanup_catalog.json.',
+            ),
           );
         }
       }

--- a/tool/bin/generate_cleanup_catalog.dart
+++ b/tool/bin/generate_cleanup_catalog.dart
@@ -1,0 +1,384 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:args/args.dart';
+import 'package:path/path.dart' as p;
+
+const startTag = '<!-- DART_CLEANUP_CATALOG_START -->';
+const endTag = '<!-- DART_CLEANUP_CATALOG_END -->';
+
+void main(List<String> arguments) {
+  final parser = ArgParser()
+    ..addFlag(
+      'write',
+      abbr: 'w',
+      negatable: false,
+      help: 'Writes the updated catalog to skills/dart-cleanup/SKILL.md.',
+    )
+    ..addFlag(
+      'validate',
+      negatable: false,
+      help: 'Validates that dart-cleanup/SKILL.md is up-to-date and sorted.',
+    )
+    ..addFlag(
+      'check-env',
+      negatable: false,
+      help: 'Checks local repositories for missing or uncataloged skills.',
+    );
+
+  final results = parser.parse(arguments);
+  final writeMode = results['write'] as bool;
+  final validateMode = results['validate'] as bool;
+  final checkEnvMode = results['check-env'] as bool;
+
+  final repoRoot = _findRepoRoot(Directory.current);
+  if (repoRoot == null) {
+    stderr.writeln('Error: Could not find repository root containing skills.');
+    exit(1);
+  }
+
+  final catalogJsonFile = File(
+    p.join(repoRoot.path, 'tool', 'data', 'dart_cleanup_catalog.json'),
+  );
+  if (!catalogJsonFile.existsSync()) {
+    stderr.writeln(
+      'Error: Catalog JSON file not found at ${catalogJsonFile.path}',
+    );
+    exit(1);
+  }
+
+  final dynamic catalogData;
+  try {
+    catalogData = jsonDecode(catalogJsonFile.readAsStringSync());
+  } catch (e) {
+    stderr.writeln('Error parsing catalog JSON: $e');
+    exit(1);
+  }
+
+  if (catalogData is! Map<String, dynamic>) {
+    stderr.writeln('Error: Catalog JSON root must be a JSON object.');
+    exit(1);
+  }
+
+  final repositories =
+      catalogData['repositories'] as Map<String, dynamic>? ?? {};
+  final categories = catalogData['categories'] as List<dynamic>? ?? [];
+
+  // Check environment & local system setup
+  final envIssues = checkLocalEnvironment(repositories, categories);
+  if (envIssues.isNotEmpty) {
+    print('------------------------------------------------------------');
+    print('🔍 Local System Environment Audit:');
+    for (final issue in envIssues) {
+      print(issue);
+    }
+    print('------------------------------------------------------------');
+  }
+
+  if (checkEnvMode) {
+    if (envIssues.any(
+      (i) =>
+          i.contains('⚠️ [UNCATALOGED SKILL]') ||
+          i.contains('⚠️ [MISSING SKILL]'),
+    )) {
+      exit(1);
+    }
+    exit(0);
+  }
+
+  // Validate catalog data structure and sorting
+  final validationErrors = validateCatalogStructure(categories);
+  if (validationErrors.isNotEmpty) {
+    stderr.writeln('Catalog validation errors:');
+    for (final err in validationErrors) {
+      stderr.writeln('  * $err');
+    }
+    exit(1);
+  }
+
+  // Generate markdown
+  final generatedMarkdown = generateCatalogMarkdown(categories, repositories);
+
+  final targetSkillFile = File(
+    p.join(repoRoot.path, 'skills', 'dart-cleanup', 'SKILL.md'),
+  );
+  if (!targetSkillFile.existsSync()) {
+    stderr.writeln('Error: SKILL.md not found at ${targetSkillFile.path}');
+    exit(1);
+  }
+
+  final skillContent = targetSkillFile.readAsStringSync();
+  final startIndex = skillContent.indexOf(startTag);
+  final endIndex = startIndex == -1
+      ? -1
+      : skillContent.indexOf(endTag, startIndex);
+
+  if (startIndex == -1 || endIndex == -1) {
+    stderr.writeln(
+      'Error: Could not find markers $startTag and $endTag in ${targetSkillFile.path}',
+    );
+    stderr.writeln(
+      'Please add the markers around the catalog section in SKILL.md.',
+    );
+    exit(1);
+  }
+
+  final updatedContent = skillContent.replaceRange(
+    startIndex,
+    endIndex + endTag.length,
+    '$startTag\n$generatedMarkdown\n$endTag',
+  );
+
+  if (validateMode) {
+    final normalizedOriginal = skillContent.replaceAll('\r\n', '\n');
+    final normalizedUpdated = updatedContent.replaceAll('\r\n', '\n');
+    if (normalizedOriginal == normalizedUpdated) {
+      print('skills/dart-cleanup/SKILL.md catalog is up-to-date!');
+      exit(0);
+    } else {
+      stderr.writeln(
+        'Error: skills/dart-cleanup/SKILL.md catalog is out-of-date.',
+      );
+      stderr.writeln(
+        'Run `dart tool/bin/generate_cleanup_catalog.dart --write` to update it.',
+      );
+      exit(1);
+    }
+  }
+
+  if (writeMode) {
+    targetSkillFile.writeAsStringSync(updatedContent);
+    print(
+      'Successfully updated skills/dart-cleanup/SKILL.md with latest catalog!',
+    );
+  } else {
+    print('--- Generated Catalog Markdown ---');
+    print(generatedMarkdown);
+    print('----------------------------------');
+    print(
+      'Run with --write (or -w) to save changes to skills/dart-cleanup/SKILL.md.',
+    );
+  }
+}
+
+List<String> checkLocalEnvironment(
+  Map<String, dynamic> repositories,
+  List<dynamic> categories,
+) {
+  final issues = <String>[];
+  final home = Platform.environment['HOME'] ?? '';
+  final allConfiguredSkills = <String, String>{}; // skill -> repoKey
+
+  for (final cat in categories) {
+    if (cat is Map<String, dynamic>) {
+      final skills = cat['skills'] as List<dynamic>? ?? [];
+      for (final s in skills) {
+        if (s is Map<String, dynamic>) {
+          final name = s['name'] as String? ?? '';
+          final repo = s['repo'] as String? ?? '';
+          if (name.isNotEmpty) {
+            allConfiguredSkills[name] = repo;
+          }
+        }
+      }
+    }
+  }
+
+  for (final entry in repositories.entries) {
+    final repoKey = entry.key;
+    final repoConfig = entry.value as Map<String, dynamic>;
+    final rawPath = repoConfig['path'] as String? ?? '';
+    final cloneUrl = repoConfig['cloneUrl'] as String? ?? '';
+    final resolvedPath = rawPath.replaceFirst('~', home);
+    final repoDir = Directory(resolvedPath);
+
+    if (!repoDir.existsSync()) {
+      issues.add(
+        '⚠️ [MISSING REPO] Repository "$repoKey" not found at $resolvedPath\n'
+        '   Fix: Clone it via:\n'
+        '   git clone $cloneUrl $resolvedPath\n',
+      );
+      continue;
+    }
+
+    final skillsDir = Directory(p.join(repoDir.path, 'skills'));
+    if (!skillsDir.existsSync()) {
+      continue;
+    }
+
+    // Find all skills on disk in this repo
+    final onDiskSkills = <String>{};
+    for (final child in skillsDir.listSync().whereType<Directory>()) {
+      final skillFile = File(p.join(child.path, 'SKILL.md'));
+      if (skillFile.existsSync()) {
+        final skillName = p.basename(child.path);
+        onDiskSkills.add(skillName);
+
+        if (!allConfiguredSkills.containsKey(skillName)) {
+          issues.add(
+            '⚠️ [UNCATALOGED SKILL] Found skill "$skillName" in "$repoKey" not listed in tool/data/dart_cleanup_catalog.json.\n'
+            '   Fix: Add "$skillName" to a category in tool/data/dart_cleanup_catalog.json with a summary.\n',
+          );
+        }
+      }
+    }
+
+    // Check skills configured for this repo in JSON exist on disk
+    for (final skillEntry in allConfiguredSkills.entries) {
+      if (skillEntry.value == repoKey) {
+        final skillName = skillEntry.key;
+        if (!onDiskSkills.contains(skillName)) {
+          issues.add(
+            '⚠️ [MISSING SKILL] Skill "$skillName" configured for "$repoKey" was not found on disk at ${p.join(skillsDir.path, skillName, 'SKILL.md')}\n'
+            '   Fix: Verify the skill exists in the repo or remove it from tool/data/dart_cleanup_catalog.json.\n',
+          );
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+
+List<String> validateCatalogStructure(List<dynamic> categories) {
+  final errors = <String>[];
+  final seenSkills = <String>{};
+
+  for (final cat in categories) {
+    if (cat is! Map<String, dynamic>) {
+      errors.add('Category entry must be a JSON object: $cat');
+      continue;
+    }
+    final catName = cat['name'] as String? ?? '';
+    if (catName.isEmpty) {
+      errors.add('Category missing name: $cat');
+    }
+
+    final skills = cat['skills'] as List<dynamic>? ?? [];
+    String? prevSkillName;
+    for (final s in skills) {
+      if (s is! Map<String, dynamic>) {
+        errors.add(
+          'Skill entry must be a JSON object: $s in category "$catName"',
+        );
+        continue;
+      }
+      final name = s['name'] as String? ?? '';
+      if (name.isEmpty) {
+        errors.add('Skill missing name in category "$catName"');
+        continue;
+      }
+      if (seenSkills.contains(name)) {
+        errors.add('Duplicate skill "$name" found across categories.');
+      }
+      seenSkills.add(name);
+
+      if (prevSkillName != null && name.compareTo(prevSkillName) < 0) {
+        errors.add(
+          'Skills in category "$catName" must be sorted alphabetically: "$name" should appear before "$prevSkillName".',
+        );
+      }
+      prevSkillName = name;
+    }
+  }
+
+  return errors;
+}
+
+String generateCatalogMarkdown(
+  List<dynamic> categories,
+  Map<String, dynamic> repositories,
+) {
+  final buffer = StringBuffer();
+  const letters = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+
+  for (var i = 0; i < categories.length; i++) {
+    final cat = categories[i] as Map<String, dynamic>;
+    final catName = cat['name'] as String;
+    final letter = i < letters.length ? letters[i] : '${i + 1}';
+    final skills = cat['skills'] as List<dynamic>? ?? [];
+
+    buffer.writeln('### $letter. $catName');
+
+    for (final s in skills) {
+      final skill = s as Map<String, dynamic>;
+      final name = skill['name'] as String;
+      final repoKey = skill['repo'] as String;
+      final summary = skill['summary'] as String;
+
+      final repoConfig = repositories[repoKey] as Map<String, dynamic>?;
+      final rawRepoPath = repoConfig?['path'] as String? ?? '~/github/$repoKey';
+      final skillPath = '$rawRepoPath/skills/$name/SKILL.md';
+
+      final entry = _formatSkillEntry(
+        name: name,
+        summary: summary,
+        path: skillPath,
+      );
+      buffer.write(entry);
+    }
+
+    if (i < categories.length - 1) {
+      buffer.writeln();
+    }
+  }
+
+  return buffer.toString().trimRight();
+}
+
+String _formatSkillEntry({
+  required String name,
+  required String summary,
+  required String path,
+}) {
+  final buffer = StringBuffer();
+  final lead = '* **`$name`**: ';
+  final wrappedSummary = _wrapProse(lead, summary, indent: '  ', maxWidth: 80);
+  buffer.writeln(wrappedSummary);
+  buffer.writeln('  * *Path*: `$path`');
+  return buffer.toString();
+}
+
+String _wrapProse(
+  String lead,
+  String text, {
+  required String indent,
+  int maxWidth = 80,
+}) {
+  final words = text.split(RegExp(r'\s+'));
+  final lines = <String>[];
+  var currentLine = lead;
+
+  for (final word in words) {
+    if (currentLine.isEmpty) {
+      currentLine = indent + word;
+    } else if (currentLine.length + 1 + word.length <= maxWidth) {
+      if (currentLine == lead) {
+        currentLine += word;
+      } else {
+        currentLine += ' $word';
+      }
+    } else {
+      lines.add(currentLine);
+      currentLine = '$indent$word';
+    }
+  }
+  if (currentLine.isNotEmpty) {
+    lines.add(currentLine);
+  }
+  return lines.join('\n');
+}
+
+Directory? _findRepoRoot(Directory startDir) {
+  var dir = startDir;
+  while (true) {
+    if (Directory(p.join(dir.path, 'skills')).existsSync()) {
+      return dir;
+    }
+    final parent = dir.parent;
+    if (parent.path == dir.path) {
+      break;
+    }
+    dir = parent;
+  }
+  return null;
+}

--- a/tool/bin/generate_cleanup_catalog.dart
+++ b/tool/bin/generate_cleanup_catalog.dart
@@ -1,13 +1,24 @@
 import 'dart:convert';
 import 'dart:io';
 import 'package:args/args.dart';
+import 'package:io/io.dart';
 import 'package:path/path.dart' as p;
 
 const startTag = '<!-- DART_CLEANUP_CATALOG_START -->';
 const endTag = '<!-- DART_CLEANUP_CATALOG_END -->';
 
 void main(List<String> arguments) {
+  exitCode = _run(arguments);
+}
+
+int _run(List<String> arguments) {
   final parser = ArgParser()
+    ..addFlag(
+      'help',
+      abbr: 'h',
+      negatable: false,
+      help: 'Print usage information.',
+    )
     ..addFlag(
       'write',
       abbr: 'w',
@@ -25,15 +36,35 @@ void main(List<String> arguments) {
       help: 'Checks local repositories for missing or uncataloged skills.',
     );
 
-  final results = parser.parse(arguments);
-  final writeMode = results['write'] as bool;
-  final validateMode = results['validate'] as bool;
-  final checkEnvMode = results['check-env'] as bool;
+  final ArgResults results;
+  try {
+    results = parser.parse(arguments);
+  } on FormatException catch (e) {
+    stderr
+      ..writeln('Error: ${e.message}\n')
+      ..writeln('Usage: dart tool/bin/generate_cleanup_catalog.dart [flags]\n')
+      ..writeln(parser.usage);
+    return ExitCode.usage.code;
+  }
+
+  if (results.flag('help')) {
+    stdout
+      ..writeln(
+        'Generates and validates the dart-cleanup skill routing catalog.\n',
+      )
+      ..writeln('Usage: dart tool/bin/generate_cleanup_catalog.dart [flags]\n')
+      ..writeln(parser.usage);
+    return ExitCode.success.code;
+  }
+
+  final writeMode = results.flag('write');
+  final validateMode = results.flag('validate');
+  final checkEnvMode = results.flag('check-env');
 
   final repoRoot = _findRepoRoot(Directory.current);
   if (repoRoot == null) {
     stderr.writeln('Error: Could not find repository root containing skills.');
-    exit(1);
+    return ExitCode.config.code;
   }
 
   final catalogJsonFile = File(
@@ -43,7 +74,7 @@ void main(List<String> arguments) {
     stderr.writeln(
       'Error: Catalog JSON file not found at ${catalogJsonFile.path}',
     );
-    exit(1);
+    return ExitCode.config.code;
   }
 
   final dynamic catalogData;
@@ -51,12 +82,12 @@ void main(List<String> arguments) {
     catalogData = jsonDecode(catalogJsonFile.readAsStringSync());
   } catch (e) {
     stderr.writeln('Error parsing catalog JSON: $e');
-    exit(1);
+    return ExitCode.data.code;
   }
 
   if (catalogData is! Map<String, dynamic>) {
     stderr.writeln('Error: Catalog JSON root must be a JSON object.');
-    exit(1);
+    return ExitCode.data.code;
   }
 
   final repositories =
@@ -66,12 +97,16 @@ void main(List<String> arguments) {
   // Check environment & local system setup
   final envIssues = checkLocalEnvironment(repositories, categories);
   if (envIssues.isNotEmpty) {
-    print('------------------------------------------------------------');
-    print('🔍 Local System Environment Audit:');
+    stderr.writeln(
+      '------------------------------------------------------------',
+    );
+    stderr.writeln('🔍 Local System Environment Audit:');
     for (final issue in envIssues) {
-      print(issue);
+      stderr.writeln(issue);
     }
-    print('------------------------------------------------------------');
+    stderr.writeln(
+      '------------------------------------------------------------',
+    );
   }
 
   if (checkEnvMode) {
@@ -80,9 +115,9 @@ void main(List<String> arguments) {
           i.contains('⚠️ [UNCATALOGED SKILL]') ||
           i.contains('⚠️ [MISSING SKILL]'),
     )) {
-      exit(1);
+      return ExitCode.config.code;
     }
-    exit(0);
+    return ExitCode.success.code;
   }
 
   // Validate catalog data structure and sorting
@@ -92,7 +127,7 @@ void main(List<String> arguments) {
     for (final err in validationErrors) {
       stderr.writeln('  * $err');
     }
-    exit(1);
+    return ExitCode.data.code;
   }
 
   // Generate markdown
@@ -103,7 +138,7 @@ void main(List<String> arguments) {
   );
   if (!targetSkillFile.existsSync()) {
     stderr.writeln('Error: SKILL.md not found at ${targetSkillFile.path}');
-    exit(1);
+    return ExitCode.config.code;
   }
 
   final skillContent = targetSkillFile.readAsStringSync();
@@ -113,13 +148,14 @@ void main(List<String> arguments) {
       : skillContent.indexOf(endTag, startIndex);
 
   if (startIndex == -1 || endIndex == -1) {
-    stderr.writeln(
-      'Error: Could not find markers $startTag and $endTag in ${targetSkillFile.path}',
-    );
-    stderr.writeln(
-      'Please add the markers around the catalog section in SKILL.md.',
-    );
-    exit(1);
+    stderr
+      ..writeln(
+        'Error: Could not find markers $startTag and $endTag in ${targetSkillFile.path}',
+      )
+      ..writeln(
+        'Please add the markers around the catalog section in SKILL.md.',
+      );
+    return ExitCode.data.code;
   }
 
   final updatedContent = skillContent.replaceRange(
@@ -132,32 +168,33 @@ void main(List<String> arguments) {
     final normalizedOriginal = skillContent.replaceAll('\r\n', '\n');
     final normalizedUpdated = updatedContent.replaceAll('\r\n', '\n');
     if (normalizedOriginal == normalizedUpdated) {
-      print('skills/dart-cleanup/SKILL.md catalog is up-to-date!');
-      exit(0);
+      stdout.writeln('skills/dart-cleanup/SKILL.md catalog is up-to-date!');
+      return ExitCode.success.code;
     } else {
-      stderr.writeln(
-        'Error: skills/dart-cleanup/SKILL.md catalog is out-of-date.',
-      );
-      stderr.writeln(
-        'Run `dart tool/bin/generate_cleanup_catalog.dart --write` to update it.',
-      );
-      exit(1);
+      stderr
+        ..writeln('Error: skills/dart-cleanup/SKILL.md catalog is out-of-date.')
+        ..writeln(
+          'Run `dart tool/bin/generate_cleanup_catalog.dart --write` to update it.',
+        );
+      return ExitCode.data.code;
     }
   }
 
   if (writeMode) {
     targetSkillFile.writeAsStringSync(updatedContent);
-    print(
+    stdout.writeln(
       'Successfully updated skills/dart-cleanup/SKILL.md with latest catalog!',
     );
   } else {
-    print('--- Generated Catalog Markdown ---');
-    print(generatedMarkdown);
-    print('----------------------------------');
-    print(
-      'Run with --write (or -w) to save changes to skills/dart-cleanup/SKILL.md.',
-    );
+    stdout
+      ..writeln('--- Generated Catalog Markdown ---')
+      ..writeln(generatedMarkdown)
+      ..writeln('----------------------------------')
+      ..writeln(
+        'Run with --write (or -w) to save changes to skills/dart-cleanup/SKILL.md.',
+      );
   }
+  return ExitCode.success.code;
 }
 
 List<String> checkLocalEnvironment(

--- a/tool/data/dart_cleanup_catalog.json
+++ b/tool/data/dart_cleanup_catalog.json
@@ -2,15 +2,21 @@
   "repositories": {
     "skills": {
       "path": "~/github/skills",
-      "cloneUrl": "https://github.com/dart-lang/skills.git"
+      "cloneUrl": "https://github.com/dart-lang/skills.git",
+      "commitSha": "26b2dcc5654cbbc3b2ec56ea94719469bc8bae9e",
+      "commitDate": "2026-09-10T12:45:58-07:00"
     },
     "dash_skills": {
       "path": "~/github/kevmoo/dash_skills",
-      "cloneUrl": "https://github.com/kevmoo/dash_skills.git"
+      "cloneUrl": "https://github.com/kevmoo/dash_skills.git",
+      "commitSha": "949bd00b69fc8449c535aeb4f4970c7ec5e21b49",
+      "commitDate": "2026-09-07T18:31:46-07:00"
     },
     "analytica.dart": {
       "path": "~/github/kevmoo/analytica.dart",
-      "cloneUrl": "https://github.com/kevmoo/analytica.dart.git"
+      "cloneUrl": "https://github.com/kevmoo/analytica.dart.git",
+      "commitSha": "1bba4de81a526b3805561227fb1adeed4e3feb45",
+      "commitDate": "2026-08-29T00:10:54-07:00"
     }
   },
   "categories": [

--- a/tool/data/dart_cleanup_catalog.json
+++ b/tool/data/dart_cleanup_catalog.json
@@ -1,0 +1,178 @@
+{
+  "repositories": {
+    "skills": {
+      "path": "~/github/skills",
+      "cloneUrl": "https://github.com/dart-lang/skills.git"
+    },
+    "dash_skills": {
+      "path": "~/github/kevmoo/dash_skills",
+      "cloneUrl": "https://github.com/kevmoo/dash_skills.git"
+    },
+    "analytica.dart": {
+      "path": "~/github/kevmoo/analytica.dart",
+      "cloneUrl": "https://github.com/kevmoo/analytica.dart.git"
+    }
+  },
+  "categories": [
+    {
+      "name": "Refactoring & Code Quality",
+      "skills": [
+        {
+          "name": "dart-build-cli-app",
+          "repo": "skills",
+          "summary": "CLI entrypoint structure, argument parsing (`package:args`), cross-platform scripts, exit codes, and compilation."
+        },
+        {
+          "name": "dart-cognitive-complexity",
+          "repo": "analytica.dart",
+          "summary": "Reduces cognitive complexity, nested loops, and deep conditionals via pattern matching & guard clauses. Includes a gated Tier 3 method-object reference for extreme cases."
+        },
+        {
+          "name": "dart-dedupe",
+          "repo": "analytica.dart",
+          "summary": "Detects, audits, and safely remediates structural code duplication across Dart and Flutter repositories using the standalone Dedupe engine (`pkg:dedupe`) and empirical test gating."
+        },
+        {
+          "name": "dart-fix-runtime-errors",
+          "repo": "skills",
+          "summary": "Resolves runtime errors, inspects active stack traces via `get_runtime_errors` and LSP, and verifies with hot reload."
+        },
+        {
+          "name": "dart-run-static-analysis",
+          "repo": "skills",
+          "summary": "Executes `dart analyze` to catch issues and `dart fix --apply` to automatically resolve mechanical lint warnings."
+        },
+        {
+          "name": "dart-undead",
+          "repo": "analytica.dart",
+          "summary": "Audits, triages, and safely remediates unreachable and dead declarations in Dart and Flutter codebases using deterministic reachability analysis (`pkg:undead`)."
+        },
+        {
+          "name": "dart-use-path-package",
+          "repo": "skills",
+          "summary": "Cross-platform file and directory path manipulation, segment splitting, and extension extraction using `package:path` and `package:file`."
+        },
+        {
+          "name": "profile-dart-code",
+          "repo": "dash_skills",
+          "summary": "Profiles Dart CLI applications using the VM Service protocol to capture CPU samples and pinpoint performance bottlenecks."
+        }
+      ]
+    },
+    {
+      "name": "Language Modernization & Syntax",
+      "skills": [
+        {
+          "name": "dart-best-practices",
+          "repo": "dash_skills",
+          "summary": "Effective Dart guidelines, class design, null safety, and idiomatic style conventions."
+        },
+        {
+          "name": "dart-long-lines",
+          "repo": "dash_skills",
+          "summary": "Formats and refactors code to adhere to the 80-column line limit (`lines_longer_than_80_chars`)."
+        },
+        {
+          "name": "dart-modern-features",
+          "repo": "dash_skills",
+          "summary": "Records, pattern matching, switch expressions, extension types, and class modifiers (`interface`, `base`, `sealed`, `final`)."
+        },
+        {
+          "name": "dart-multiline-strings",
+          "repo": "dash_skills",
+          "summary": "Converts consecutive print statements and string concatenations into clean triple-quoted multiline strings."
+        },
+        {
+          "name": "dart-use-pattern-matching",
+          "repo": "skills",
+          "summary": "Applies Dart 3 pattern matching, switch expressions, and destructuring to validate schemas and simplify control flow."
+        },
+        {
+          "name": "dart-use-primary-constructors",
+          "repo": "skills",
+          "summary": "Adopts primary constructor syntax, empty-body semicolon syntax, in-body initializers, and concise forms."
+        }
+      ]
+    },
+    {
+      "name": "Testing & Assertions",
+      "skills": [
+        {
+          "name": "dart-add-unit-test",
+          "repo": "skills",
+          "summary": "Writes and organizes unit tests for functions, methods, and classes using `package:test` with clean structure."
+        },
+        {
+          "name": "dart-collect-coverage",
+          "repo": "skills",
+          "summary": "Collects test coverage using `package:coverage` and generates LCOV reports."
+        },
+        {
+          "name": "dart-generate-test-mocks",
+          "repo": "skills",
+          "summary": "Defines and generates mock objects for external dependencies using `package:mockito` and `build_runner`."
+        },
+        {
+          "name": "dart-matcher-best-practices",
+          "repo": "dash_skills",
+          "summary": "Best practices, custom matchers, and async matcher patterns for legacy `package:matcher` assertions."
+        },
+        {
+          "name": "dart-migrate-to-checks-package",
+          "repo": "skills",
+          "summary": "Migrates legacy `expect(a, equals(b))` matchers from `package:matcher` to fluent `package:checks` syntax."
+        },
+        {
+          "name": "dart-test-coverage",
+          "repo": "dash_skills",
+          "summary": "Inspects, analyzes, and improves test coverage across a Dart package, locating missed lines."
+        },
+        {
+          "name": "dart-test-fundamentals",
+          "repo": "dash_skills",
+          "summary": "Core `package:test` practices, test grouping, `setUp`/`tearDown` lifecycles, and `dart_test.yaml` configuration."
+        }
+      ]
+    },
+    {
+      "name": "Documentation, Packaging & Native Interop",
+      "skills": [
+        {
+          "name": "dart-doc-validation",
+          "repo": "dash_skills",
+          "summary": "Validates doc comments using `dart doc` to catch broken or unresolved references and macros."
+        },
+        {
+          "name": "dart-package-maintenance",
+          "repo": "dash_skills",
+          "summary": "Best practices for package maintenance, versioning, changelog curation, and publishing workflows."
+        },
+        {
+          "name": "dart-resolve-package-conflicts",
+          "repo": "skills",
+          "summary": "Resolves package dependency version conflicts when `pub get` fails due to incompatible constraints."
+        },
+        {
+          "name": "dart-setup-ffi-assets",
+          "repo": "skills",
+          "summary": "Compiles and packages C/C++ native assets using Dart's Native Assets hook system (`hook/build.dart` and `hook/link.dart`)."
+        },
+        {
+          "name": "dart-use-doc-examples",
+          "repo": "skills",
+          "summary": "Injects external code examples into Dartdoc via `{@example}` directives and filters with `#region` tags."
+        },
+        {
+          "name": "dart-use-ffigen",
+          "repo": "skills",
+          "summary": "Automatically generates C/Objective-C/Swift FFI bindings using `package:ffigen` instead of hand-crafting `dart:ffi`."
+        },
+        {
+          "name": "dart-write-documentation",
+          "repo": "skills",
+          "summary": "Effective Dart `///` doc comment conventions, API documentation rules, and reference linking."
+        }
+      ]
+    }
+  ]
+}

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   yaml: ^3.1.0
   args: ^2.4.0
   path: ^1.9.0
+  io: ^1.0.5
 
 dev_dependencies:
   checks: ^0.3.0

--- a/tool/test/dart_cleanup_catalog_test.dart
+++ b/tool/test/dart_cleanup_catalog_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 import 'package:test/test.dart';
+import '../bin/generate_cleanup_catalog.dart';
 
 void main() {
   group('dart_cleanup_catalog data integrity', () {
@@ -138,4 +139,26 @@ void main() {
       );
     },
   );
+
+  group('EnvIssue and EnvIssueType', () {
+    test('issue types declare correct fatal statuses', () {
+      expect(EnvIssueType.missingRepo.isFatal, isFalse);
+      expect(EnvIssueType.notGitRepo.isFatal, isTrue);
+      expect(EnvIssueType.mismatchedRemote.isFatal, isTrue);
+      expect(EnvIssueType.uncatalogedSkill.isFatal, isTrue);
+      expect(EnvIssueType.missingSkill.isFatal, isTrue);
+    });
+
+    test('EnvIssue formats readable output with tag and fix', () {
+      const issue = EnvIssue(
+        EnvIssueType.uncatalogedSkill,
+        'Found foo in bar',
+        fix: 'Add foo to catalog',
+      );
+      expect(issue.isFatal, isTrue);
+      final rendered = issue.toString();
+      expect(rendered, contains('⚠️ [UNCATALOGED SKILL] Found foo in bar'));
+      expect(rendered, contains('Fix: Add foo to catalog'));
+    });
+  });
 }

--- a/tool/test/dart_cleanup_catalog_test.dart
+++ b/tool/test/dart_cleanup_catalog_test.dart
@@ -1,0 +1,103 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:test/test.dart';
+
+void main() {
+  group('dart_cleanup_catalog data integrity', () {
+    late Map<String, dynamic> catalogData;
+    late List<dynamic> categories;
+
+    setUpAll(() {
+      final catalogPath =
+          Directory.current.path.split(Platform.pathSeparator).last == 'tool'
+          ? 'data/dart_cleanup_catalog.json'
+          : 'tool/data/dart_cleanup_catalog.json';
+      final file = File(catalogPath);
+      expect(file.existsSync(), isTrue, reason: 'Catalog JSON must exist');
+      catalogData = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+      categories = catalogData['categories'] as List<dynamic>;
+    });
+
+    test('categories are not empty and have distinct names', () {
+      expect(categories, isNotEmpty);
+      final names = <String>{};
+      for (final cat in categories) {
+        final name = (cat as Map<String, dynamic>)['name'] as String;
+        expect(name, isNotEmpty);
+        expect(names.add(name), isTrue, reason: 'Duplicate category: $name');
+      }
+    });
+
+    test('skills in each category are sorted alphabetically', () {
+      for (final cat in categories) {
+        final catMap = cat as Map<String, dynamic>;
+        final catName = catMap['name'] as String;
+        final skills = catMap['skills'] as List<dynamic>;
+        final skillNames = skills
+            .map((s) => (s as Map<String, dynamic>)['name'] as String)
+            .toList();
+        final sortedNames = List<String>.from(skillNames)..sort();
+        expect(
+          skillNames,
+          equals(sortedNames),
+          reason: 'Skills in category "$catName" must be sorted alphabetically',
+        );
+      }
+    });
+
+    test('skills have no duplicates across entire catalog', () {
+      final seen = <String>{};
+      for (final cat in categories) {
+        final catMap = cat as Map<String, dynamic>;
+        final skills = catMap['skills'] as List<dynamic>;
+        for (final s in skills) {
+          final name = (s as Map<String, dynamic>)['name'] as String;
+          expect(
+            seen.add(name),
+            isTrue,
+            reason: 'Duplicate skill "$name" found in catalog',
+          );
+        }
+      }
+    });
+
+    test('skills define valid repositories', () {
+      final repos = catalogData['repositories'] as Map<String, dynamic>;
+      for (final cat in categories) {
+        final catMap = cat as Map<String, dynamic>;
+        final skills = catMap['skills'] as List<dynamic>;
+        for (final s in skills) {
+          final skill = s as Map<String, dynamic>;
+          final repo = skill['repo'] as String;
+          expect(
+            repos.containsKey(repo),
+            isTrue,
+            reason: 'Unknown repo "$repo" for skill "${skill['name']}"',
+          );
+        }
+      }
+    });
+  });
+
+  test(
+    'validate skills/dart-cleanup/SKILL.md is up-to-date with catalog JSON',
+    () async {
+      final scriptPath =
+          Directory.current.path.split(Platform.pathSeparator).last == 'tool'
+          ? 'bin/generate_cleanup_catalog.dart'
+          : 'tool/bin/generate_cleanup_catalog.dart';
+      final result = await Process.run(Platform.resolvedExecutable, [
+        scriptPath,
+        '--validate',
+      ]);
+      expect(
+        result.exitCode,
+        0,
+        reason:
+            'dart-cleanup/SKILL.md is out of date. Run dart tool/bin/generate_cleanup_catalog.dart --write to update it.\n'
+            'stdout:\n${result.stdout}\n'
+            'stderr:\n${result.stderr}',
+      );
+    },
+  );
+}

--- a/tool/test/dart_cleanup_catalog_test.dart
+++ b/tool/test/dart_cleanup_catalog_test.dart
@@ -5,6 +5,7 @@ import 'package:test/test.dart';
 void main() {
   group('dart_cleanup_catalog data integrity', () {
     late Map<String, dynamic> catalogData;
+    late Map<String, dynamic> repositories;
     late List<dynamic> categories;
 
     setUpAll(() {
@@ -15,7 +16,45 @@ void main() {
       final file = File(catalogPath);
       expect(file.existsSync(), isTrue, reason: 'Catalog JSON must exist');
       catalogData = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+      repositories = catalogData['repositories'] as Map<String, dynamic>;
       categories = catalogData['categories'] as List<dynamic>;
+    });
+
+    test('repositories have valid paths, cloneUrls, and pinned commits', () {
+      expect(repositories, isNotEmpty);
+      final shaRegex = RegExp(r'^[0-9a-f]{40}$');
+
+      for (final entry in repositories.entries) {
+        final config = entry.value as Map<String, dynamic>;
+        final rawPath = config['path'] as String?;
+        expect(rawPath, isNotNull, reason: 'Repo ${entry.key} must have path');
+        expect(rawPath, startsWith('~/github/'));
+
+        final cloneUrl = config['cloneUrl'] as String?;
+        expect(cloneUrl, isNotNull);
+        expect(cloneUrl, startsWith('https://github.com/'));
+        expect(cloneUrl, endsWith('.git'));
+
+        final commitSha = config['commitSha'] as String?;
+        if (commitSha != null) {
+          expect(
+            shaRegex.hasMatch(commitSha),
+            isTrue,
+            reason:
+                'Commit SHA for ${entry.key} must be 40-char hex string: $commitSha',
+          );
+        }
+
+        final commitDate = config['commitDate'] as String?;
+        if (commitDate != null) {
+          expect(
+            DateTime.tryParse(commitDate),
+            isNotNull,
+            reason:
+                'Commit date for ${entry.key} must be valid ISO-8601: $commitDate',
+          );
+        }
+      }
     });
 
     test('categories are not empty and have distinct names', () {
@@ -62,7 +101,6 @@ void main() {
     });
 
     test('skills define valid repositories', () {
-      final repos = catalogData['repositories'] as Map<String, dynamic>;
       for (final cat in categories) {
         final catMap = cat as Map<String, dynamic>;
         final skills = catMap['skills'] as List<dynamic>;
@@ -70,7 +108,7 @@ void main() {
           final skill = s as Map<String, dynamic>;
           final repo = skill['repo'] as String;
           expect(
-            repos.containsKey(repo),
+            repositories.containsKey(repo),
             isTrue,
             reason: 'Unknown repo "$repo" for skill "${skill['name']}"',
           );


### PR DESCRIPTION
Expands the `dart-cleanup` router catalog with official `dart-lang/skills`, establishes declarative JSON metadata, adds automated CLI generation with environment auditing, and tracks repository commit provenance.

### Key Changes
- **Declarative Catalog Metadata**: Added [tool/data/dart_cleanup_catalog.json](file:///usr/local/google/home/kevmoo/github/kevmoo/kevmoo_skills/tool/data/dart_cleanup_catalog.json) defining tracked repositories (`skills`, `dash_skills`, `analytica.dart`) and all 28 skills categorized and sorted alphabetically.
- **Generator & Environment Audit**: Authored [tool/bin/generate_cleanup_catalog.dart](file:///usr/local/google/home/kevmoo/github/kevmoo/kevmoo_skills/tool/bin/generate_cleanup_catalog.dart) conforming to `dart-build-cli-app` best practices:
  - `--check-env`: Verifies directories exist, validates git remote URLs against GitHub clone URLs, and flags uncataloged or missing skills with copyable remediation commands.
  - `--write`: Auto-queries HEAD commit SHA and ISO commit date per repo, updates JSON metadata, and renders the catalog and a documented `Required Local Repositories` table in [skills/dart-cleanup/SKILL.md](file:///usr/local/google/home/kevmoo/github/kevmoo/kevmoo_skills/skills/dart-cleanup/SKILL.md).
  - `--validate`: Fast CI check ensuring `SKILL.md` is strictly in sync with JSON.
- **Provenance & Repository Table**: Renders a GitHub-linked markdown table in `SKILL.md` showing target repositories, local checkout paths, and pinned commit SHAs with commit dates.
- **Automated Testing**: Added comprehensive unit tests in [tool/test/dart_cleanup_catalog_test.dart](file:///usr/local/google/home/kevmoo/github/kevmoo/kevmoo_skills/tool/test/dart_cleanup_catalog_test.dart) covering schema validity, 40-character SHAs, ISO dates, unique skill names, alphabetical sorting, and `--validate` sync.
