### PR TITLE
fix(sidequest): make batch explicitly fail and accept documented aliases

### DIFF
--- a/skills/sidequest/SKILL.md
+++ b/skills/sidequest/SKILL.md
@@ -70,7 +70,7 @@ sidequest blocker add 1.1 "Broken build dependency"
 sidequest sidequest add "Tangent item" [--global] [--parked] [--note="..."]
 
 # 3. Batch Operations (Atomic multi-item execution in a single call)
-sidequest batch '[{"op":"subquest_add","quest_id":"1","title":"Backend"},{"op":"step_add","subquest_id":"1.2","title":"API client"}]'
+sidequest batch '[{"type":"subquest_add","quest":"1","title":"Backend"},{"type":"step_add","subquest":"1.2","title":"API client"}]'
 
 # 4. Complete One or Multiple Items (Atomic disk write & star update)
 sidequest complete 1.1.1 1.1.2 1.1

--- a/skills/sidequest/lib/src/cli/command_runner.dart
+++ b/skills/sidequest/lib/src/cli/command_runner.dart
@@ -672,15 +672,34 @@ class BatchCommand extends SidequestCommand {
     }
     final decoded = jsonDecode(rest[0]);
     final data = await requireData();
+    final dataClone = SidequestData.fromJson(data.toJson());
 
-    if (decoded is List) {
-      _applyBatchList(data, decoded);
-    } else if (decoded is Map<String, dynamic>) {
-      _applyBatchMap(data, decoded);
+    int applied = 0;
+    int total = 0;
+
+    try {
+      if (decoded is List) {
+        total = decoded.length;
+        applied = _applyBatchList(dataClone, decoded);
+      } else if (decoded is Map<String, dynamic>) {
+        total = 1;
+        if (decoded['operations'] is List) {
+          total = (decoded['operations'] as List).length;
+        }
+        applied = _applyBatchMap(dataClone, decoded);
+      }
+    } catch (e) {
+      stderr.writeln('Error applying batch: $e');
+      return 1;
     }
 
-    await store.save(data);
-    stdout.writeln('✔ Executed batch operations');
+    if (total > 0 && applied == 0) {
+      stderr.writeln('Error: 0 of $total operations applied.');
+      return 1;
+    }
+
+    await store.save(dataClone);
+    stdout.writeln('✔ Executed $applied of $total batch operations');
     return 0;
   }
 }
@@ -973,36 +992,45 @@ bool _removeSingleItem(SidequestData data, String id) {
   return found;
 }
 
-void _applyBatchList(SidequestData data, List<dynamic> list) {
+int _applyBatchList(SidequestData data, List<dynamic> list) {
+  int count = 0;
   for (final op in list) {
     if (op is Map<String, dynamic>) {
       _applyBatchOp(data, op);
+      count++;
+    } else {
+      throw StateError('Invalid operation format: expected object.');
     }
   }
+  return count;
 }
 
-void _applyBatchMap(SidequestData data, Map<String, dynamic> map) {
+int _applyBatchMap(SidequestData data, Map<String, dynamic> map) {
   if (map['operations'] is List) {
-    _applyBatchList(data, map['operations'] as List);
-    return;
+    return _applyBatchList(data, map['operations'] as List);
   }
-  _applyLegacyBatchMap(data, map);
+  return _applyLegacyBatchMap(data, map);
 }
 
-void _applyLegacyBatchMap(SidequestData data, Map<String, dynamic> map) {
+int _applyLegacyBatchMap(SidequestData data, Map<String, dynamic> map) {
+  int count = 0;
   if (map['complete'] is List) {
     for (final id in map['complete'] as List) {
       final nextOrder = data.lastCompletionOrder + 1;
       final result = _completeSingleItem(data, id.toString(), nextOrder);
       if (result == _ItemCompleteResult.completedWithOrder) {
         data.lastCompletionOrder = nextOrder;
+      } else if (result == _ItemCompleteResult.notFound) {
+        throw StateError('Item "$id" not found for completion.');
       }
+      count++;
     }
   }
 
   if (map['addSubQuest'] is Map) {
     final sqMap = map['addSubQuest'] as Map<String, dynamic>;
-    final qId = sqMap['quest'] as String? ?? '1';
+    final qId =
+        sqMap['quest']?.toString() ?? sqMap['quest_id']?.toString() ?? '1';
     final quest = _findQuest(data, qId);
     if (quest != null) {
       final nextSubNumber = _nextSuffixNumber(
@@ -1016,12 +1044,15 @@ void _applyLegacyBatchMap(SidequestData data, Map<String, dynamic> map) {
           status: TaskStatus.inProgress,
         ),
       );
+      count++;
+    } else {
+      throw StateError('Main Quest "$qId" not found.');
     }
   }
 
   if (map['vcs'] is Map) {
     final vcsMap = map['vcs'] as Map<String, dynamic>;
-    final qId = vcsMap['quest'] as String? ?? '1';
+    final qId = vcsMap['quest']?.toString() ?? '1';
     final quest = _findQuest(data, qId);
     if (quest != null) {
       final files =
@@ -1032,12 +1063,17 @@ void _applyLegacyBatchMap(SidequestData data, Map<String, dynamic> map) {
         modifiedFiles: files,
         details: vcsMap['details'] as String?,
       );
+      count++;
+    } else {
+      throw StateError('Main Quest "$qId" not found.');
     }
   }
+  return count;
 }
 
 void _applyBatchOp(SidequestData data, Map<String, dynamic> op) {
-  final type = (op['type'] as String? ?? '').toLowerCase();
+  final type = (op['type']?.toString() ?? op['op']?.toString() ?? '')
+      .toLowerCase();
 
   switch (type) {
     case 'quest_add':
@@ -1054,6 +1090,8 @@ void _applyBatchOp(SidequestData data, Map<String, dynamic> op) {
       _applyBatchSideQuestAdd(data, op);
     case 'vcs':
       _applyBatchVcs(data, op);
+    default:
+      throw StateError('Unknown operation type: "$type"');
   }
 }
 
@@ -1086,12 +1124,18 @@ void _applyBatchComplete(SidequestData data, Map<String, dynamic> op) {
     final result = _completeSingleItem(data, id, nextOrder);
     if (result == _ItemCompleteResult.completedWithOrder) {
       data.lastCompletionOrder = nextOrder;
+    } else if (result == _ItemCompleteResult.notFound) {
+      throw StateError('Item "$id" not found for completion.');
     }
   }
 }
 
 void _applyBatchSubQuestAdd(SidequestData data, Map<String, dynamic> op) {
-  final qId = op['questId']?.toString() ?? op['quest']?.toString() ?? '1';
+  final qId =
+      op['questId']?.toString() ??
+      op['quest_id']?.toString() ??
+      op['quest']?.toString() ??
+      '1';
   final title =
       op['title']?.toString() ?? op['description']?.toString() ?? 'SubQuest';
   final quest = data.quests.where((q) => q.id == qId).firstOrNull;
@@ -1101,12 +1145,17 @@ void _applyBatchSubQuestAdd(SidequestData data, Map<String, dynamic> op) {
     quest.subQuests.add(
       SubQuest(id: subId, title: title, status: TaskStatus.inProgress),
     );
+  } else {
+    throw StateError('Main Quest "$qId" not found.');
   }
 }
 
 void _applyBatchStepAdd(SidequestData data, Map<String, dynamic> op) {
   final subId =
-      op['subquestId']?.toString() ?? op['subquest']?.toString() ?? '1.1';
+      op['subquestId']?.toString() ??
+      op['subquest_id']?.toString() ??
+      op['subquest']?.toString() ??
+      '1.1';
   final title =
       op['title']?.toString() ?? op['description']?.toString() ?? 'Step';
   final sub = _findSubQuest(data, subId);
@@ -1120,12 +1169,17 @@ void _applyBatchStepAdd(SidequestData data, Map<String, dynamic> op) {
         status: TaskStatus.pending,
       ),
     );
+  } else {
+    throw StateError('Sub-Quest "$subId" not found.');
   }
 }
 
 void _applyBatchBlockerAdd(SidequestData data, Map<String, dynamic> op) {
   final subId =
-      op['subquestId']?.toString() ?? op['subquest']?.toString() ?? '1.1';
+      op['subquestId']?.toString() ??
+      op['subquest_id']?.toString() ??
+      op['subquest']?.toString() ??
+      '1.1';
   final title =
       op['title']?.toString() ?? op['description']?.toString() ?? 'Blocker';
   final sub = _findSubQuest(data, subId);
@@ -1139,6 +1193,8 @@ void _applyBatchBlockerAdd(SidequestData data, Map<String, dynamic> op) {
         status: TaskStatus.inProgress,
       ),
     );
+  } else {
+    throw StateError('Sub-Quest "$subId" not found.');
   }
 }
 
@@ -1157,19 +1213,29 @@ void _applyBatchSideQuestAdd(SidequestData data, Map<String, dynamic> op) {
       SideQuest(id: id, title: title, status: status, note: note),
     );
   } else {
-    final qId = op['quest'].toString();
+    final qId =
+        op['quest']?.toString() ??
+        op['quest_id']?.toString() ??
+        op['questId']?.toString() ??
+        '1';
     final quest = data.quests.where((q) => q.id == qId).firstOrNull;
     if (quest != null) {
       final id = data.generateNextSideQuestId(quest);
       quest.sideQuests.add(
         SideQuest(id: id, title: title, status: status, note: note),
       );
+    } else {
+      throw StateError('Main Quest "$qId" not found.');
     }
   }
 }
 
 void _applyBatchVcs(SidequestData data, Map<String, dynamic> op) {
-  final qId = op['quest']?.toString() ?? '1';
+  final qId =
+      op['quest']?.toString() ??
+      op['quest_id']?.toString() ??
+      op['questId']?.toString() ??
+      '1';
   final quest = data.quests.where((q) => q.id == qId).firstOrNull;
   if (quest != null) {
     final files = (op['files'] as List<dynamic>?)?.cast<String>() ?? const [];
@@ -1179,6 +1245,8 @@ void _applyBatchVcs(SidequestData data, Map<String, dynamic> op) {
       modifiedFiles: files,
       details: op['details']?.toString(),
     );
+  } else {
+    throw StateError('Main Quest "$qId" not found.');
   }
 }
 

--- a/skills/sidequest/lib/src/cli/command_runner.dart
+++ b/skills/sidequest/lib/src/cli/command_runner.dart
@@ -682,11 +682,20 @@ class BatchCommand extends SidequestCommand {
         total = decoded.length;
         applied = _applyBatchList(dataClone, decoded);
       } else if (decoded is Map<String, dynamic>) {
-        total = 1;
         if (decoded['operations'] is List) {
           total = (decoded['operations'] as List).length;
+        } else {
+          int mapOps = 0;
+          if (decoded['addSubQuest'] != null) mapOps++;
+          if (decoded['complete'] != null) mapOps++;
+          if (decoded['vcs'] != null) mapOps++;
+          total = max(mapOps, 1);
         }
         applied = _applyBatchMap(dataClone, decoded);
+      } else {
+        throw FormatException(
+          'Batch payload must be a JSON array or object, got ${decoded.runtimeType}',
+        );
       }
     } catch (e) {
       stderr.writeln('Error applying batch: $e');
@@ -1031,7 +1040,7 @@ int _applyLegacyBatchMap(SidequestData data, Map<String, dynamic> map) {
     final sqMap = map['addSubQuest'] as Map<String, dynamic>;
     final qId =
         sqMap['quest']?.toString() ?? sqMap['quest_id']?.toString() ?? '1';
-    final quest = _findQuest(data, qId);
+    final quest = _findQuest(data, qId, silent: true);
     if (quest != null) {
       final nextSubNumber = _nextSuffixNumber(
         quest.subQuests.map((sq) => sq.id),
@@ -1053,7 +1062,7 @@ int _applyLegacyBatchMap(SidequestData data, Map<String, dynamic> map) {
   if (map['vcs'] is Map) {
     final vcsMap = map['vcs'] as Map<String, dynamic>;
     final qId = vcsMap['quest']?.toString() ?? '1';
-    final quest = _findQuest(data, qId);
+    final quest = _findQuest(data, qId, silent: true);
     if (quest != null) {
       final files =
           (vcsMap['files'] as List<dynamic>?)?.cast<String>() ?? const [];
@@ -1117,9 +1126,13 @@ void _applyBatchQuestAdd(SidequestData data, Map<String, dynamic> op) {
 void _applyBatchComplete(SidequestData data, Map<String, dynamic> op) {
   final rawIds = op['ids'] ?? op['id'];
   final idList = rawIds is List
-      ? rawIds.map((e) => e.toString()).toList()
-      : [rawIds?.toString() ?? ''];
-  for (final id in idList.where((s) => s.isNotEmpty)) {
+      ? rawIds.map((e) => e.toString().trim()).toList()
+      : [rawIds?.toString().trim() ?? ''];
+  final validIds = idList.where((s) => s.isNotEmpty).toList();
+  if (validIds.isEmpty) {
+    throw StateError('No IDs specified for complete operation.');
+  }
+  for (final id in validIds) {
     final nextOrder = data.lastCompletionOrder + 1;
     final result = _completeSingleItem(data, id, nextOrder);
     if (result == _ItemCompleteResult.completedWithOrder) {
@@ -1158,7 +1171,7 @@ void _applyBatchStepAdd(SidequestData data, Map<String, dynamic> op) {
       '1.1';
   final title =
       op['title']?.toString() ?? op['description']?.toString() ?? 'Step';
-  final sub = _findSubQuest(data, subId);
+  final sub = _findSubQuest(data, subId, silent: true);
   if (sub != null) {
     final nextNumber = _nextSuffixNumber(sub.items.map((i) => i.id));
     sub.items.add(
@@ -1182,7 +1195,7 @@ void _applyBatchBlockerAdd(SidequestData data, Map<String, dynamic> op) {
       '1.1';
   final title =
       op['title']?.toString() ?? op['description']?.toString() ?? 'Blocker';
-  final sub = _findSubQuest(data, subId);
+  final sub = _findSubQuest(data, subId, silent: true);
   if (sub != null) {
     final nextNumber = _nextSuffixNumber(sub.items.map((i) => i.id));
     sub.items.add(
@@ -1201,23 +1214,21 @@ void _applyBatchBlockerAdd(SidequestData data, Map<String, dynamic> op) {
 void _applyBatchSideQuestAdd(SidequestData data, Map<String, dynamic> op) {
   final title =
       op['title']?.toString() ?? op['description']?.toString() ?? 'Side Quest';
-  final isGlobal =
-      op['global'] == true || (op['quest'] == null && data.quests.isEmpty);
+  final qId =
+      op['quest']?.toString() ??
+      op['quest_id']?.toString() ??
+      op['questId']?.toString();
+  final isGlobal = op['global'] == true || (qId == null && data.quests.isEmpty);
   final isParked = op['parked'] == true;
   final status = isParked ? SideQuestStatus.parked : SideQuestStatus.active;
   final note = op['note']?.toString();
 
-  if (isGlobal || op['quest'] == null) {
+  if (isGlobal || qId == null) {
     final id = data.generateNextGlobalSideQuestId();
     data.globalSideQuests.add(
       SideQuest(id: id, title: title, status: status, note: note),
     );
   } else {
-    final qId =
-        op['quest']?.toString() ??
-        op['quest_id']?.toString() ??
-        op['questId']?.toString() ??
-        '1';
     final quest = data.quests.where((q) => q.id == qId).firstOrNull;
     if (quest != null) {
       final id = data.generateNextSideQuestId(quest);
@@ -1250,19 +1261,24 @@ void _applyBatchVcs(SidequestData data, Map<String, dynamic> op) {
   }
 }
 
-MainQuest? _findQuest(SidequestData data, String id) {
+MainQuest? _findQuest(SidequestData data, String id, {bool silent = false}) {
   final q = data.quests.where((e) => e.id == id).firstOrNull;
-  if (q == null) stderr.writeln('Error: Main Quest "$id" not found.');
+  if (!silent && q == null)
+    stderr.writeln('Error: Main Quest "$id" not found.');
   return q;
 }
 
-SubQuest? _findSubQuest(SidequestData data, String subId) {
+SubQuest? _findSubQuest(
+  SidequestData data,
+  String subId, {
+  bool silent = false,
+}) {
   for (final q in data.quests) {
     for (final sq in q.subQuests) {
       if (sq.id == subId) return sq;
     }
   }
-  stderr.writeln('Error: Sub-Quest "$subId" not found.');
+  if (!silent) stderr.writeln('Error: Sub-Quest "$subId" not found.');
   return null;
 }
 

--- a/tool/test/sidequest_test.dart
+++ b/tool/test/sidequest_test.dart
@@ -643,6 +643,56 @@ void main() {
     );
 
     test(
+      'successfully applies batch mutations using documented aliases (#105)',
+      () async {
+        final runner = SidequestCliRunner(store: store);
+
+        final aliasBatchJson = jsonEncode([
+          {'op': 'subquest_add', 'quest_id': '1', 'title': 'Alias SubQuest'},
+          {'op': 'step_add', 'subquest_id': '1.1', 'title': 'Alias Step'},
+          {'op': 'blocker_add', 'subquest_id': '1.1', 'title': 'Alias Blocker'},
+          {
+            'op': 'sidequest_add',
+            'quest_id': '1',
+            'title': 'Scoped SideQuest with quest_id',
+          },
+          {
+            'op': 'sidequest_add',
+            'global': true,
+            'title': 'Global SideQuest with op alias',
+          },
+          {'op': 'complete', 'id': '1.1.1'},
+        ]);
+
+        final code = await runner.run(['batch', aliasBatchJson]);
+        check(code).equals(0);
+
+        final data = (await store.load())!;
+        check(data.quests[0].subQuests.length).equals(1);
+        check(data.quests[0].subQuests[0].title).equals('Alias SubQuest');
+        check(data.quests[0].subQuests[0].items.length).equals(2);
+        check(data.quests[0].subQuests[0].items[0].title).equals('Alias Step');
+        check(
+          data.quests[0].subQuests[0].items[0].status,
+        ).equals(TaskStatus.completed);
+        check(
+          data.quests[0].subQuests[0].items[1].title,
+        ).equals('Alias Blocker');
+
+        // Verify sidequest scoping with quest_id attaches to Quest 1 rather than globalSideQuests
+        check(data.quests[0].sideQuests.length).equals(1);
+        check(
+          data.quests[0].sideQuests[0].title,
+        ).equals('Scoped SideQuest with quest_id');
+
+        check(data.globalSideQuests.length).equals(1);
+        check(
+          data.globalSideQuests[0].title,
+        ).equals('Global SideQuest with op alias');
+      },
+    );
+
+    test(
       'fails explicitly without mutating for bad batch schemas (#105)',
       () async {
         final runner = SidequestCliRunner(store: store);
@@ -690,6 +740,18 @@ void main() {
         data = (await store.load())!;
         // The first subquest should NOT be saved
         check(data.quests[0].subQuests.length).equals(0);
+
+        // Case 4: Non-collection primitive payload throws
+        final primitiveJson = jsonEncode(123);
+        final code4 = await runner.run(['batch', primitiveJson]);
+        check(code4).equals(1);
+
+        // Case 5: Complete operation with empty IDs throws
+        final emptyCompleteJson = jsonEncode([
+          {'type': 'complete', 'ids': []},
+        ]);
+        final code5 = await runner.run(['batch', emptyCompleteJson]);
+        check(code5).equals(1);
       },
     );
 

--- a/tool/test/sidequest_test.dart
+++ b/tool/test/sidequest_test.dart
@@ -642,6 +642,57 @@ void main() {
       },
     );
 
+    test(
+      'fails explicitly without mutating for bad batch schemas (#105)',
+      () async {
+        final runner = SidequestCliRunner(store: store);
+
+        // Original state
+        final initialData = (await store.load())!;
+        check(initialData.quests.length).equals(1);
+        check(initialData.quests[0].subQuests.length).equals(0);
+
+        // Case 1: The documented 'op' key works, but with a non-existent 'quest_id' it throws and aborts.
+        final missingQuestJson = jsonEncode([
+          {
+            'op': 'subquest_add',
+            'quest_id': 'invalid-id',
+            'title': 'Lost SubQuest',
+          },
+        ]);
+        final code1 = await runner.run(['batch', missingQuestJson]);
+        check(code1).equals(1);
+
+        var data = (await store.load())!;
+        // Make sure NO side effect occurred (atomicity check)
+        check(data.quests.length).equals(1);
+        check(data.quests[0].subQuests.length).equals(0);
+
+        // Case 2: Unknown 'type' key throws
+        final unknownTypeJson = jsonEncode([
+          {'type': 'some_unknown_op'},
+        ]);
+        final code2 = await runner.run(['batch', unknownTypeJson]);
+        check(code2).equals(1);
+
+        // Case 3: Mixed batch where one succeeds but the next fails, ensuring atomic rollback
+        final atomicRollbackJson = jsonEncode([
+          {
+            'op': 'subquest_add',
+            'quest_id': '1',
+            'title': 'Temporary SubQuest',
+          },
+          {'op': 'unknown_fail'},
+        ]);
+        final code3 = await runner.run(['batch', atomicRollbackJson]);
+        check(code3).equals(1);
+
+        data = (await store.load())!;
+        // The first subquest should NOT be saved
+        check(data.quests[0].subQuests.length).equals(0);
+      },
+    );
+
     test('updates VCS state via CLI and handles unknown items', () async {
       final runner = SidequestCliRunner(store: store);
 


### PR DESCRIPTION
Fixes silent dropping of batch items in the sidequest CLI.

- Updates the CLI to use `type` / `quest` / `subquest` tags, with aliases for documented shapes like `op` / `quest_id`.
- Throws an error on unrecognized operation types and aborted missing targets.
- Deep clones payload to fail atomically if any mutation aborts.
- Exits with an error code on failure.
- Fixes documentation mismatch.
- Adds regression tests for #105.

Fixes #105
