### PR TITLE
chore: standardize markdown formatting and workflow

### DIFF
--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -1,0 +1,22 @@
+name: Markdown
+
+# Runs unconditionally on every PR to main -- deliberately NO `paths:` filter.
+# This job is a required status check, and a path-filtered required check never
+# reports on PRs that touch no markdown, blocking them forever at
+# "Expected - waiting for status to be reported".
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  # Job ID is the check-run context name the branch ruleset matches on.
+  markdown:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "24"
+      - run: npx --yes prettier@3.9.6 --check "**/*.md"

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,12 @@
+{
+  "overrides": [
+    {
+      "files": ["**/*.md"],
+      "options": {
+        "proseWrap": "always",
+        "printWidth": 80,
+        "embeddedLanguageFormatting": "off"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -7,11 +7,14 @@ domains or tasks.
 ## Skills Inventory
 
 <!-- SKILLS_LIST_START -->
+
 To install any skill individually:
+
 ```bash
 npx skills add kevmoo/kevmoo_skills --skill <skill-name>
 ```
 
+<!-- prettier-ignore -->
 | Skill | Description | Key Features |
 |-------|-------------|--------------|
 | **[clarify-confirm-continue](skills/clarify-confirm-continue/SKILL.md)** | Orchestrates a disciplined task intake workflow across code, docs, and project files by autonomously fact-checking the workspace, resolving genuine decision forks, and confirming execution readiness via ask_question before making modifications. Use when starting multi-step tasks, refactorings, ambiguous feature requests, broad documentation updates, or when invoked via /clarify-confirm-continue or "ccc". Don't use for trivial single-turn lookups, straightforward single-line edits where intent is unambiguous, or emergency rollbacks. |  |
@@ -29,4 +32,5 @@ npx skills add kevmoo/kevmoo_skills --skill <skill-name>
 | **[review-pr](skills/review-pr/SKILL.md)** | Reviews GitHub Pull Requests or local Git branch diffs using an adversarial 13-angle review rubric and the Inquisitor Presumption of Theater doctrine to eliminate LLM noise. Evaluates code correctness, removed behavior, error handling, testing, and simplification, generates a ranked Markdown report with clickable line permalinks, and presents an interactive action gate (keep findings, apply local fixes, or post inline to GitHub). Use when reviewing a PR (#N or URL), auditing a local feature branch, or invoked via /review-pr. Don't use for Google3 Piper changelists (use /cl-finalize or review) or general formatting. | 13 analytical review angles (correctness, removed behavior, simplification, testing), Inquisitor Presumption of Theater doctrine (zero AI fluff or pedantry), Clickable GitHub permalinks to source lines, Interactive 3-way action gate (chat only, apply local fixes, post to GitHub) |
 | **[sem-cli](skills/sem-cli/SKILL.md)** | Use the `sem` CLI (`sem-cli`) for fast local code exploration, instant call-graph navigation (`callers`/`refs`), signature-only context packing (`--headers`), hotspot and co-change discovery (`sem log`), transitive impact analysis (`sem impact`), and entity-level semantic diffs (`sem diff`). | Instant call-graph navigation, signature-only context packing, entity-addressed substring search, hotspot and co-change analysis, transitive impact analysis, semantic diffs |
 | **[sidequest](skills/sidequest/SKILL.md)** | Synthesizes conversation history and active tasks into a visual hierarchy map (`sidequest.md`) backed by a deterministic JSON state file (`sidequest.json`). Supports multiple sequential and concurrent main quests, sub-quests, and side-quests with automatic hierarchical numbering and completion sequencing. Use when the user invokes `/sidequest`, asks where we are, what we were doing, or what's on our stack, or when the conversation branches across multiple topics, blockers, or digressions. Don't use for simple one-off questions. | Conversation mapping, Task hierarchy & numbering, VCS state tracking, Subagent history audits |
+
 <!-- SKILLS_LIST_END -->

--- a/skills/clarify-confirm-continue/SKILL.md
+++ b/skills/clarify-confirm-continue/SKILL.md
@@ -28,9 +28,11 @@ are fully aligned before any modification or extensive execution begins.
 ### Phase 1: Fact-Checking & Fork-Hunting
 
 #### 1. Fact-Check the Workspace First (Zero-User-Burden)
+
 Before asking any questions, inspect the environment autonomously using
 read-only tools (`grep_search`, `view_file`, `list_dir`, `code_search`,
 `moma_search`):
+
 - **Codebases**: Check function signatures, type definitions, conventions, and
   existing test suites.
 - **Documents & Project Files**: Read relevant Markdown files (`*.md`), design
@@ -39,35 +41,41 @@ read-only tools (`grep_search`, `view_file`, `list_dir`, `code_search`,
   workspace files or documentation.
 
 #### 2. Fork-Hunting (Genuine Decisions vs. Fake Dilemmas)
+
 Evaluate the task for unresolved decisions by categorizing them:
 
 <!-- mdformat off(prevent table wrapping) -->
-| Category | Definition | Action |
-| :--- | :--- | :--- |
-| **Workspace Facts** | Verifiable via inspection tools. | **Never ask**; inspect autonomously. |
-| **Fake Dilemmas** | Obvious right choice vs obviously broken choices; asking permission for standard best practices. | **Never ask**; execute the obvious right choice. |
-| **Genuine Decision Forks** | 2+ viable, defensible paths with real trade-offs (API design, document framing, breaking changes). | **Clarify** before summarizing. |
+
+| Category                   | Definition                                                                                         | Action                                           |
+| :------------------------- | :------------------------------------------------------------------------------------------------- | :----------------------------------------------- |
+| **Workspace Facts**        | Verifiable via inspection tools.                                                                   | **Never ask**; inspect autonomously.             |
+| **Fake Dilemmas**          | Obvious right choice vs obviously broken choices; asking permission for standard best practices.   | **Never ask**; execute the obvious right choice. |
+| **Genuine Decision Forks** | 2+ viable, defensible paths with real trade-offs (API design, document framing, breaking changes). | **Clarify** before summarizing.                  |
+
 <!-- mdformat on -->
 
-* **Examples of Fake Dilemmas (Do not ask—execute standard best practices)**:
-  - *"Should I write tests for the new feature?"* (Always write tests).
-  - *"Should I fix the syntax error or leave it broken?"* (Obvious brownie vs.
+- **Examples of Fake Dilemmas (Do not ask—execute standard best practices)**:
+  - _"Should I write tests for the new feature?"_ (Always write tests).
+  - _"Should I fix the syntax error or leave it broken?"_ (Obvious brownie vs.
     kick-in-the-face).
-  - *"Should I format the code to comply with style rules?"* (Standard hygiene).
+  - _"Should I format the code to comply with style rules?"_ (Standard hygiene).
 
-* **Examples of Genuine Decision Forks (Clarification required)**:
+- **Examples of Genuine Decision Forks (Clarification required)**:
   - **API & Architecture**: Breaking change vs. deprecation shim; synchronous
-    vs. streaming response; choosing between two existing architectural patterns.
-  - **Documentation & Non-Code**: High-level executive summary vs. deep technical
-    breakdown; standalone doc vs. appending to an existing guide; choosing between
-    competing taxonomies.
+    vs. streaming response; choosing between two existing architectural
+    patterns.
+  - **Documentation & Non-Code**: High-level executive summary vs. deep
+    technical breakdown; standalone doc vs. appending to an existing guide;
+    choosing between competing taxonomies.
   - **Scope Boundaries**: Inclusions vs. exclusions when both are reasonable and
     defensible.
 
 #### 3. Interrogate Unsettled Forks
+
 If one or more **Genuine Decision Forks** exist:
-- Present independent decision forks in a single focused `ask_question` call; ask
-  dependent/sequential forks one at a time.
+
+- Present independent decision forks in a single focused `ask_question` call;
+  ask dependent/sequential forks one at a time.
 - State the trade-offs clearly.
 - **Always provide your recommended choice** with rationale.
 - Wait for user feedback before drafting the final execution summary.
@@ -81,23 +89,24 @@ If one or more **Genuine Decision Forks** exist:
 Once all genuine decision forks are settled (or immediately if zero genuine
 forks exist), invoke the `ask_question` tool with a single readiness gate.
 
-> [!IMPORTANT]
-> **Preventing UI Collapse:** In many agentic harnesses (e.g., Jetski,
-> Antigravity), pre-tool chat text emitted in the same turn as a tool call is
-> automatically collapsed into a progress/thought accordion. To ensure the
-> structured summary is immediately visible and prominent, embed the full
+> [!IMPORTANT] **Preventing UI Collapse:** In many agentic harnesses (e.g.,
+> Jetski, Antigravity), pre-tool chat text emitted in the same turn as a tool
+> call is automatically collapsed into a progress/thought accordion. To ensure
+> the structured summary is immediately visible and prominent, embed the full
 > markdown summary **directly inside the `question` argument** of
 > `ask_question`.
 
 Structure the `question` argument in `ask_question` using markdown:
+
 - **🎯 Goals**: What will be accomplished.
 - **🛡️ Non-Goals / Scope Boundaries**: What will explicitly be left untouched.
-- **📌 Settled Decisions & Invariants**: Agreed choices from Phase 1 and verified
-  workspace facts (no unresolved questions or speculative assumptions).
+- **📌 Settled Decisions & Invariants**: Agreed choices from Phase 1 and
+  verified workspace facts (no unresolved questions or speculative assumptions).
 - **🛠️ Execution Plan**: High-level steps to be performed once approved.
 - Conclude with: `*How would you like to proceed?*`
 
 Configure the `options` array with:
+
 - `"(Recommended) Yes, proceed"`
 - `"Open in artifact"`
 - `"No, adjust in chat"`
@@ -112,9 +121,9 @@ Configure the `options` array with:
   artifact directory. Configure the file to request interactive
   approval/feedback (e.g., set `ArtifactMetadata` with `UserFacing: true`,
   `RequestFeedback: true`, and a concise `Summary` to render an interactive
-  'Proceed' button). If the harness does not support interactive gates,
-  instruct the user in chat to review the file and reply 'Proceed' when they are
-  ready. Stop calling tools and go idle to await reactive wakeup.
+  'Proceed' button). If the harness does not support interactive gates, instruct
+  the user in chat to review the file and reply 'Proceed' when they are ready.
+  Stop calling tools and go idle to await reactive wakeup.
 - **If "No, adjust in chat" or Custom Write-In**: Apply user feedback, adjust
   the scope or plan accordingly, and re-confirm if substantial changes were
   made.
@@ -123,8 +132,8 @@ Configure the `options` array with:
 
 ## Execution Safety Invariants
 
-- **No Pre-Approval Modifications**: Do not edit workspace files, create branches,
-  or run mutating commands during Phase 1 or Phase 2.
+- **No Pre-Approval Modifications**: Do not edit workspace files, create
+  branches, or run mutating commands during Phase 1 or Phase 2.
 - **Explicit Approval Gate**: You must receive confirmation via `ask_question`
   (or write-in approval) before transitioning to execution.
 - **Global Guardrails Preserved**: Approval at the confirmation gate authorizes

--- a/skills/dart-cleanup/SKILL.md
+++ b/skills/dart-cleanup/SKILL.md
@@ -12,11 +12,10 @@ compatibility: "Requires local checkouts in ~/github/kevmoo and ~/github/skills"
 
 # 🎯 Dart Cleanup & Refactoring Router
 
-> [!NOTE]
-> **Personal Environment Router**: This skill is optimized for `@kevmoo`'s
-> local development environment and assumes specialized skills are checked out
-> under `~/github/kevmoo/` and `~/github/skills/`. Other users should clone the
-> required repositories or adapt the catalog paths in
+> [!NOTE] **Personal Environment Router**: This skill is optimized for
+> `@kevmoo`'s local development environment and assumes specialized skills are
+> checked out under `~/github/kevmoo/` and `~/github/skills/`. Other users
+> should clone the required repositories or adapt the catalog paths in
 > [Skill Catalog](#-skill-catalog) to match their local layout.
 
 Orchestrates specialized Dart workflows from local GitHub checkouts without
@@ -32,34 +31,35 @@ When invoked with text (e.g. `/dart-cleanup convert expect matchers to checks`),
 evaluate the input against the [Skill Catalog](#-skill-catalog) using this
 3-tier confidence decision tree:
 
-* **Tier 1: Unambiguous Clear Match (High Confidence / 90%+ sure)**
-  * Exactly 1 skill in the catalog clearly maps to the requested
-    transformation.
-  * *Action*:
+- **Tier 1: Unambiguous Clear Match (High Confidence / 90%+ sure)**
+  - Exactly 1 skill in the catalog clearly maps to the requested transformation.
+  - _Action_:
     1. Check for the target `SKILL.md` at its candidate path in `~/github/`.
     2. If missing, output the
        [Missing Checkout Safety Net](#missing-checkout-safety-net).
     3. If present, call `view_file` on the target `SKILL.md`, hydrate its
-       untruncated instructions into active context, and execute the
-       refactoring immediately.
-* **Tier 2: Uncertain / Close Match (Medium Confidence)**
-  * A skill seems close or relevant, but there is ambiguity.
-  * *Action*: Stop and ask the user for confirmation before hydrating:
-    > *"I think you might mean **`<skill-name>`**"*
-    > *([SKILL.md](file:///path/to/SKILL.md)). Would you like me to load and*
-    > *run this workflow?"*
-* **Tier 3: No Clear Match or Bare Invocation (Low Confidence / Empty Input)**
-  * No skill matches the prompt, or `/dart-cleanup` was invoked with no
+       untruncated instructions into active context, and execute the refactoring
+       immediately.
+- **Tier 2: Uncertain / Close Match (Medium Confidence)**
+  - A skill seems close or relevant, but there is ambiguity.
+  - _Action_: Stop and ask the user for confirmation before hydrating:
+    > _"I think you might mean **`<skill-name>`**"_
+    > _([SKILL.md](file:///path/to/SKILL.md)). Would you like me to load and_
+    > _run this workflow?"_
+- **Tier 3: No Clear Match or Bare Invocation (Low Confidence / Empty Input)**
+  - No skill matches the prompt, or `/dart-cleanup` was invoked with no
     arguments.
-  * *Action*: Output:
-    > *"I couldn't find an unambiguous skill match for your request. Here is*
-    > *the catalog of available specialized Dart skills:"*
-    Render the categorized [Skill Catalog](#-skill-catalog) with clickable
-    `file://` links so the user can choose.
+  - _Action_: Output:
+    > _"I couldn't find an unambiguous skill match for your request. Here is_
+    > _the catalog of available specialized Dart skills:"_ Render the
+    > categorized [Skill Catalog](#-skill-catalog) with clickable `file://`
+    > links so the user can choose.
 
 ### 2. Missing Checkout Safety Net
+
 If a target `SKILL.md` is selected but missing from the local filesystem,
 output:
+
 > ⚠️ **Missing local checkout**: Target skill `<skill-name>` was not found at
 > `~/github/...`. Please ensure `https://github.com/<org>/<repo>` is cloned into
 > `~/github/`.
@@ -69,14 +69,17 @@ output:
 ## 📋 Skill Catalog & Path Priority
 
 <!-- DART_CLEANUP_CATALOG_START -->
+
+<!-- prettier-ignore-start -->
+
 ### Required Local Repositories
 
 <!-- mdformat off(prevent table wrapping) -->
 | Repository | Local Directory | Synced Commit |
 | :--- | :--- | :--- |
 | [`dart-lang/skills`](https://github.com/dart-lang/skills) | `~/github/skills` | [`26b2dcc`](https://github.com/dart-lang/skills/commit/26b2dcc5654cbbc3b2ec56ea94719469bc8bae9e) |
-| [`kevmoo/analytica.dart`](https://github.com/kevmoo/analytica.dart) | `~/github/kevmoo/analytica.dart` | [`1bba4de`](https://github.com/kevmoo/analytica.dart/commit/1bba4de81a526b3805561227fb1adeed4e3feb45) |
-| [`kevmoo/dash_skills`](https://github.com/kevmoo/dash_skills) | `~/github/kevmoo/dash_skills` | [`949bd00`](https://github.com/kevmoo/dash_skills/commit/949bd00b69fc8449c535aeb4f4970c7ec5e21b49) |
+| [`kevmoo/analytica.dart`](https://github.com/kevmoo/analytica.dart) | `~/github/kevmoo/analytica.dart` | [`0114d16`](https://github.com/kevmoo/analytica.dart/commit/0114d16b76df87f7bea27f9b11888518fb787357) |
+| [`kevmoo/dash_skills`](https://github.com/kevmoo/dash_skills) | `~/github/kevmoo/dash_skills` | [`6c39005`](https://github.com/kevmoo/dash_skills/commit/6c3900555225a113d4dbd89b4cda4b41c72130ae) |
 <!-- mdformat on -->
 
 ### A. Refactoring & Code Quality
@@ -174,5 +177,7 @@ output:
 * **`dart-write-documentation`**: Effective Dart `///` doc comment conventions,
   API documentation rules, and reference linking.
   * *Path*: `~/github/skills/skills/dart-write-documentation/SKILL.md`
-<!-- DART_CLEANUP_CATALOG_END -->
 
+<!-- prettier-ignore-end -->
+
+<!-- DART_CLEANUP_CATALOG_END -->

--- a/skills/distilling-strategies-interactively/SKILL.md
+++ b/skills/distilling-strategies-interactively/SKILL.md
@@ -26,13 +26,13 @@ and synthesize a definitive decision matrix and action plan.
 
 ## Why This Approach Matters
 
-- **Avoids Premature Optimization:** Writing code before resolving
-  architectural contradictions leads to wasted effort and refactoring loops.
+- **Avoids Premature Optimization:** Writing code before resolving architectural
+  contradictions leads to wasted effort and refactoring loops.
 - **Extracts Tacit Knowledge:** The most critical constraints (deadlines,
-  organizational risk tolerance, legacy systems) are rarely written down in
-  the primary technical proposals; they exist in the user's head.
-- **Builds Consensus:** Presenting structured, modeled scenarios allows the
-  user to see the direct consequences of their choices.
+  organizational risk tolerance, legacy systems) are rarely written down in the
+  primary technical proposals; they exist in the user's head.
+- **Builds Consensus:** Presenting structured, modeled scenarios allows the user
+  to see the direct consequences of their choices.
 
 ---
 
@@ -42,13 +42,13 @@ Follow this sequence to guide the user from chaos to a clear action plan. Copy
 this checklist to track progress:
 
 - [ ] **Phase 1: Artifact Mapping & Contradiction Triage** → Output: Strategic
-  Landscape Analysis
-- [ ] **Phase 2: The Socratic Interview** → Output: Structured 4-6 Question
-  Quiz (Execution Halted)
-- [ ] **Phase 3: Scenario Modeling & Trade-Off Matrix** → Output: Clean
-  Markdown comparison table (Triggered by Quiz answers)
+      Landscape Analysis
+- [ ] **Phase 2: The Socratic Interview** → Output: Structured 4-6 Question Quiz
+      (Execution Halted)
+- [ ] **Phase 3: Scenario Modeling & Trade-Off Matrix** → Output: Clean Markdown
+      comparison table (Triggered by Quiz answers)
 - [ ] **Phase 4: Final Synthesis & Action Plan** → Output:
-  `DISTILLED_STRATEGY.md`
+      `DISTILLED_STRATEGY.md`
 
 ---
 
@@ -105,8 +105,13 @@ highly targeted, interactive quiz to extract the user's latent constraints.
 - Avoid vague questions (e.g., "What do you want?"). Use forced-choice or
   comparative questions.
 - **Interactive Option Selection**:
-  - If the hosting platform supports interactive choice modals (e.g., Antigravity's `ask_question` tool), you are strongly encouraged to present predictable or multiple-choice questions using that tool (configured with `is_multi_select: true` or single-select) to reduce user typing overhead.
-  - For open-ended questions, or if the harness does not support interactive question modals, fall back to outputting the quiz as a numbered Markdown list directly in chat.
+  - If the hosting platform supports interactive choice modals (e.g.,
+    Antigravity's `ask_question` tool), you are strongly encouraged to present
+    predictable or multiple-choice questions using that tool (configured with
+    `is_multi_select: true` or single-select) to reduce user typing overhead.
+  - For open-ended questions, or if the harness does not support interactive
+    question modals, fall back to outputting the quiz as a numbered Markdown
+    list directly in chat.
 - Structure the quiz into exactly three categories:
 
 1. **Hard Constraints & Guardrails:** Focus on unyielding boundaries (e.g.,
@@ -149,21 +154,20 @@ Please answer the following questions to help narrow down the path forward:
 
 ### Phase 3: Scenario Modeling & Trade-Off Matrix
 
-*(This phase activates ONLY after the user provides their answers to the Phase 2
-quiz.)*
+_(This phase activates ONLY after the user provides their answers to the Phase 2
+quiz.)_
 
 Evaluate the competing paths through the lens of the user's quiz responses.
-Synthesize these into a clean Markdown table comparing the top 2 viable
-options.
+Synthesize these into a clean Markdown table comparing the top 2 viable options.
 
 Use this exact schema:
 
-Dimension                                                              | Option A: {Name}                                       | Option B: {Name}
-:--------------------------------------------------------------------- | :----------------------------------------------------- | :--------
-**Core Concept**                                                       | *Brief description of this path.*                      | *Brief description of this path.*
-**Alignment with Your Goals**                                          | *Explain how this path satisfies or violates the specific preferences expressed in the quiz.*                       | *Explain how this path satisfies or violates the specific preferences expressed in the quiz.*
-**The Catch / Tax**                                                    | *What you explicitly sacrifice if you choose this path (e.g., developer speed, infrastructure cost, migration time).*         | *What you explicitly sacrifice if you choose this path.*
-**Execution Friction**                                                 | *Low / Medium / High, with a 1-sentence justification based on the artifacts.*                                 | *Low / Medium / High, with a 1-sentence justification based on the artifacts.*
+| Dimension                     | Option A: {Name}                                                                                                      | Option B: {Name}                                                                              |
+| :---------------------------- | :-------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------- |
+| **Core Concept**              | _Brief description of this path._                                                                                     | _Brief description of this path._                                                             |
+| **Alignment with Your Goals** | _Explain how this path satisfies or violates the specific preferences expressed in the quiz._                         | _Explain how this path satisfies or violates the specific preferences expressed in the quiz._ |
+| **The Catch / Tax**           | _What you explicitly sacrifice if you choose this path (e.g., developer speed, infrastructure cost, migration time)._ | _What you explicitly sacrifice if you choose this path._                                      |
+| **Execution Friction**        | _Low / Medium / High, with a 1-sentence justification based on the artifacts._                                        | _Low / Medium / High, with a 1-sentence justification based on the artifacts._                |
 
 ---
 
@@ -174,11 +178,12 @@ artifacts directory (`<appDataDir>/brain/<conversation-id>`) using the
 `write_to_file` tool. Save this document without requesting interactive
 approval/feedback (e.g., set `RequestFeedback: false` if using Antigravity's
 `ArtifactMetadata`), as it serves as a strategic record rather than an
-interactive gateway to immediate execution. This document serves as the source of truth for execution.
+interactive gateway to immediate execution. This document serves as the source
+of truth for execution.
 
 Structure the document as follows:
 
-1. **The Recommended Path:** A clear, singular recommendation. Justify *why*
+1. **The Recommended Path:** A clear, singular recommendation. Justify _why_
    this path is the optimal choice based on the intersection of the technical
    artifacts and the user's quiz inputs.
 2. **Immediate Next Steps (3-5 Actions):** Actionable, concrete steps to

--- a/skills/gerrit-stacked-cls/SKILL.md
+++ b/skills/gerrit-stacked-cls/SKILL.md
@@ -10,16 +10,24 @@ key_features:
 ---
 
 ## 1. When to use this skill
-Use this skill when you need to create, update, or manage a chain of dependent changelists (CLs) in Gerrit (stacked CLs) for the Dart SDK or similar repositories using Chromium's `depot_tools`.
+
+Use this skill when you need to create, update, or manage a chain of dependent
+changelists (CLs) in Gerrit (stacked CLs) for the Dart SDK or similar
+repositories using Chromium's `depot_tools`.
 
 ## 2. Core Concepts
-*   **Relation Chain**: Gerrit links commits together based on their parent-child relationship in the pushed git history.
-*   **Change-Id**: Gerrit identifies a CL by the Change-Id: line in the commit message.
-*   **Commit Hash**: Gerrit identifies a *Patchset* within a CL by the git commit hash.
+
+- **Relation Chain**: Gerrit links commits together based on their parent-child
+  relationship in the pushed git history.
+- **Change-Id**: Gerrit identifies a CL by the Change-Id: line in the commit
+  message.
+- **Commit Hash**: Gerrit identifies a _Patchset_ within a CL by the git commit
+  hash.
 
 ## 3. Procedural Workflows
 
 ### Creating Stacked CLs
+
 1.  **Start with the base CL**:
     ```bash
     git new-branch branch1
@@ -27,8 +35,7 @@ Use this skill when you need to create, update, or manage a chain of dependent c
     git commit -m "First change"
     git cl upload
     ```
-2.  **Create the dependent CL**:
-    Create a new branch on top of `branch1`.
+2.  **Create the dependent CL**: Create a new branch on top of `branch1`.
     ```bash
     git checkout branch1
     git new-branch branch2
@@ -39,30 +46,55 @@ Use this skill when you need to create, update, or manage a chain of dependent c
     Gerrit will automatically create a relation chain.
 
 ### Updating a Specific CL in a Stack
-To update a specific CL without confusing Gerrit, you must ensure that the commit you push has the **correct Change-Id** and that it is the **last** Change-Id in the commit message if multiple are present (though ideally, keep only one).
+
+To update a specific CL without confusing Gerrit, you must ensure that the
+commit you push has the **correct Change-Id** and that it is the **last**
+Change-Id in the commit message if multiple are present (though ideally, keep
+only one).
 
 #### Method A: Amending (If allowed by user rules)
+
 If allowed to amend, this is the cleanest way:
+
 1.  Checkout the branch for the CL you want to update.
 2.  Make changes.
 3.  Run `git commit --amend`. Keep the original `Change-Id` line intact!
 4.  Run `git cl upload`.
 
 #### Method B: New Commit + Squash (Following strict no-amend rules)
+
 If forbidden from amending active PRs:
+
 1.  Make changes on the branch.
 2.  Commit as a new commit (generating a new Change-Id).
 3.  To update the existing CL on Gerrit without creating a new one:
-    *   Squash the new commit into the previous one using git reset --soft HEAD~2 (assuming one fixup commit) and then committing again.
-    *   **CRITICAL**: Ensure the final commit message contains **only** the `Change-Id` of the CL you want to update. If multiple `Change-Id:` lines are present, Gerrit will typically use the **last** one!
+    - Squash the new commit into the previous one using git reset --soft HEAD~2
+      (assuming one fixup commit) and then committing again.
+    - **CRITICAL**: Ensure the final commit message contains **only** the
+      `Change-Id` of the CL you want to update. If multiple `Change-Id:` lines
+      are present, Gerrit will typically use the **last** one!
 
 ### Resolving Conflicts in Stacked CLs
-When rebasing a dependent branch (e.g., `branch2`) on top of an updated base branch (`branch1`), conflicts may arise in generated files (like `.wat` files).
-1.  Accept OURS (the upstream/base version) during conflict resolution to get past the rebase conflict quickly.
+
+When rebasing a dependent branch (e.g., `branch2`) on top of an updated base
+branch (`branch1`), conflicts may arise in generated files (like `.wat` files).
+
+1.  Accept OURS (the upstream/base version) during conflict resolution to get
+    past the rebase conflict quickly.
 2.  Complete the rebase (`git rebase --continue`).
-3.  **Re-generate** the expectations or generated files using the appropriate tool (e.g., `ir_test.dart -w`).
-4.  Commit the newly generated files to keep the expectation history clean and accurate.
+3.  **Re-generate** the expectations or generated files using the appropriate
+    tool (e.g., `ir_test.dart -w`).
+4.  Commit the newly generated files to keep the expectation history clean and
+    accurate.
 
 ## 4. Critical Pitfalls
-*   **Multiple Change-Ids in a Commit Message**: If you squash commits or copy-paste messages, you might end up with multiple `Change-Id:` lines. Gerrit reads them and usually routes the update to the CL corresponding to the **last** `Change-Id` in the message. Always clean up commit messages to have exactly one target `Change-Id`.
-*   **No New Changes**: If you try to push a commit that is identical in content to an existing patchset, Gerrit will reject it. To force a new patchset (e.g., to restore an older state), use `git commit --amend --no-edit` to update the committer timestamp and generate a new commit hash.
+
+- **Multiple Change-Ids in a Commit Message**: If you squash commits or
+  copy-paste messages, you might end up with multiple `Change-Id:` lines. Gerrit
+  reads them and usually routes the update to the CL corresponding to the
+  **last** `Change-Id` in the message. Always clean up commit messages to have
+  exactly one target `Change-Id`.
+- **No New Changes**: If you try to push a commit that is identical in content
+  to an existing patchset, Gerrit will reject it. To force a new patchset (e.g.,
+  to restore an older state), use `git commit --amend --no-edit` to update the
+  committer timestamp and generate a new commit hash.

--- a/skills/github-post/SKILL.md
+++ b/skills/github-post/SKILL.md
@@ -51,20 +51,20 @@ doing any work:
    a **Pull Request**?
 2. **Target Repository**: Which exact GitHub repository (`owner/repo`)?
 
-> [!IMPORTANT]
-> **STOP. DON'T GUESS.**
-> If the user's intent is ambiguous (e.g. *"create a post for this"* without
-> specifying Issue vs. PR), or if the target repository cannot be deterministically
-> resolved from the current git checkout, or if multiple remotes/forks exist:
-> **The agent MUST STOP and explicitly ask the user for clarification** using
-> `ask_question` or chat before proceeding. Never guess or fabricate targets.
+> [!IMPORTANT] **STOP. DON'T GUESS.** If the user's intent is ambiguous (e.g.
+> _"create a post for this"_ without specifying Issue vs. PR), or if the target
+> repository cannot be deterministically resolved from the current git checkout,
+> or if multiple remotes/forks exist: **The agent MUST STOP and explicitly ask
+> the user for clarification** using `ask_question` or chat before proceeding.
+> Never guess or fabricate targets.
 
 ---
 
 ### Step 2: Repository Orientation
 
 Before drafting, run the bundled orientation tool to inspect the target
-repository's maintainers, title prefixes, label vocabulary, and native templates:
+repository's maintainers, title prefixes, label vocabulary, and native
+templates:
 
 ```bash
 # For a local git repository checkout:
@@ -74,12 +74,13 @@ dart run skills/github-post/bin/orient.dart
 dart run skills/github-post/bin/orient.dart -R invertase/melos
 ```
 
-* **What it gathers**:
-  * Active human maintainers and reviewers (filtering out automated bots).
-  * Common issue title prefixes (`request:`, `[analyzer]`, `area/foo:`).
-  * Common PR title prefixes (`feat(scope):`, `fix(scope):`, `chore:`).
-  * Repository label vocabulary and detected issue/PR form schemas (`.yml` field IDs).
-* **Slop Contagion Guardrail**: Use orientation output *strictly* for taxonomy,
+- **What it gathers**:
+  - Active human maintainers and reviewers (filtering out automated bots).
+  - Common issue title prefixes (`request:`, `[analyzer]`, `area/foo:`).
+  - Common PR title prefixes (`feat(scope):`, `fix(scope):`, `chore:`).
+  - Repository label vocabulary and detected issue/PR form schemas (`.yml` field
+    IDs).
+- **Slop Contagion Guardrail**: Use orientation output _strictly_ for taxonomy,
   prefixes, and template adherence. Do NOT adopt decorative slop, emojis, or
   conversational fluff found in historical repository posts.
 
@@ -91,10 +92,12 @@ Always draft the complete title and body into a dedicated Markdown artifact in
 the conversation artifact directory (`<appDataDir>/brain/<conversation-id>/`)
 before touching the GitHub CLI, explicitly namespaced by repository:
 
-* **For Issues**: `draft_github_<owner>_<repo>_issue.md`
-  *(e.g., `draft_github_invertase_melos_issue.md` or `draft_github_kevmoo_kevmoo_skills_issue.md`)*
-* **For Pull Requests**: `draft_github_<owner>_<repo>_pr.md`
-  *(e.g., `draft_github_invertase_melos_pr.md` or `draft_github_kevmoo_kevmoo_skills_pr.md`)*
+- **For Issues**: `draft_github_<owner>_<repo>_issue.md` _(e.g.,
+  `draft_github_invertase_melos_issue.md` or
+  `draft_github_kevmoo_kevmoo_skills_issue.md`)_
+- **For Pull Requests**: `draft_github_<owner>_<repo>_pr.md` _(e.g.,
+  `draft_github_invertase_melos_pr.md` or
+  `draft_github_kevmoo_kevmoo_skills_pr.md`)_
 
 Always provide `ArtifactMetadata` with `RequestFeedback: true` so the user can
 review the rendered draft directly in the UI.
@@ -104,29 +107,30 @@ review the rendered draft directly in the UI.
 Maintainers suffer from low-effort LLM fatigue. A good submission takes under 15
 seconds to triage. Strictly enforce:
 
-* **No Decorative Emojis**: Never prefix titles, headers, or bullet points with
+- **No Decorative Emojis**: Never prefix titles, headers, or bullet points with
   emojis (`🚀`, `🐛`, `📋`, `💡`, `✨`, `⚠️`, `🔍`).
-* **No Gratuitous Dividers**: Do not insert `---` horizontal rules between every
+- **No Gratuitous Dividers**: Do not insert `---` horizontal rules between every
   minor section. Standard Markdown headers (`###`) provide sufficient hierarchy.
-* **No Conversational Fluff or Pleasantries**:
-  * Omit opening pleasantries (*"While investigating the codebase..."*, *"I hope
-    this helps..."*).
-  * Omit closing pleasantries (*"Let me know what you think!"*, *"I would be
-    happy to submit a PR..."*).
-* **No Speculative Architecture Essays**:
-  * In bug reports: State the observed defect, provide exact error logs/repro steps,
-    and limit proposed fixes to 1–2 factual sentences (or omit entirely).
-  * In PRs: Explain strictly the rationale ("why") and the isolated diff ("what
+- **No Conversational Fluff or Pleasantries**:
+  - Omit opening pleasantries (_"While investigating the codebase..."_, _"I hope
+    this helps..."_).
+  - Omit closing pleasantries (_"Let me know what you think!"_, _"I would be
+    happy to submit a PR..."_).
+- **No Speculative Architecture Essays**:
+  - In bug reports: State the observed defect, provide exact error logs/repro
+    steps, and limit proposed fixes to 1–2 factual sentences (or omit entirely).
+  - In PRs: Explain strictly the rationale ("why") and the isolated diff ("what
     changed").
-* **No Inline Multiline Shell Escapes**: Never pass multiline Markdown inline via
-  `--body "line 1\nline 2"`. Always use `--body-file`.
+- **No Inline Multiline Shell Escapes**: Never pass multiline Markdown inline
+  via `--body "line 1\nline 2"`. Always use `--body-file`.
 
 ---
 
 ### Step 4: Mandatory Approval Gate (Hard Stop)
 
-Before running `gh issue create` or `gh pr create`, the agent MUST halt execution
-and prompt the user for explicit confirmation using the `ask_question` tool.
+Before running `gh issue create` or `gh pr create`, the agent MUST halt
+execution and prompt the user for explicit confirmation using the `ask_question`
+tool.
 
 ```dart
 // Example confirmation prompt
@@ -143,8 +147,8 @@ ask_question({
 });
 ```
 
-* **If Approved**: Proceed to Step 5.
-* **If Declined / Paused**: Keep the artifact as draft and yield cleanly.
+- **If Approved**: Proceed to Step 5.
+- **If Declined / Paused**: Keep the artifact as draft and yield cleanly.
 
 ---
 
@@ -165,7 +169,8 @@ ask_question({
    rm /tmp/post_body.md
    ```
 3. **Verify Output**: Confirm the submission succeeded and output the clickable
-   link (`https://github.com/owner/repo/issues/123` or `https://github.com/owner/repo/pull/123`).
+   link (`https://github.com/owner/repo/issues/123` or
+   `https://github.com/owner/repo/pull/123`).
 
 ---
 
@@ -173,20 +178,22 @@ ask_question({
 
 Use concise, imperative titles (≤70 characters):
 
-* **When Authoring an Issue**: Adopt the repository's issue prefix convention
+- **When Authoring an Issue**: Adopt the repository's issue prefix convention
   (e.g., `request: ...`, `[subsystem] ...`, `area/foo: ...`).
-* **When Authoring a PR**: Adopt Conventional Commits (`feat(scope): ...`,
+- **When Authoring a PR**: Adopt Conventional Commits (`feat(scope): ...`,
   `fix(scope): ...`, `refactor(scope): ...`) unless the repository explicitly
   mandates an alternative format.
 
 <!-- mdformat off(prevent table wrapping) -->
-| Post Type | Format Pattern | High-Signal Example | Slop Example to Avoid |
-| :--- | :--- | :--- | :--- |
-| **Bug** | `[subsystem] Failure on condition` | `[analyzer] Crash with NullPointer when config.json is empty` | `Bug in analyzer` or `[CRITICAL] System failure` |
-| **Bug** | `subsystem: Failure on condition` | `cli: Flag --output fails when target directory is missing` | `CLI tool is broken` |
-| **Feature** | `[subsystem] Imperative capability` | `[auth] Support PKCE flow in OAuth2 authentication client` | `Feature request: make authentication better` |
-| **Feature** | `request: Imperative capability` | `request: avoid cascading releases when constraints allow update` | `Feature idea for melos` |
-| **PR** | `type(scope): imperative summary` | `feat(orient): add remote repo support and bot filter` | `Updates and fixes` |
+
+| Post Type   | Format Pattern                      | High-Signal Example                                               | Slop Example to Avoid                            |
+| :---------- | :---------------------------------- | :---------------------------------------------------------------- | :----------------------------------------------- |
+| **Bug**     | `[subsystem] Failure on condition`  | `[analyzer] Crash with NullPointer when config.json is empty`     | `Bug in analyzer` or `[CRITICAL] System failure` |
+| **Bug**     | `subsystem: Failure on condition`   | `cli: Flag --output fails when target directory is missing`       | `CLI tool is broken`                             |
+| **Feature** | `[subsystem] Imperative capability` | `[auth] Support PKCE flow in OAuth2 authentication client`        | `Feature request: make authentication better`    |
+| **Feature** | `request: Imperative capability`    | `request: avoid cascading releases when constraints allow update` | `Feature idea for melos`                         |
+| **PR**      | `type(scope): imperative summary`   | `feat(orient): add remote repo support and bot filter`            | `Updates and fixes`                              |
+
 <!-- mdformat on -->
 
 ---
@@ -195,7 +202,7 @@ Use concise, imperative titles (≤70 characters):
 
 ### 1. Bug Report Template
 
-```markdown
+````markdown
 ### Summary
 1–2 sentence description of the failure and trigger condition.
 
@@ -206,15 +213,18 @@ Use concise, imperative titles (≤70 characters):
 ### Observed Behavior
 ```text
 <literal error output, exception message, or raw stack trace>
-```
+````
 
 ### Expected Behavior
+
 <1–2 sentences describing the expected outcome>
 
 ### Environment / Target
+
 - Target Commit / Version: `<commit_hash>`
 - Runtime / Platform: `<e.g. Linux x86_64, Dart 3.8.0, Node 22>`
-```
+
+````
 
 ### 2. Feature Proposal Template
 
@@ -231,7 +241,7 @@ Concrete description of the proposed interface, behavior, or flag.
 
 ### Non-Goals
 - What this feature explicitly does NOT cover
-```
+````
 
 ### 3. Pull Request Template
 
@@ -260,11 +270,13 @@ element's `label:` attribute. Map conceptual anti-slop sections to the form's
 specific fields:
 
 <!-- mdformat off(prevent table wrapping) -->
-| Conceptual Section | Common YAML Field IDs | Rendered Form Heading |
-| :--- | :--- | :--- |
-| **Trigger Command** | `command`, `repro_command` | `### Command` |
-| **Context & Problem** | `description`, `context`, `problem` | `### Description` or `### Context` |
-| **Reasoning / Impact** | `reasoning`, `motivation` | `### Reasoning` |
-| **Proposed Solution** | `solution`, `proposal`, `idea` | `### Proposed Solution` |
-| **Additional Context** | `additional_context`, `comments` | `### Additional Context` (put Acceptance Criteria here) |
+
+| Conceptual Section     | Common YAML Field IDs               | Rendered Form Heading                                   |
+| :--------------------- | :---------------------------------- | :------------------------------------------------------ |
+| **Trigger Command**    | `command`, `repro_command`          | `### Command`                                           |
+| **Context & Problem**  | `description`, `context`, `problem` | `### Description` or `### Context`                      |
+| **Reasoning / Impact** | `reasoning`, `motivation`           | `### Reasoning`                                         |
+| **Proposed Solution**  | `solution`, `proposal`, `idea`      | `### Proposed Solution`                                 |
+| **Additional Context** | `additional_context`, `comments`    | `### Additional Context` (put Acceptance Criteria here) |
+
 <!-- mdformat on -->

--- a/skills/github-pr-triage/SKILL.md
+++ b/skills/github-pr-triage/SKILL.md
@@ -11,13 +11,13 @@ key_features:
 
 ## When to use this skill
 
-- Use this skill when asked to address review comments, pull request
-  feedback, or debug failing CI/CD runs on a GitHub pull request in an
-  interactive, single-pass manner.
-- This skill MUST be activated when the user asks you to "look at comments on
-  my PR", "address comments/reviews", "fix the build/checks", or provides a PR
+- Use this skill when asked to address review comments, pull request feedback,
+  or debug failing CI/CD runs on a GitHub pull request in an interactive,
+  single-pass manner.
+- This skill MUST be activated when the user asks you to "look at comments on my
+  PR", "address comments/reviews", "fix the build/checks", or provides a PR
   URL/branch and asks you to fix it.
-- *Note*: For continuous autonomous iteration loops with AI code review bots
+- _Note_: For continuous autonomous iteration loops with AI code review bots
   (such as Gemini Code Assist), use the `pr-loop` skill instead, which uses this
   skill's `triage.dart` script as its underlying triage engine.
 
@@ -27,19 +27,21 @@ key_features:
   AI bot like Gemini Code Assist or a human engineer — is infallible. AI review
   bots frequently hallucinate syntax limitations, suggest outdated patterns, or
   misunderstand broader repository architecture.
-- **Treat Severity Badges as Unverified External Claims**: Bot-generated severity
-  tags (such as `![critical]` or `![security-high]`) are unverified external claims,
-  NOT confirmed system diagnostics or compiler errors. Never blindly trust badges.
-- **Mandatory Pre-Edit Empirical Verification Gate**:
-  Before editing code for any reviewer comment claiming a syntax error, compilation
-  failure, or type issue, the agent MUST run static analysis (`dart analyze`) on
-  the **unmodified existing codebase** first.
-  - If `dart analyze` returns **0 issues**, the reviewer's claim is empirically false.
-    The item MUST be classified as `👎 Disagree (Hallucinated Syntax/Compile Error)` and
-    NO code changes may be made for that item.
+- **Treat Severity Badges as Unverified External Claims**: Bot-generated
+  severity tags (such as `![critical]` or `![security-high]`) are unverified
+  external claims, NOT confirmed system diagnostics or compiler errors. Never
+  blindly trust badges.
+- **Mandatory Pre-Edit Empirical Verification Gate**: Before editing code for
+  any reviewer comment claiming a syntax error, compilation failure, or type
+  issue, the agent MUST run static analysis (`dart analyze`) on the **unmodified
+  existing codebase** first.
+  - If `dart analyze` returns **0 issues**, the reviewer's claim is empirically
+    false. The item MUST be classified as
+    `👎 Disagree (Hallucinated Syntax/Compile Error)` and NO code changes may be
+    made for that item.
 - **You have the execution advantage**: External reviewers inspect static code,
-  whereas you can execute live compilers, static analyzers (`dart analyze`),
-  and test suites (`dart test`). Always empirically test claims before accepting
+  whereas you can execute live compilers, static analyzers (`dart analyze`), and
+  test suites (`dart test`). Always empirically test claims before accepting
   them.
 - **You are free to disagree**: If a reviewer's claim is technically wrong, if
   their suggestion introduces compiler warnings or regressions, or if the
@@ -56,38 +58,46 @@ key_features:
   the user (using `ask_question` or chat) to clarify which PR or branch to
   target before taking action.
 
-1. **Run the Triage Script**:
-   Execute the `triage.dart` helper script using the `run_command` tool.
-   Use the `--dir` (or `-C`) option to specify the path to the target
-   repository directory (the project you want to triage). This ensures that the
-   underlying `git` and `gh` commands resolve to the correct repository and
-   branch:
+1. **Run the Triage Script**: Execute the `triage.dart` helper script using the
+   `run_command` tool. Use the `--dir` (or `-C`) option to specify the path to
+   the target repository directory (the project you want to triage). This
+   ensures that the underlying `git` and `gh` commands resolve to the correct
+   repository and branch:
+
    ```bash
    dart run <path-to-github-pr-triage-skill>/bin/triage.dart --dir <path-to-target-repository>
    ```
-   *Note*: If you need to target a specific PR or URL, you can also pass `--pr`:
+
+   _Note_: If you need to target a specific PR or URL, you can also pass `--pr`:
+
    ```bash
    dart run <path-to-github-pr-triage-skill>/bin/triage.dart --dir <path-to-target-repository> --pr <pr-number-or-url>
    ```
+
    **Save the raw stdout of this script** as a new markdown artifact named
    `raw_triage_output.md` in the artifacts directory (using the `write_to_file`
    tool).
 
 2. **Verify Workspace State**:
    - The script output will show the PR URL, title, branch, Remote Commit SHA,
-     Local Commit SHA, and Sync Status (`in_sync`, `behind_remote`, `ahead_of_remote`, `diverged`, or `branch_mismatch`).
-   - Verify that your current git branch matches the PR source branch (`headRefName`).
+     Local Commit SHA, and Sync Status (`in_sync`, `behind_remote`,
+     `ahead_of_remote`, `diverged`, or `branch_mismatch`).
+   - Verify that your current git branch matches the PR source branch
+     (`headRefName`).
    - Check the **Sync Status**:
-     - If `Sync Status` is `behind_remote`, pull the latest remote commits (`git pull`) before making changes.
-     - If `Sync Status` is `ahead_of_remote` or `diverged`, push or sync local commits (`git push`).
-     - Do not start making code edits while the local workspace is out of sync with the remote PR.
+     - If `Sync Status` is `behind_remote`, pull the latest remote commits
+       (`git pull`) before making changes.
+     - If `Sync Status` is `ahead_of_remote` or `diverged`, push or sync local
+       commits (`git push`).
+     - Do not start making code edits while the local workspace is out of sync
+       with the remote PR.
 
 3. **Analyze Open Comments**:
    - The script lists all unresolved review threads, top-level review comments
      (overall review summaries), and general PR conversation comments.
    - Read the conversations carefully to understand what reviewers are
      requesting.
-   - Focus *only* on unresolved or actionable comments. Ignore comments marked
+   - Focus _only_ on unresolved or actionable comments. Ignore comments marked
      as resolved unless they provide necessary context.
    - Ignore comments from the PR author themselves unless they clarify a
      reviewer's comment.
@@ -97,15 +107,16 @@ key_features:
    - **Active/Pending CI Handling**: If any CI status checks are currently
      running or pending:
      - Inform the user and call `ask_question` to ask their preference:
-       * Option 1: `(Recommended) Proceed with triaging open comments now`
-       * Option 2: `Wait for active CI status checks to complete first`
-     - **MANDATORY HARD BLOCK**: When CI is pending, you MUST halt execution after
-       calling `ask_question`. Do NOT proceed to Step 5 (Generate a Triage Report)
-       or create the `pr_triage_report.md` artifact until the user has answered,
-       because final CI results might change the triage plan and action items.
-     - *(Note: This interactive prompt and hard block are bypassed when
-       operating within an outer orchestrator skill like `pr-loop`, which handles
-       background timers automatically)*.
+       - Option 1: `(Recommended) Proceed with triaging open comments now`
+       - Option 2: `Wait for active CI status checks to complete first`
+     - **MANDATORY HARD BLOCK**: When CI is pending, you MUST halt execution
+       after calling `ask_question`. Do NOT proceed to Step 5 (Generate a Triage
+       Report) or create the `pr_triage_report.md` artifact until the user has
+       answered, because final CI results might change the triage plan and
+       action items.
+     - _(Note: This interactive prompt and hard block are bypassed when
+       operating within an outer orchestrator skill like `pr-loop`, which
+       handles background timers automatically)_.
    - Analyze the stack traces, compile errors, or analyzer failures to
      understand why any failed checks failed.
 
@@ -127,27 +138,30 @@ key_features:
      - **Summary of Feedback/Failure**: A concise summary of the reviewer
        comment(s) or CI failure(s), including direct markdown links back to the
        comments/checks on GitHub. When linking to comments, use a descriptive
-       link that includes both the comment/review number and the GitHub username of the
-       reviewer (e.g. `[Comment #1 by @reviewer_username](#)` or `[Review #1 by @reviewer_username](#)`).
-     - **Thread & Comment/Review Identifiers (For Comments)**: Explicitly preserve the
-       `Thread ID` (e.g. `PRRT_...`), `Comment ID` (e.g. `3438780787`), or `Review ID`
-       (e.g. `PRR_...`) from the header in `raw_triage_output.md` under each action
-       item so the resolution step (`gh api` or `gh pr comment`) has immediate access
-       to the identifiers without extra API lookups.
+       link that includes both the comment/review number and the GitHub username
+       of the reviewer (e.g. `[Comment #1 by @reviewer_username](#)` or
+       `[Review #1 by @reviewer_username](#)`).
+     - **Thread & Comment/Review Identifiers (For Comments)**: Explicitly
+       preserve the `Thread ID` (e.g. `PRRT_...`), `Comment ID` (e.g.
+       `3438780787`), or `Review ID` (e.g. `PRR_...`) from the header in
+       `raw_triage_output.md` under each action item so the resolution step
+       (`gh api` or `gh pr comment`) has immediate access to the identifiers
+       without extra API lookups.
      - **Agent Assessment (For Comments)**:
        - **Agreement Level**: A short indicator of your agreement using one of
          these categories:
-         * `🔥 Urgent` (Critical fix for a crash, bug, or CI blocker; we should
+         - `🔥 Urgent` (Critical fix for a crash, bug, or CI blocker; we should
            fix immediately)
-         * `👍 Solid` (Good suggestion; we should implement it)
-         * `🤷 Meh` (Optional nit or stylistic preference; we could address
-           it, but it's low priority)
-         * `👎 Disagree` (Incorrect or counter-productive suggestion; we should
+         - `👍 Solid` (Good suggestion; we should implement it)
+         - `🤷 Meh` (Optional nit or stylistic preference; we could address it,
+           but it's low priority)
+         - `👎 Disagree` (Incorrect or counter-productive suggestion; we should
            explain why and propose no action)
-        - **Empirical Verification**: Output of `dart analyze` or `dart test` run on
-          the unmodified codebase before accepting any fix or classifying a claim.
-        - **Rationale**: Your technical explanation of why you agree,
-         disagree, or recommend a specific direction.
+       - **Empirical Verification**: Output of `dart analyze` or `dart test` run
+         on the unmodified codebase before accepting any fix or classifying a
+         claim.
+       - **Rationale**: Your technical explanation of why you agree, disagree,
+         or recommend a specific direction.
      - **Planned Action**:
        - The target file name(s) and specific line ranges.
        - The proposed changes (e.g. explanation, code snippet/diff, or "No
@@ -162,10 +176,10 @@ key_features:
 
 7. **Surgical Implementation & Verification**:
    - Once approved, address the comments and failures one by one.
-   - **Add tests for new behavior**: When a reviewer requests new behavior,
-     bug fixes, or edge-case handling, proactively write automated tests
-     (typically placed in the `test/` directory with a `_test.dart` suffix) to
-     verify the changes and prevent future regressions.
+   - **Add tests for new behavior**: When a reviewer requests new behavior, bug
+     fixes, or edge-case handling, proactively write automated tests (typically
+     placed in the `test/` directory with a `_test.dart` suffix) to verify the
+     changes and prevent future regressions.
    - Follow standard development workflows: run formatting, analysis, and tests
      locally to verify fixes before finishing.
 
@@ -190,17 +204,19 @@ key_features:
        2. `Do nothing`
    - **Execute Selected Actions**:
      - If committing is selected, stage all modified and new files (using
-       `git add <files>` or `git add .` if no untracked scratch files exist)
-       and create a descriptive commit.
+       `git add <files>` or `git add .` if no untracked scratch files exist) and
+       create a descriptive commit.
      - If pushing is selected, run `git push`.
-     - If replying and resolving is selected, execute the `triage.dart resolve` commands
-       using the patterns listed below.
+     - If replying and resolving is selected, execute the `triage.dart resolve`
+       commands using the patterns listed below.
 
 ## Replying and Resolving Comments
 
-For every addressed review thread, you MUST execute thread resolution (thread resolution is explicit, mandatory, and un-skippable).
+For every addressed review thread, you MUST execute thread resolution (thread
+resolution is explicit, mandatory, and un-skippable).
 
-Use the `resolve` subcommand in `triage.dart` to programmatically reply to comments and resolve threads without shell-escaping issues:
+Use the `resolve` subcommand in `triage.dart` to programmatically reply to
+comments and resolve threads without shell-escaping issues:
 
 ```bash
 # Reply to a comment and resolve its thread (pass --dir if outside target repo):
@@ -210,26 +226,28 @@ dart run <path-to-github-pr-triage-skill>/bin/triage.dart resolve --dir <path-to
 dart run <path-to-github-pr-triage-skill>/bin/triage.dart resolve --dir <path-to-target-repository> <thread_graphql_id>
 ```
 
-*Note: `<thread_graphql_id>` is the GraphQL node ID (e.g., `PRRT_...`) and `<comment_database_id>` is the numeric database ID (e.g., `3438780787`), exactly as output in `raw_triage_output.md`.*
-
+_Note: `<thread_graphql_id>` is the GraphQL node ID (e.g., `PRRT_...`) and
+`<comment_database_id>` is the numeric database ID (e.g., `3438780787`), exactly
+as output in `raw_triage_output.md`._
 
 ## Constraints
+
 - **Hard CI Gate**: If CI checks are running or pending, you MUST halt execution
   after calling `ask_question` in Step 4 and DO NOT proceed to Step 5 or
-  generate `pr_triage_report.md` until the user responds, as pending CI
-  results may alter the final triage plan. (Note: Bypassed ONLY IF operating
-  within an outer orchestrator skill like `pr-loop`).
+  generate `pr_triage_report.md` until the user responds, as pending CI results
+  may alter the final triage plan. (Note: Bypassed ONLY IF operating within an
+  outer orchestrator skill like `pr-loop`).
 - **CRITICAL**: You MUST NOT modify files or make any code edits to address PR
-  comments or CI failures before generating a `pr_triage_report.md` artifact
-  and obtaining explicit user approval on the plan. (Note: This constraint is
+  comments or CI failures before generating a `pr_triage_report.md` artifact and
+  obtaining explicit user approval on the plan. (Note: This constraint is
   bypassed ONLY IF operating within an outer orchestrator skill like `pr-loop`
   with upfront user consent).
 - **VCS Authorization**: Selecting an option in `ask_question` that explicitly
   mentions committing or pushing serves as the user's explicit permission to
-  perform those operations for the triage fixes. Do NOT ask for permission
-  a second time if the user selects one of those options. (Note: This
-  constraint is bypassed ONLY IF operating within an outer orchestrator skill
-  like `pr-loop` with upfront user consent).
+  perform those operations for the triage fixes. Do NOT ask for permission a
+  second time if the user selects one of those options. (Note: This constraint
+  is bypassed ONLY IF operating within an outer orchestrator skill like
+  `pr-loop` with upfront user consent).
 - **Sync Code Before Comments**: Do not post "Done" or "Fixed" comment replies
   or resolve threads on GitHub while the corresponding code fixes remain
   uncommitted or unpushed.

--- a/skills/gob-curl/SKILL.md
+++ b/skills/gob-curl/SKILL.md
@@ -9,8 +9,8 @@ key_features:
 
 ## When to use this skill
 
-When the user gives you a link to a Gerrit CL or asks you to inspect the
-status, review comments, or CI results of a CL on Gerrit (e.g.,
+When the user gives you a link to a Gerrit CL or asks you to inspect the status,
+review comments, or CI results of a CL on Gerrit (e.g.,
 `https://dart-review.googlesource.com/c/sdk/+/478860` or `sdk~478860`).
 
 ## How to use this skill
@@ -19,21 +19,22 @@ Use the `run_command` tool to execute `gob-curl` against the Gerrit REST API
 endpoints.
 
 **CRITICAL RULE:**
-*   You MUST ONLY do `GET` requests.
-*   Do NOT attempt to `POST`, `PUT`, or `DELETE` anything.
+
+- You MUST ONLY do `GET` requests.
+- Do NOT attempt to `POST`, `PUT`, or `DELETE` anything.
 
 ### Forming the URL
 
 Gerrit CL URLs usually look like
-`https://dart-review.googlesource.com/c/sdk/+/478860`.
-The `<change-id>` for the API can be the project and CL number: `sdk~478860`.
-Always strictly quote the URL in the shell command to avoid globbing issues
-with `~` and `?`.
+`https://dart-review.googlesource.com/c/sdk/+/478860`. The `<change-id>` for the
+API can be the project and CL number: `sdk~478860`. Always strictly quote the
+URL in the shell command to avoid globbing issues with `~` and `?`.
 
 ### Finding the CL from a local branch
 
 If you need to inspect a local branch in the `sdk` repository and find its
 corresponding CL:
+
 1. Run `git log -1` to locate the `Change-Id` in the most recent commit message.
 2. Query Gerrit using the Change-Id to find the CL number:
    ```bash
@@ -44,10 +45,11 @@ corresponding CL:
 
 ### Useful Endpoints for Inspecting CL Status
 
-**1. Get Comprehensive Change Details**
-This is the most useful endpoint to get an overall picture of the CL. It
-includes labels (e.g., Code-Review, Commit-Queue), messages, current revision
-info, and the files modified in the current patchset.
+**1. Get Comprehensive Change Details** This is the most useful endpoint to get
+an overall picture of the CL. It includes labels (e.g., Code-Review,
+Commit-Queue), messages, current revision info, and the files modified in the
+current patchset.
+
 ```bash
 gob-curl 'https://dart-review.googlesource.com/changes/<change-id>/detail?o=LABELS&o=MESSAGES&o=CURRENT_REVISION&o=CURRENT_COMMIT&o=CURRENT_FILES'
 # Example: gob-curl 'https://dart-review.googlesource.com/changes/sdk~478860/detail?o=LABELS&o=MESSAGES&o=CURRENT_REVISION&o=CURRENT_COMMIT&o=CURRENT_FILES'
@@ -64,25 +66,25 @@ You can use the Buildbucket CLI (`bb`) to quickly fetch the failure details:
 **NOTE:** Some `bb` commands may require you to be authenticated. If you see
 "Login required", ask the user to run `bb auth-login` in their terminal.
 
+1. **Find the failed steps**: Extract the Build ID from the URL
+   (`8689486480122051441`) and use `bb get` with the `-steps` flag to see which
+   step failed:
 
-1. **Find the failed steps**:
-   Extract the Build ID from the URL (`8689486480122051441`) and use `bb get`
-   with the `-steps` flag to see which step failed:
    ```bash
    bb get -steps <BUILD_ID>
    ```
+
    Look for the step marked `FAILURE` (e.g., `Step "build dart" FAILURE`).
 
-2. **Fetch the raw execution logs**:
-   Use `bb log` passing the build ID and the exact name of the failed step to
-   print the logs directly to your terminal:
+2. **Fetch the raw execution logs**: Use `bb log` passing the build ID and the
+   exact name of the failed step to print the logs directly to your terminal:
    ```bash
    bb log <BUILD_ID> "<STEP_NAME>"
    ```
-   *Example:* `bb log 8689486480122051441 "build dart"`
+   _Example:_ `bb log 8689486480122051441 "build dart"`
 
-**Alternative method using curl:**
-If you do not have the `bb` CLI installed, you can extract the Build ID and use the BuildBucket API:
+**Alternative method using curl:** If you do not have the `bb` CLI installed,
+you can extract the Build ID and use the BuildBucket API:
 
 ```bash
 # Get the failing step and log URLs inside the BuildBucket API
@@ -96,44 +98,57 @@ curl -s -X POST 'https://cr-buildbucket.appspot.com/prpc/buildbucket.v2.Builds/G
 curl -s 'https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/<build-id>/+/u/<failed_step_name>/stdout?format=raw'
 ```
 
-**3. Get Inline Review Comments**
-Retrieve inline comments left by reviewers on specific files in the CL.
+**3. Get Inline Review Comments** Retrieve inline comments left by reviewers on
+specific files in the CL.
+
 ```bash
 gob-curl 'https://dart-review.googlesource.com/changes/<change-id>/comments'
 ```
 
-**4. Get Reviewers and their Votes Detailed**
-If you need specific details on who has reviewed the CL and what their votes are.
+**4. Get Reviewers and their Votes Detailed** If you need specific details on
+who has reviewed the CL and what their votes are.
+
 ```bash
 gob-curl 'https://dart-review.googlesource.com/changes/<change-id>/reviewers'
 ```
 
 **5. Get the Commit Message of the Current Revision**
+
 ```bash
 gob-curl 'https://dart-review.googlesource.com/changes/<change-id>/revisions/current/commit'
 ```
 
-**6. Check Tryjob and Test Results**
-Tryjob and CI test results are typically recorded as messages on the CL. To see
-if tests passed or failed on the latest patchset:
+**6. Check Tryjob and Test Results** Tryjob and CI test results are typically
+recorded as messages on the CL. To see if tests passed or failed on the latest
+patchset:
+
 ```bash
 gob-curl 'https://dart-review.googlesource.com/changes/<change-id>/detail?o=MESSAGES&o=LABELS'
 ```
+
 Check the `messages` array for the most recent status updates from CI bots
 (e.g., "Tryjobs failed" or "Dry run: This CL passed all dry run builders"). The
 `attention_set` object may also indicate a reason like `ps#8: Tryjobs failed`.
 
-
 ### Constraints and Best Practices
-*   Always use single quotes (`'`) around the URL when calling `gob-curl` to
-    avoid zsh issues with query parameters and special characters.
-*   The output format starts with a magic string `)]}'\n`. Be prepared to handle
-    or strip this when parsing the JSON output if you are scripting it (though
-    `gob-curl` often prints it as is, and you can just read past it).
-*   Review the `messages` array in the change detail or the output of `comments`
-    to identify specific feedback you need to address in the code.
+
+- Always use single quotes (`'`) around the URL when calling `gob-curl` to avoid
+  zsh issues with query parameters and special characters.
+- The output format starts with a magic string `)]}'\n`. Be prepared to handle
+  or strip this when parsing the JSON output if you are scripting it (though
+  `gob-curl` often prints it as is, and you can just read past it).
+- Review the `messages` array in the change detail or the output of `comments`
+  to identify specific feedback you need to address in the code.
 
 ### Asynchronous Execution for Large Logs
-If fetching massive execution logs (e.g., `bb log <BUILD_ID> "<STEP_NAME>"` for a long build step), the download can block the session:
-- **Background Execution**: Propose the command asynchronously (e.g., in Antigravity, set `WaitMsBeforeAsync: 500` or let it background) and schedule a `schedule` wakeup timer to check the task status, allowing you to remain responsive.
-- **Harness-Agnostic Fallback**: Propose the command as a POSIX background job redirecting output to a file (e.g., `bb log ... > build_step.log 2>&1 &`) and monitor the file size or process status (`ps`) in subsequent turns.
+
+If fetching massive execution logs (e.g., `bb log <BUILD_ID> "<STEP_NAME>"` for
+a long build step), the download can block the session:
+
+- **Background Execution**: Propose the command asynchronously (e.g., in
+  Antigravity, set `WaitMsBeforeAsync: 500` or let it background) and schedule a
+  `schedule` wakeup timer to check the task status, allowing you to remain
+  responsive.
+- **Harness-Agnostic Fallback**: Propose the command as a POSIX background job
+  redirecting output to a file (e.g., `bb log ... > build_step.log 2>&1 &`) and
+  monitor the file size or process status (`ps`) in subsequent turns.

--- a/skills/just-brainstorm/SKILL.md
+++ b/skills/just-brainstorm/SKILL.md
@@ -13,10 +13,11 @@ key_features:
 
 ## When to use this skill
 
-Activate this skill when you need to think through a design, explore options,
-or evaluate the impact of a potential change before writing code.
+Activate this skill when you need to think through a design, explore options, or
+evaluate the impact of a potential change before writing code.
 
 Examples of trigger phrases:
+
 - "Let me brainstorm..."
 - "Just brainstorming here..."
 - "What if we [do specific change]..."
@@ -34,26 +35,32 @@ Examples of trigger phrases:
 ## Procedural Workflow
 
 ### 1. Gather Context & Empirical Data (Read-Only)
-- Inspect the codebase using read-only tools (`grep_search`, `view_file`, `list_dir`)
-  to ground your brainstorming or analysis in reality.
+
+- Inspect the codebase using read-only tools (`grep_search`, `view_file`,
+  `list_dir`) to ground your brainstorming or analysis in reality.
 - **For Impact Analysis ("What-if")**: Gather real statistics. Calculate usage
   counts, identify affected call sites, and map out dependencies. Do not guess.
 
 ### 2. Interactive Alignment (`ask_question`)
+
 - Use `ask_question` early if the goals, constraints, or the scope of the
   "what-if" scenario are unclear.
 
 ### 3. Generate the Artifact
+
 - Write the output to a `.md` file in the conversation artifacts directory.
-- Use `RequestFeedback: false` in the artifact metadata (do not block with "Proceed" gates).
+- Use `RequestFeedback: false` in the artifact metadata (do not block with
+  "Proceed" gates).
 - **Structure for Design Brainstorming**:
   - Present 2–4 distinct options.
   - Highlight tradeoffs (pros/cons) and relative complexity.
 - **Structure for Impact Analysis ("What-if")**:
   - Detail the step-by-step impact if the change were executed.
-  - List breaking changes, migration friction, and affected modules with metrics.
+  - List breaking changes, migration friction, and affected modules with
+    metrics.
   - Provide a summary risk/feasibility verdict.
 
 ### 4. Conclude with Next Steps
+
 - Suggest 1–3 actionable next steps (e.g., create an implementation plan,
   explore a specific option deeper, or start implementation).

--- a/skills/markdown-long-lines/SKILL.md
+++ b/skills/markdown-long-lines/SKILL.md
@@ -11,24 +11,28 @@ key_features:
 ---
 
 ## 1. When to use this skill
+
 Use this skill whenever editing or creating Markdown (`.md`) files in the
 repository.
 
 ## 2. Line Wrapping Guidelines
-- **Target Width**: Wrap prose text cleanly within 80 columns for new
-  files and newly added lines.
+
+- **Target Width**: Wrap prose text cleanly within 80 columns for new files and
+  newly added lines.
 - **Exceptions ("Within Reason")**: Do NOT wrap lines where breaking them would
   corrupt syntax or structure:
   - YAML frontmatter / metadata blocks
-  - Fenced code blocks (`` ``` ``)
+  - Fenced code blocks (` ``` `)
   - Long URLs or Markdown link destinations
   - Markdown tables
 
 ## 3. Clarifying Execution Scope
+
 If the context or scope of how this skill should be run is vague, use the
 `ask_question` tool to clarify the user's intent.
 
 For example, ask whether formatting should apply to:
+
 1. Just the currently active or specified file.
 2. All new or modified Markdown files in the current session.
 3. All Markdown files across the entire repository.

--- a/skills/new-worktree/SKILL.md
+++ b/skills/new-worktree/SKILL.md
@@ -34,19 +34,19 @@ against the following boundaries:
      (`https://github.com/dart-lang/sdk`, e.g., located at `~/github/dart-sdk`).
    - **Hard Block**: If operating in the Dart SDK repository, stop immediately
      and ask if the user wants to use their specialized Dart SDK flow instead
-     (e.g., `dart-sdk-bootstrap`). Do not proceed without clarification. The Dart
-     SDK relies on specialized toolchains, `gclient` checkouts, and dedicated
-     bootstrap workflows that standard Git worktree operations break.
+     (e.g., `dart-sdk-bootstrap`). Do not proceed without clarification. The
+     Dart SDK relies on specialized toolchains, `gclient` checkouts, and
+     dedicated bootstrap workflows that standard Git worktree operations break.
 
 ## Location & Naming Conventions
 
 When creating a worktree, observe strict placement and naming rules:
 
-* **Location**: Place the new worktree directory right next to the source
+- **Location**: Place the new worktree directory right next to the source
   repository directory (as a direct sibling in the parent folder).
-* **Worktree Naming**: Format the folder name as
+- **Worktree Naming**: Format the folder name as
   `_[original repo folder name]-[branch-name]`.
-* **Branch Naming**: Derive a clean, hyphen-separated branch name from the user
+- **Branch Naming**: Derive a clean, hyphen-separated branch name from the user
   request (e.g., `issue-12345` or `fix-auth-crash`).
 
 ### Examples
@@ -61,11 +61,12 @@ When creating a worktree, observe strict placement and naming rules:
 ## Execution Steps
 
 1. **Verify Pre-Flight Boundaries**: Confirm location under `~/github`, confirm
-   Git repository status, and ensure the repo is not the Dart SDK. Do not require
-   a clean working directory; worktrees allow branching safely from a dirty tree.
-2. **Fetch Latest Remote State & Resolve Base Branch**: Run `git fetch origin` to ensure
-   local tracking branches are up to date. Dynamically resolve the remote default
-   branch (`origin/HEAD`, `origin/main`, or `origin/master`):
+   Git repository status, and ensure the repo is not the Dart SDK. Do not
+   require a clean working directory; worktrees allow branching safely from a
+   dirty tree.
+2. **Fetch Latest Remote State & Resolve Base Branch**: Run `git fetch origin`
+   to ensure local tracking branches are up to date. Dynamically resolve the
+   remote default branch (`origin/HEAD`, `origin/main`, or `origin/master`):
    ```bash
    TARGET_BASE=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null || (git show-ref --verify --quiet refs/remotes/origin/main && echo "origin/main") || echo "origin/master")
    ```
@@ -73,11 +74,13 @@ When creating a worktree, observe strict placement and naming rules:
    path `{sibling_worktree_path}` based on naming rules.
 4. **Collision Pre-Flight & Stale Worktree Pruning**:
    - Check if `{sibling_worktree_path}` or local `{branch_name}` already exists.
-   - If previous worktrees were removed manually, run `git worktree prune` to clear stale metadata.
+   - If previous worktrees were removed manually, run `git worktree prune` to
+     clear stale metadata.
 5. **Execute Worktree Creation**:
    ```bash
    git worktree add -b {branch_name} {sibling_worktree_path} ${TARGET_BASE}
    ```
 6. **Output Clickable Link**: Provide the user with a clickable link to the new
-   worktree using the precise scheme `[link text](file:///absolute/path/to/worktree)`.
-   Never wrap link text or syntax in backticks.
+   worktree using the precise scheme
+   `[link text](file:///absolute/path/to/worktree)`. Never wrap link text or
+   syntax in backticks.

--- a/skills/pr-loop/SKILL.md
+++ b/skills/pr-loop/SKILL.md
@@ -20,11 +20,13 @@ automated AI code review bot (such as `gemini-code-assist`,
 `gemini-code-review`, or similar PR review agents).
 
 ## 📦 Prerequisites & Skill Dependencies
+
 - **REQUIRED SKILL**: `github-pr-triage` MUST be installed alongside `pr-loop`.
 - `pr-loop` directly depends on binaries, scripts, and rule definitions provided
   by `github-pr-triage` (including `triage.dart` and `github_cli.dart`).
 
 ## When to use this skill
+
 - Use this skill when asked to get into a review loop with an AI review agent on
   a pull request.
 - Trigger when the user asks to "loop with gemini", "run the PR loop", "iterate
@@ -35,8 +37,8 @@ automated AI code review bot (such as `gemini-code-assist`,
 - **NEVER GUESS Target PR or Branch**: Agents MUST NEVER guess the target branch
   or pull request. If the active local branch or PR is ambiguous, unclear, or
   not explicitly confirmed by the user, the agent MUST pause and explicitly ask
-  the user for clarification using the `ask_question` tool before initiating
-  the loop or executing any git pushes or gh commands.
+  the user for clarification using the `ask_question` tool before initiating the
+  loop or executing any git pushes or gh commands.
 - **Request Blanket Upfront Consent**: When initiating `pr-loop`, the agent MUST
   first confirm the target feature branch and remote with the user using the
   `ask_question` tool, requesting blanket consent for autonomous commits and
@@ -53,24 +55,36 @@ automated AI code review bot (such as `gemini-code-assist`,
 
 ## 🛑 Early Termination & Task Cleanup
 
-If the user halts the execution of `pr-loop` early, or if you decide to pivot to another task, you MUST clean up any active background timers or scheduled tasks to prevent orphaned wakeups:
-- **Antigravity Task Management**: Run `manage_task(Action="list")` to locate any active `schedule` timers created by this skill, and cancel them using `manage_task(Action="kill", TaskId="...")`.
-- **Harness-Agnostic Fallback**: If the harness does not support a graphical task manager, locate the system process PID (if using POSIX background tasks) by inspecting prior tool calls or using standard process commands (e.g., `ps` or `pgrep`), and ensure you kill those background jobs using standard shell signals (e.g., `kill <PID>`) upon termination. Avoid writing temporary state files to the workspace to prevent repository pollution.
+If the user halts the execution of `pr-loop` early, or if you decide to pivot to
+another task, you MUST clean up any active background timers or scheduled tasks
+to prevent orphaned wakeups:
+
+- **Antigravity Task Management**: Run `manage_task(Action="list")` to locate
+  any active `schedule` timers created by this skill, and cancel them using
+  `manage_task(Action="kill", TaskId="...")`.
+- **Harness-Agnostic Fallback**: If the harness does not support a graphical
+  task manager, locate the system process PID (if using POSIX background tasks)
+  by inspecting prior tool calls or using standard process commands (e.g., `ps`
+  or `pgrep`), and ensure you kill those background jobs using standard shell
+  signals (e.g., `kill <PID>`) upon termination. Avoid writing temporary state
+  files to the workspace to prevent repository pollution.
 
 ## 🏗️ Architectural Relationship & Rule Inheritance
+
 This skill functions as an autonomous, multi-pass loop wrapper around the core
 triage capabilities defined in the `github-pr-triage` skill.
 
 **MANDATORY RULE DELEGATION**: `pr-loop` strictly inherits and follows ALL
 rules, mindsets, and protocols defined in `github-pr-triage` to the letter
-(excluding manual triage report generation and interactive approval steps,
-which are bypassed in favor of autonomous execution):
+(excluding manual triage report generation and interactive approval steps, which
+are bypassed in favor of autonomous execution):
+
 1. **Critical Mindset**: Follow `github-pr-triage`'s mandate that reviewer
    feedback is NOT gospel. Empirically verify claims with compilers/analyzers
    and freely disagree (`👎 Disagree`).
 2. **Assessment & Test Directives**: Categorize items using `github-pr-triage`'s
-   Agreement Matrix and proactively write automated tests when reviewers
-   request new behavior.
+   Agreement Matrix and proactively write automated tests when reviewers request
+   new behavior.
 3. **Resolution APIs**: Use `github-pr-triage`'s exact API endpoints for comment
    replies and GraphQL thread resolutions.
 
@@ -79,106 +93,113 @@ which are bypassed in favor of autonomous execution):
 ## 🔄 The Autonomous Loop Workflow
 
 ### 1. Upfront Consent, Initial Push & PR Creation
-* **Request Upfront Consent**: Use the `ask_question` tool to request blanket
+
+- **Request Upfront Consent**: Use the `ask_question` tool to request blanket
   approval for autonomous commits and pushes during this review loop session,
   stating the active feature branch and remote. **Wait for the user's explicit
   response before proceeding to any git push or PR creation.**
-* Verify local working tree state (`git status`); commit any uncommitted work.
-* Push feature branch to origin: `git push -u origin <head_branch>`.
-* Create the PR via GitHub CLI if not already opened:
+- Verify local working tree state (`git status`); commit any uncommitted work.
+- Push feature branch to origin: `git push -u origin <head_branch>`.
+- Create the PR via GitHub CLI if not already opened:
   ```bash
   gh pr create --title "<type>(<scope>): <summary>" \
     --body "<walkthrough_summary>" --base main --head <head_branch>
   ```
 
 ### 2. [START] Immediate Status Check & Polling Timer
-* **Immediate Initial Check**: Before scheduling a background timer, execute an
-  immediate check of PR status (`dart run <path-to-pr-loop-skill>/bin/pr_status.dart --dir .` or `gh pr view`).
-  * If actionable review comments or failed CI checks already exist, **bypass the initial timer** and proceed directly to Step 3/4.
-  * If review feedback or CI checks are still in progress, proceed to schedule the background wakeup timer.
-* **Transition to Wait State**:
-  * **If CI checks are running/pending**:
+
+- **Immediate Initial Check**: Before scheduling a background timer, execute an
+  immediate check of PR status
+  (`dart run <path-to-pr-loop-skill>/bin/pr_status.dart --dir .` or
+  `gh pr view`).
+  - If actionable review comments or failed CI checks already exist, **bypass
+    the initial timer** and proceed directly to Step 3/4.
+  - If review feedback or CI checks are still in progress, proceed to schedule
+    the background wakeup timer.
+- **Transition to Wait State**:
+  - **If CI checks are running/pending**:
     1. Retrieve all active GHA run IDs for the current commit SHA:
-       `gh run list --commit <commit_sha> --json databaseId,status`
-       and filter for runs where status is not `completed`.
-       (If the returned list is empty, GHA has not registered the runs yet.
-       Retry up to 3 times with a 5-second delay; if still empty, proceed
-       to Step 3/4).
+       `gh run list --commit <commit_sha> --json databaseId,status` and filter
+       for runs where status is not `completed`. (If the returned list is empty,
+       GHA has not registered the runs yet. Retry up to 3 times with a 5-second
+       delay; if still empty, proceed to Step 3/4).
     2. Watch the runs:
-       * **Antigravity**: Dynamically construct and execute the watch command
+       - **Antigravity**: Dynamically construct and execute the watch command
          using the `run_command` tool:
-         * If there is only one active run ID, run `gh run watch <run_id>`.
-         * If there are multiple active run IDs, run them in parallel (e.g.,
+         - If there is only one active run ID, run `gh run watch <run_id>`.
+         - If there are multiple active run IDs, run them in parallel (e.g.,
            `gh run watch <run_id_1> & gh run watch <run_id_2> & wait`).
-         * If there are no active GHA run IDs (e.g., due to external non-GHA
+         - If there are no active GHA run IDs (e.g., due to external non-GHA
            checks), fall back to scheduling a polling timer (e.g., `schedule`
-           with `DurationSeconds=300`).
-         Before going idle, verify that all addressed review threads report
-         `isResolved: true` (resolve them if not). Then, **STOP calling tools**
-         and go idle; you will be reactively woken up when all runs complete.
-       * **Other Agents / Harnesses**: If your harness supports long-running
+           with `DurationSeconds=300`). Before going idle, verify that all
+           addressed review threads report `isResolved: true` (resolve them if
+           not). Then, **STOP calling tools** and go idle; you will be
+           reactively woken up when all runs complete.
+       - **Other Agents / Harnesses**: If your harness supports long-running
          commands and active GHA run IDs exist, run `gh run watch <run_id>` for
-         each run synchronously. If not, or if there are no active GHA run IDs (e.g.,
-         due to external non-GHA checks), verify that all addressed review
-         threads report `isResolved: true` (resolve them if not) before
+         each run synchronously. If not, or if there are no active GHA run IDs
+         (e.g., due to external non-GHA checks), verify that all addressed
+         review threads report `isResolved: true` (resolve them if not) before
          scheduling a long-interval timer (e.g., 5-10 minutes) or going idle.
-  * **If ONLY bot review is pending (no CI running)**:
-    1. Call the `schedule` tool with `DurationSeconds=120` to poll for comments (or use harness-specific polling/timer).
+  - **If ONLY bot review is pending (no CI running)**:
+    1. Call the `schedule` tool with `DurationSeconds=120` to poll for comments
+       (or use harness-specific polling/timer).
     2. **STOP calling tools** and go idle.
 
 ### 3. Wakeup & Feedback Ingestion (Comments & CI/CD)
-* When reactive wakeup resumes your execution from the timer, inspect both
+
+- When reactive wakeup resumes your execution from the timer, inspect both
   reviewer comments and failing CI/CD status checks.
-* **Deterministic Status Verification Engine**:
-  Run the `pr_status.dart` helper script to evaluate whether the PR is ready for
-  termination or requires further triage:
+- **Deterministic Status Verification Engine**: Run the `pr_status.dart` helper
+  script to evaluate whether the PR is ready for termination or requires further
+  triage:
   ```bash
   dart run <path-to-pr-loop-skill>/bin/pr_status.dart --dir .
   ```
-* **Strict Termination Rules ([STOP])**:
-  A PR is ONLY clean and ready for loop termination when `pr_status.dart`
-  returns `"can_terminate": true`. Specifically, termination requires:
+- **Strict Termination Rules ([STOP])**: A PR is ONLY clean and ready for loop
+  termination when `pr_status.dart` returns `"can_terminate": true`.
+  Specifically, termination requires:
   1. Every check run in `gh pr checks` has completed cleanly (`SUCCESS`).
   2. `reviewThreads` has 0 unresolved threads.
   3. No review pass is currently in progress (i.e., no new review request has
      been submitted since the last bot review).
-  4. The local git branch commit SHA is fully in sync with the remote PR head commit (`is_synced: true`).
+  4. The local git branch commit SHA is fully in sync with the remote PR head
+     commit (`is_synced: true`).
 
-  > [!IMPORTANT]
-  > **NO LOCAL OVERRIDES / RATIONALIZATIONS**:
-  > Passing local tests (`dart analyze`, `dart test`) are NEVER a substitute for remote CI status.
-  > If `pr_status.dart` returns `"can_terminate": false`, the agent MUST NOT exit the loop
-  > or declare victory early under any circumstances, regardless of local test results.
-* **Action on In-Progress Activity (Waiting for CI/Review)**:
-  If `pr_status.dart` returns `"can_terminate": false` because CI checks or a
+  > [!IMPORTANT] **NO LOCAL OVERRIDES / RATIONALIZATIONS**: Passing local tests
+  > (`dart analyze`, `dart test`) are NEVER a substitute for remote CI status.
+  > If `pr_status.dart` returns `"can_terminate": false`, the agent MUST NOT
+  > exit the loop or declare victory early under any circumstances, regardless
+  > of local test results.
+
+- **Action on In-Progress Activity (Waiting for CI/Review)**: If
+  `pr_status.dart` returns `"can_terminate": false` because CI checks or a
   review pass are still in progress, go idle to wait for them. DO NOT start
   triaging or editing code until BOTH review comments and CI runs have fully
   completed!
-  * **Waiting for CI**:
-    * **Antigravity**: Retrieve all active GHA run IDs. Dynamically
-      construct and execute the watch command using the `run_command` tool:
-      * If there is only one active run ID, run `gh run watch <run_id>`.
-      * If there are multiple active run IDs, run them in parallel (e.g.,
+  - **Waiting for CI**:
+    - **Antigravity**: Retrieve all active GHA run IDs. Dynamically construct
+      and execute the watch command using the `run_command` tool:
+      - If there is only one active run ID, run `gh run watch <run_id>`.
+      - If there are multiple active run IDs, run them in parallel (e.g.,
         `gh run watch <run_id_1> & gh run watch <run_id_2> & wait`).
-      * If there are no active GHA run IDs (e.g., due to external non-GHA
-        checks), fall back to scheduling a polling timer (e.g., `schedule`
-        with `DurationSeconds=300`).
-      Before going idle, verify that all addressed review threads report
-      `isResolved: true` (resolve them if not). Then, **STOP calling tools**,
-      and go idle. The platform will wake you up reactively when all runs
-      complete.
-    * **Other Agents / Harnesses**: Run `gh run watch <run_id>` synchronously
+      - If there are no active GHA run IDs (e.g., due to external non-GHA
+        checks), fall back to scheduling a polling timer (e.g., `schedule` with
+        `DurationSeconds=300`). Before going idle, verify that all addressed
+        review threads report `isResolved: true` (resolve them if not). Then,
+        **STOP calling tools**, and go idle. The platform will wake you up
+        reactively when all runs complete.
+    - **Other Agents / Harnesses**: Run `gh run watch <run_id>` synchronously
       for each active run if your harness allows long-running commands and
-      active GHA run IDs exist. Otherwise, or if there are no active GHA run
-      IDs (e.g., due to external non-GHA checks), verify that all addressed
-      review threads report `isResolved: true` (resolve them if not) before
-      scheduling a timer or falling back to checking CI status at larger
-      intervals (e.g., 5-10 minutes) using standard timers or sleep commands,
-      or going idle.
-  * **Waiting for Bot Review only**: If CI is complete but the bot review pass
+      active GHA run IDs exist. Otherwise, or if there are no active GHA run IDs
+      (e.g., due to external non-GHA checks), verify that all addressed review
+      threads report `isResolved: true` (resolve them if not) before scheduling
+      a timer or falling back to checking CI status at larger intervals (e.g.,
+      5-10 minutes) using standard timers or sleep commands, or going idle.
+  - **Waiting for Bot Review only**: If CI is complete but the bot review pass
     is still in progress, call `schedule` with a short interval (e.g., 60-120
     seconds) to poll for comments (or use harness-specific polling/timer).
-* **Unified Triage Engine**: If `pr_status.dart` indicates unresolved threads or
+- **Unified Triage Engine**: If `pr_status.dart` indicates unresolved threads or
   failed CI runs exist (`"can_terminate": false`), run `triage.dart` as defined
   in `github-pr-triage`:
   ```bash
@@ -186,40 +207,43 @@ which are bypassed in favor of autonomous execution):
   ```
 
 ### 4. Critical Assessment, Empirical Verification & Loop Convergence
-* **Follow `github-pr-triage` Rules to the Letter**:
-  * Apply the **Agreement Matrix** (`🔥 Urgent`, `👍 Solid`, `🤷 Meh`,
+
+- **Follow `github-pr-triage` Rules to the Letter**:
+  - Apply the **Agreement Matrix** (`🔥 Urgent`, `👍 Solid`, `🤷 Meh`,
     `👎 Disagree`).
-  * Exercise **Empirical Skepticism** using `dart analyze` and `dart test`.
-  * **Proactively write automated tests** for reviewer-requested behavior.
-* **Pragmatic Complexity & Anti-Overengineering Guardrail**:
-  Before implementing structural refactorings suggested by automated bots (e.g.
-  creating new classes/structs, adding caching maps, or rearranging working
-  data flows), evaluate the file's scope and scale. If a suggestion adds
-  boilerplate ceremony or premature optimization for small-scale scripts or
-  internal build utilities, classify it as `🤷 Meh` / overengineering. Reject
-  it using `👎 Disagree` with technical rationale: `"Deferring structural refactoring; existing implementation is pragmatically optimal."`
-* **Loop Convergence Protocol (Progressive Criticality Ramp)**:
-  To prevent infinite spinning where new diffs generate endless feedback,
-  the agent MUST track its iteration count (e.g. by counting `fix(review):`
-  commits in `git log origin/main..HEAD`) and apply its OWN evaluation:
-  * **Pass 1 (Full Ingestion)**: Address `🔥 Urgent` bugs and `👍 Solid`
+  - Exercise **Empirical Skepticism** using `dart analyze` and `dart test`.
+  - **Proactively write automated tests** for reviewer-requested behavior.
+- **Pragmatic Complexity & Anti-Overengineering Guardrail**: Before implementing
+  structural refactorings suggested by automated bots (e.g. creating new
+  classes/structs, adding caching maps, or rearranging working data flows),
+  evaluate the file's scope and scale. If a suggestion adds boilerplate ceremony
+  or premature optimization for small-scale scripts or internal build utilities,
+  classify it as `🤷 Meh` / overengineering. Reject it using `👎 Disagree` with
+  technical rationale:
+  `"Deferring structural refactoring; existing implementation is pragmatically optimal."`
+- **Loop Convergence Protocol (Progressive Criticality Ramp)**: To prevent
+  infinite spinning where new diffs generate endless feedback, the agent MUST
+  track its iteration count (e.g. by counting `fix(review):` commits in
+  `git log origin/main..HEAD`) and apply its OWN evaluation:
+  - **Pass 1 (Full Ingestion)**: Address `🔥 Urgent` bugs and `👍 Solid`
     functional improvements.
-  * **Passes 2–5 (Strict Relevance Filter)**: Reject optional `🤷 Meh`
-    nitpicks, micro-optimizations, or syntactic alternative cascades (such as
-    switching `!= null` checks to `isNotEmpty` or minor variable renamings)
-    using `👎 Disagree`. Only implement clear, essential bug fixes or safety
+  - **Passes 2–5 (Strict Relevance Filter)**: Reject optional `🤷 Meh` nitpicks,
+    micro-optimizations, or syntactic alternative cascades (such as switching
+    `!= null` checks to `isNotEmpty` or minor variable renamings) using
+    `👎 Disagree`. Only implement clear, essential bug fixes or safety
     improvements.
-  * **Passes 6+ (Blockers Only / Force Convergence)**:
-    Address ONLY `🔥 Urgent` blockers (bugs, compiler errors, analyzer
-    warnings, security risks). For any optional refactorings or stylistic
-    suggestions, reject them using `👎 Disagree` with rationale:
+  - **Passes 6+ (Blockers Only / Force Convergence)**: Address ONLY `🔥 Urgent`
+    blockers (bugs, compiler errors, analyzer warnings, security risks). For any
+    optional refactorings or stylistic suggestions, reject them using
+    `👎 Disagree` with rationale:
     `"Deferring optional suggestion to maintain loop convergence; code verified."`
-  * **Max Loop Circuit-Breaker**: Cap execution at 10 iterations max.
-* Surgically apply verified fixes (including newly created test files) and
+  - **Max Loop Circuit-Breaker**: Cap execution at 10 iterations max.
+- Surgically apply verified fixes (including newly created test files) and
   verify clean local quality gates.
 
 ### 5. Commit, Push & Resolve Threads
-* **Commit & Push Fixes (If changes were made)**: Check `git status`. If code
+
+- **Commit & Push Fixes (If changes were made)**: Check `git status`. If code
   edits or new test files were created, stage, commit, and push them to origin
   (using `git add <files>` or `git add .` if no untracked scratch files exist):
   ```bash
@@ -227,33 +251,40 @@ which are bypassed in favor of autonomous execution):
   git commit -m "fix(review): <concise summary of remediations>"
   git push origin HEAD
   ```
-  *(Note: If no code changes were made, e.g. all comments were disagreed with,
-  skip committing and pushing).*
-* **Reply & Resolve Protocol (MANDATORY)**:
-  For every addressed review thread, you MUST execute thread resolution (thread resolution is explicit, mandatory, and un-skippable).
-  Use the `resolve` subcommand in `triage.dart`:
+  _(Note: If no code changes were made, e.g. all comments were disagreed with,
+  skip committing and pushing)._
+- **Reply & Resolve Protocol (MANDATORY)**: For every addressed review thread,
+  you MUST execute thread resolution (thread resolution is explicit, mandatory,
+  and un-skippable). Use the `resolve` subcommand in `triage.dart`:
+
   ```bash
   dart run <path-to-github-pr-triage-skill>/bin/triage.dart resolve <thread_id> <comment_id> "<your concise explanation>"
   ```
 
-* **Pre-Timer Verification Gate (MANDATORY)**:
-  Before calling `schedule` or going idle, query GraphQL (or run `pr_status.dart`)
-  to verify that all addressed review threads report `isResolved: true`. If any
-  addressed thread reports `isResolved: false`, immediately execute the
-  `resolveReviewThread` mutation for that thread BEFORE setting the background
-  wakeup timer.
+- **Pre-Timer Verification Gate (MANDATORY)**: Before calling `schedule` or
+  going idle, query GraphQL (or run `pr_status.dart`) to verify that all
+  addressed review threads report `isResolved: true`. If any addressed thread
+  reports `isResolved: false`, immediately execute the `resolveReviewThread`
+  mutation for that thread BEFORE setting the background wakeup timer.
 
 ### 6. Trigger Subsequent Review Pass (Or Terminate Zero-Change Loop)
-* **Zero-Code-Change Loop Termination Rule**:
-  If **0 code changes** were made in an iteration because all review comments were evaluated via the empirical verification gate (`dart analyze` returned 0 issues) and classified as `👎 Disagree`:
-  * **DO NOT** comment `/gemini review` on the PR. Re-triggering the review bot on the exact same commit causes an infinite review loop.
-  * **DO** post empirical disagreement replies on all review threads, resolve all threads via GraphQL (`triage.dart resolve`), and **terminate the loop immediately** with a final status summary.
-* **Subsequent Push Review Trigger**:
-  If code changes or new test files **were** committed and pushed to `origin`, you MUST explicitly prompt the bot again by posting a comment on the main PR thread:
+
+- **Zero-Code-Change Loop Termination Rule**: If **0 code changes** were made in
+  an iteration because all review comments were evaluated via the empirical
+  verification gate (`dart analyze` returned 0 issues) and classified as
+  `👎 Disagree`:
+  - **DO NOT** comment `/gemini review` on the PR. Re-triggering the review bot
+    on the exact same commit causes an infinite review loop.
+  - **DO** post empirical disagreement replies on all review threads, resolve
+    all threads via GraphQL (`triage.dart resolve`), and **terminate the loop
+    immediately** with a final status summary.
+- **Subsequent Push Review Trigger**: If code changes or new test files **were**
+  committed and pushed to `origin`, you MUST explicitly prompt the bot again by
+  posting a comment on the main PR thread:
   ```bash
   gh pr comment <pr_number> --body "/gemini review"
   ```
-* Once `/gemini review` is posted and all threads are verified as resolved, loop
+- Once `/gemini review` is posted and all threads are verified as resolved, loop
   back immediately to **Step 2 [START]** to schedule your background timer
   (e.g., 120s for review bot ingestion, or adaptive duration for CI) and go
   idle!
@@ -261,6 +292,7 @@ which are bypassed in favor of autonomous execution):
 ---
 
 ## 🏁 Loop Termination & Handoff
+
 1. When the loop stops, report the total number of review iterations executed
    and link to the final merged/approved PR.
 2. If operating in Wynette Hybrid Production mode

--- a/skills/quick-question/SKILL.md
+++ b/skills/quick-question/SKILL.md
@@ -18,6 +18,7 @@ requests a quick clarification, asks for a TL;DR explanation, or uses the short
 prefix `qq`.
 
 Examples of trigger phrases:
+
 - "qq..." / "qq: ..."
 - "Quick question..."
 - "TL;DR on..."
@@ -26,8 +27,8 @@ Examples of trigger phrases:
 ## Critical Rule: Accuracy Over Speculation & Zero Code Changes
 
 - **ACCURACY IS THE TOP PRIORITY**: The most important goal when using this
-  skill is offering ACCURATE guidance. Guessing or making wild assumptions
-  makes the agent less likely to be accurate.
+  skill is offering ACCURATE guidance. Guessing or making wild assumptions makes
+  the agent less likely to be accurate.
 - **NO FILE EDITS OR CREATION**: Zero file changes are expected or allowed. Do
   not edit files or alter repository state.
 - **DO NOT ASSUME ACTION IS DESIRED**: Answer the question directly. Never
@@ -37,19 +38,22 @@ Examples of trigger phrases:
 ## Procedural & Formatting Rules
 
 ### 1. Handling Unclear Requests (Be Up-Front)
+
 - If the user's question is vague or unclear, be completely up-front about it
   inline in your response rather than making blind guesses.
 - Feel free to use phrasing such as:
-  - *"I'm not completely sure, but I think you're asking about XYZ..."*
-  - *"I don't really understand what you mean. Can you offer a bit more
-    context?"*
+  - _"I'm not completely sure, but I think you're asking about XYZ..."_
+  - _"I don't really understand what you mean. Can you offer a bit more
+    context?"_
 
 ### 2. Direct Chat Output (NO Artifacts)
+
 - **Direct Chat Response**: Do NOT create artifacts (`.md` files in the
   conversation artifacts directory) for quick questions. Deliver the response
   inline directly to the user.
 
 ### 3. Conciseness & Structure
+
 - **Brief TL;DR**: Always lead with a very brief TL;DR or direct answer.
 - **Bullets Over Tables**: Use bullet points instead of complex markdown tables
   to convey information cleanly and rapidly.
@@ -58,9 +62,11 @@ Examples of trigger phrases:
   necessary for basic correctness.
 
 ### 4. Tool Avoidance (`ask_question`)
+
 - **AVOID `ask_question` tool calls**: Do not invoke the interactive modal tool.
   Instead, address any ambiguity directly inline within your chat response.
 
 ### 5. Optional Next Steps
+
 - Feel free to suggest **0 to 3 obvious next steps** at the end of your response
   if they are genuinely useful, but keep them brief and non-intrusive.

--- a/skills/review-pr/RUBRIC.md
+++ b/skills/review-pr/RUBRIC.md
@@ -1,6 +1,8 @@
 # Review Rubric: 13 Angles & The Inquisitor Doctrine
 
-The model-agnostic code review evaluation rubric. Evaluates changes through 13 analytical lenses and filters candidate findings through the adversarial Inquisitor doctrine to eliminate reviewer theater and LLM noise.
+The model-agnostic code review evaluation rubric. Evaluates changes through 13
+analytical lenses and filters candidate findings through the adversarial
+Inquisitor doctrine to eliminate reviewer theater and LLM noise.
 
 ---
 
@@ -9,130 +11,210 @@ The model-agnostic code review evaluation rubric. Evaluates changes through 13 a
 Every pull request diff must be evaluated across these 13 distinct lenses:
 
 ### 1. Line Scan
+
 Audit local line-level syntax, types, and logic:
-* Nullability mismatches, unsafe bang operators (`!`), unhandled `null` branches.
-* Off-by-one errors in slice ranges, array indexes, or loop termination bounds.
-* Dynamic type casts (`as Foo`) that can throw at runtime without prior type checks (`is Foo`).
-* Boolean operator precedence and accidental assignment in conditional expressions.
+
+- Nullability mismatches, unsafe bang operators (`!`), unhandled `null`
+  branches.
+- Off-by-one errors in slice ranges, array indexes, or loop termination bounds.
+- Dynamic type casts (`as Foo`) that can throw at runtime without prior type
+  checks (`is Foo`).
+- Boolean operator precedence and accidental assignment in conditional
+  expressions.
 
 ### 2. Removed Behavior
+
 Audit what was deleted:
-* What invariants, error branches, or validations were removed?
-* Does deleted code silently break assumptions in un-modified caller files?
-* Were cleanup steps (e.g. closing streams, timers, file handles) accidentally dropped?
-* Were fallback branches removed prematurely before downstream consumers migrated?
+
+- What invariants, error branches, or validations were removed?
+- Does deleted code silently break assumptions in un-modified caller files?
+- Were cleanup steps (e.g. closing streams, timers, file handles) accidentally
+  dropped?
+- Were fallback branches removed prematurely before downstream consumers
+  migrated?
 
 ### 3. Cross-File Tracer
+
 Trace dependencies beyond the diff hunks:
-* Did an interface, signature, or exported type change without updating all call sites?
-* Do package exports (`index.dart`, `__init__.py`, `mod.rs`) properly re-export new APIs?
-* Do mock implementations in test fixtures still mirror the updated production contract?
+
+- Did an interface, signature, or exported type change without updating all call
+  sites?
+- Do package exports (`index.dart`, `__init__.py`, `mod.rs`) properly re-export
+  new APIs?
+- Do mock implementations in test fixtures still mirror the updated production
+  contract?
 
 ### 4. Language Pitfalls
+
 Check language-specific traps and footguns:
-* **Dart / Flutter**:
-  * Unawaited futures causing race conditions or floating exceptions.
-  * Mutating collections during iteration; missing `toList()` when transforming lazy iterables.
-  * Stream subscriptions without cancellation in `dispose()`.
-  * Passing non-constant expressions into `const` constructors or using mutable objects as default arguments.
-* **Go**:
-  * Goroutine leaks; channels with unbuffered writers that block indefinitely.
-  * Mutating loop variables across goroutines; missing `context.Context` deadline propagation.
-* **Python**:
-  * Mutable default arguments (`def foo(bar=[])`).
-  * Unbounded global dicts causing memory leaks; catch-all `except:` swallowing `KeyboardInterrupt` or `SystemExit`.
+
+- **Dart / Flutter**:
+  - Unawaited futures causing race conditions or floating exceptions.
+  - Mutating collections during iteration; missing `toList()` when transforming
+    lazy iterables.
+  - Stream subscriptions without cancellation in `dispose()`.
+  - Passing non-constant expressions into `const` constructors or using mutable
+    objects as default arguments.
+- **Go**:
+  - Goroutine leaks; channels with unbuffered writers that block indefinitely.
+  - Mutating loop variables across goroutines; missing `context.Context`
+    deadline propagation.
+- **Python**:
+  - Mutable default arguments (`def foo(bar=[])`).
+  - Unbounded global dicts causing memory leaks; catch-all `except:` swallowing
+    `KeyboardInterrupt` or `SystemExit`.
 
 ### 5. Invariants & Wrappers
+
 Inspect abstraction boundaries and invariants:
-* Are domain invariants enforced in public constructors or factory methods?
-* Does a wrapper type leak its underlying implementation primitives to callers?
-* Are state transitions atomic, or can the object be left in an inconsistent intermediate state upon failure?
+
+- Are domain invariants enforced in public constructors or factory methods?
+- Does a wrapper type leak its underlying implementation primitives to callers?
+- Are state transitions atomic, or can the object be left in an inconsistent
+  intermediate state upon failure?
 
 ### 6. Testing Skeptic
+
 Scrutinize test quality, not just line coverage:
-* Are tests asserting actual behavior, or are they assertion-free "smoke tests" that only verify non-crashing execution?
-* Do tests exercise negative paths, timeout behavior, and invalid inputs, or only the happy path?
-* Are mocks over-specified (testing the mock instead of real behavior)?
-* Does every bug fix include a deterministic regression test reproducing the original issue?
+
+- Are tests asserting actual behavior, or are they assertion-free "smoke tests"
+  that only verify non-crashing execution?
+- Do tests exercise negative paths, timeout behavior, and invalid inputs, or
+  only the happy path?
+- Are mocks over-specified (testing the mock instead of real behavior)?
+- Does every bug fix include a deterministic regression test reproducing the
+  original issue?
 
 ### 7. Error Handling
+
 Inspect exception and error paths:
-* Are exceptions swallowed silently or caught without logging/rethrowing?
-* Do functions return ambiguous `null` or `-1` instead of throwing typed, informative error classes?
-* Is error context preserved when wrapping/re-throwing exceptions?
+
+- Are exceptions swallowed silently or caught without logging/rethrowing?
+- Do functions return ambiguous `null` or `-1` instead of throwing typed,
+  informative error classes?
+- Is error context preserved when wrapping/re-throwing exceptions?
 
 ### 8. Reuse
+
 Check for wheel reinvention:
-* Does the diff introduce helper functions, math algorithms, or string parsers that already exist in the standard library, core SDK, or existing project dependencies (e.g. `package:collection`, `package:path`, `lodash`, `guava`)?
-* Is duplicate helper logic introduced across sibling modules instead of consolidating into a common internal utility?
+
+- Does the diff introduce helper functions, math algorithms, or string parsers
+  that already exist in the standard library, core SDK, or existing project
+  dependencies (e.g. `package:collection`, `package:path`, `lodash`, `guava`)?
+- Is duplicate helper logic introduced across sibling modules instead of
+  consolidating into a common internal utility?
 
 ### 9. Simplification
+
 The subtractive lens (eliminate over-engineering):
-* Is this more complex than the problem requires?
-* Does the change add premature abstractions, single-caller interfaces, or speculative configuration knobs that nothing uses?
-* Can nested conditional branches be flattened with early-return guard clauses or switch expressions?
+
+- Is this more complex than the problem requires?
+- Does the change add premature abstractions, single-caller interfaces, or
+  speculative configuration knobs that nothing uses?
+- Can nested conditional branches be flattened with early-return guard clauses
+  or switch expressions?
 
 ### 10. Efficiency
+
 Audit performance in hot paths:
-* Are expensive operations (JSON parsing, regex compilation, reflection, filesystem I/O) executed inside tight loops?
-* Are collections repeatedly resized or allocated unnecessarily?
-* Are lookups performed via $O(N)$ linear scans when a `Set` or `Map` lookup would be $O(1)$?
+
+- Are expensive operations (JSON parsing, regex compilation, reflection,
+  filesystem I/O) executed inside tight loops?
+- Are collections repeatedly resized or allocated unnecessarily?
+- Are lookups performed via $O(N)$ linear scans when a `Set` or `Map` lookup
+  would be $O(1)$?
 
 ### 11. Altitude
+
 Step back and evaluate high-level architectural coherence:
-* Does this feature or logic belong in this package/layer, or does it violate separation of concerns?
-* Does the change solve the actual user problem, or does it apply a superficial band-aid to a deeper structural flaw?
+
+- Does this feature or logic belong in this package/layer, or does it violate
+  separation of concerns?
+- Does the change solve the actual user problem, or does it apply a superficial
+  band-aid to a deeper structural flaw?
 
 ### 12. Readability & Conventions
+
 Verify developer ergonomics and repository norms:
-* Are public APIs and exported symbols documented with clear, grammatically sound docstrings?
-* Do variable and function names convey intent rather than implementation mechanics?
-* Does the code follow repository style guidelines and pass formatters (`dart format`, `gofmt`, `black`)?
+
+- Are public APIs and exported symbols documented with clear, grammatically
+  sound docstrings?
+- Do variable and function names convey intent rather than implementation
+  mechanics?
+- Does the code follow repository style guidelines and pass formatters
+  (`dart format`, `gofmt`, `black`)?
 
 ### 13. Cyclomatic Complexity
+
 Evaluate nesting and cognitive strain:
-* Are functions excessively long (>50 lines) or deeply indented (>3 levels)?
-* Does the function carry high Cognitive Complexity (nested loops, branching ternary operators, nested lambdas)?
-* Can complex logic be decomposed into pure, testable sub-functions?
+
+- Are functions excessively long (>50 lines) or deeply indented (>3 levels)?
+- Does the function carry high Cognitive Complexity (nested loops, branching
+  ternary operators, nested lambdas)?
+- Can complex logic be decomposed into pure, testable sub-functions?
 
 ---
 
 ## ⚖️ Part 2: The Inquisitor Doctrine ("Presumption of Theater")
 
-**Every candidate review finding is reviewer theater and pedantic noise until proven otherwise.**
+**Every candidate review finding is reviewer theater and pedantic noise until
+proven otherwise.**
 
-LLM reviewers suffer from severe incentive bias: they invent imaginary hazards to prove they performed work. The Inquisitor acts as an adversarial filter. A finding MUST demonstrate concrete, mechanical proof of runtime defect or measurable maintenance harm, or face summary dismissal.
+LLM reviewers suffer from severe incentive bias: they invent imaginary hazards
+to prove they performed work. The Inquisitor acts as an adversarial filter. A
+finding MUST demonstrate concrete, mechanical proof of runtime defect or
+measurable maintenance harm, or face summary dismissal.
 
 ### The Five Inquisitorial Filters
 
 Filter every candidate finding against these five pathologies:
 
 1. **Imaginary Architecture & Unverified Assumptions**:
-   * *Trap*: The reviewer assumes an execution model, threading model, or API contract absent from the codebase.
-   * *Rule*: If the reviewer cannot cite an exact call site or contractual specification proving the assumption, **DISMISS** as `[DISMISSED: INVENTED_ARCHITECTURE]`.
+   - _Trap_: The reviewer assumes an execution model, threading model, or API
+     contract absent from the codebase.
+   - _Rule_: If the reviewer cannot cite an exact call site or contractual
+     specification proving the assumption, **DISMISS** as
+     `[DISMISSED: INVENTED_ARCHITECTURE]`.
 
 2. **Synchronous Hand-Wringing & Defensive Paranoia**:
-   * *Trap*: Demanding thread locks, async mutexes, or memory barriers in single-threaded, synchronous execution paths.
-   * *Rule*: If the scenario requires impossible execution interleavings or paranoid double-checks, **DISMISS** as `[DISMISSED: PARANOIA]`.
+   - _Trap_: Demanding thread locks, async mutexes, or memory barriers in
+     single-threaded, synchronous execution paths.
+   - _Rule_: If the scenario requires impossible execution interleavings or
+     paranoid double-checks, **DISMISS** as `[DISMISSED: PARANOIA]`.
 
 3. **Pedantic Escalation**:
-   * *Trap*: Elevating minor stylistic preferences, harmless setup repetition, or test fixture boilerplate to "architectural flaws".
-   * *Rule*: If the code causes zero measurable harm to maintainability or runtime safety, **DISMISS** as `[DISMISSED: PEDANTIC_ESCALATION]`.
+   - _Trap_: Elevating minor stylistic preferences, harmless setup repetition,
+     or test fixture boilerplate to "architectural flaws".
+   - _Rule_: If the code causes zero measurable harm to maintainability or
+     runtime safety, **DISMISS** as `[DISMISSED: PEDANTIC_ESCALATION]`.
 
 4. **Harmless Idempotence & Belt-and-Suspenders**:
-   * *Trap*: Complaining about defensive null-checks, idempotent resets, or explicit cleanups because "the framework already handles it".
-   * *Rule*: If the pattern is harmless defensive programming that does not harm readability or performance, **DISMISS** as `[DISMISSED: HARMLESS]`.
+   - _Trap_: Complaining about defensive null-checks, idempotent resets, or
+     explicit cleanups because "the framework already handles it".
+   - _Rule_: If the pattern is harmless defensive programming that does not harm
+     readability or performance, **DISMISS** as `[DISMISSED: HARMLESS]`.
 
 5. **Hallucinated Dependencies & APIs**:
-   * *Trap*: Suggesting the author use third-party libraries, non-existent SDK methods, or unverified packages.
-   * *Rule*: If the proposed replacement symbol or dependency cannot be verified to exist in the repository's active dependencies or language SDK, **DISMISS** as `[DISMISSED: HALLUCINATED_API]`.
+   - _Trap_: Suggesting the author use third-party libraries, non-existent SDK
+     methods, or unverified packages.
+   - _Rule_: If the proposed replacement symbol or dependency cannot be verified
+     to exist in the repository's active dependencies or language SDK,
+     **DISMISS** as `[DISMISSED: HALLUCINATED_API]`.
 
 ---
 
 ## 🎯 Part 3: Severity Verdicts
 
-Only findings that survive the Inquisitor filters are reported. Assign exactly one severity:
+Only findings that survive the Inquisitor filters are reported. Assign exactly
+one severity:
 
-* **🚨 `[BLOCKING]`**: Must be addressed before merge. Correctness bugs, data loss, race conditions, broken tests, security vulnerabilities, or public API breaks.
-* **💡 `[SUGGESTION]`**: Highly recommended improvements. Measurable performance wins, significant simplification, eliminating wheel reinvention, or missing edge-case test coverage.
-* **🧹 `[HYGIENE_NIT]`**: Minor polish (dead imports, typos, docstring drift). Keep only if accompanied by confirmed defects or high signal. If the PR has zero blocking defects and zero suggestions, suppress cosmetic nits to deliver a clean approval.
+- **🚨 `[BLOCKING]`**: Must be addressed before merge. Correctness bugs, data
+  loss, race conditions, broken tests, security vulnerabilities, or public API
+  breaks.
+- **💡 `[SUGGESTION]`**: Highly recommended improvements. Measurable performance
+  wins, significant simplification, eliminating wheel reinvention, or missing
+  edge-case test coverage.
+- **🧹 `[HYGIENE_NIT]`**: Minor polish (dead imports, typos, docstring drift).
+  Keep only if accompanied by confirmed defects or high signal. If the PR has
+  zero blocking defects and zero suggestions, suppress cosmetic nits to deliver
+  a clean approval.

--- a/skills/review-pr/SKILL.md
+++ b/skills/review-pr/SKILL.md
@@ -11,16 +11,29 @@ key_features:
 
 # GitHub PR Reviewer (`/review-pr`)
 
-A disciplined, senior-grade code reviewer for GitHub Pull Requests and local Git branches. Powered by the 13-angle evaluation rubric and the adversarial **Inquisitor Doctrine ("Presumption of Theater")** in [`RUBRIC.md`](RUBRIC.md) to purge hallucinatory AI fluff, pedantic theater, and unverified assumptions.
+A disciplined, senior-grade code reviewer for GitHub Pull Requests and local Git
+branches. Powered by the 13-angle evaluation rubric and the adversarial
+**Inquisitor Doctrine ("Presumption of Theater")** in [`RUBRIC.md`](RUBRIC.md)
+to purge hallucinatory AI fluff, pedantic theater, and unverified assumptions.
 
 ---
 
 ## 🎯 Primary Capabilities
 
-1. **Native Git & GitHub Scope Detection**: Audits open GitHub PRs (`gh pr diff <PR>`) or local branch diffs (`git diff $(git merge-base origin/main HEAD)..HEAD`) with zero Google3 / Critique dependencies.
-2. **Adversarial Inquisitor Gating**: Every candidate finding must survive the Five Inquisitorial Filters in [`RUBRIC.md`](RUBRIC.md) (Imaginary Architecture, Synchronous Paranoia, Pedantic Escalation, Harmless Idempotence, and Hallucinated APIs) before reaching the report.
-3. **Clickable GitHub Permalinks**: Formats all findings with direct permalinks to source files and line ranges on GitHub (`https://github.com/<owner>/<repo>/blob/<sha>/<file>#L<start>-L<end>`).
-4. **Interactive Action Gate (`ask_question`)**: Concludes with a 3-way decision gate allowing the user to keep findings in chat, auto-remediate nits locally in the worktree, or post comments to GitHub.
+1. **Native Git & GitHub Scope Detection**: Audits open GitHub PRs
+   (`gh pr diff <PR>`) or local branch diffs
+   (`git diff $(git merge-base origin/main HEAD)..HEAD`) with zero Google3 /
+   Critique dependencies.
+2. **Adversarial Inquisitor Gating**: Every candidate finding must survive the
+   Five Inquisitorial Filters in [`RUBRIC.md`](RUBRIC.md) (Imaginary
+   Architecture, Synchronous Paranoia, Pedantic Escalation, Harmless
+   Idempotence, and Hallucinated APIs) before reaching the report.
+3. **Clickable GitHub Permalinks**: Formats all findings with direct permalinks
+   to source files and line ranges on GitHub
+   (`https://github.com/<owner>/<repo>/blob/<sha>/<file>#L<start>-L<end>`).
+4. **Interactive Action Gate (`ask_question`)**: Concludes with a 3-way decision
+   gate allowing the user to keep findings in chat, auto-remediate nits locally
+   in the worktree, or post comments to GitHub.
 
 ---
 
@@ -28,8 +41,10 @@ A disciplined, senior-grade code reviewer for GitHub Pull Requests and local Git
 
 ### Step 1: Pre-Flight Scope & Diff Detection
 
-1. **Explicit PR Target (URL or Number)**:
-   If a PR URL or issue number is provided (e.g. `/review-pr https://github.com/foo/bar/pull/42` or `/review-pr #42`):
+1. **Explicit PR Target (URL or Number)**: If a PR URL or issue number is
+   provided (e.g. `/review-pr https://github.com/foo/bar/pull/42` or
+   `/review-pr #42`):
+
    ```bash
    # Extract PR metadata, base/head SHAs, and repo details
    gh pr view <PR> --json headRepositoryOwner,headRepository,headRefName,baseRefName,headRefOid,number,title,body,url
@@ -38,8 +53,9 @@ A disciplined, senior-grade code reviewer for GitHub Pull Requests and local Git
    gh pr diff <PR>
    ```
 
-2. **Active Worktree / Branch Detection**:
-   If invoked inside a Git repository without arguments:
+2. **Active Worktree / Branch Detection**: If invoked inside a Git repository
+   without arguments:
+
    ```bash
    # Determine target base commit
    TARGET_BASE=$(git merge-base origin/main HEAD 2>/dev/null || git merge-base origin/master HEAD 2>/dev/null || git merge-base main HEAD)
@@ -52,8 +68,9 @@ A disciplined, senior-grade code reviewer for GitHub Pull Requests and local Git
    ```
 
 3. **PR Intent & Linked Issues**:
-   * Inspect the PR title and description body.
-   * If the PR description references a tracking issue (e.g. `Fixes #123`, `Closes #456`), fetch the issue context:
+   - Inspect the PR title and description body.
+   - If the PR description references a tracking issue (e.g. `Fixes #123`,
+     `Closes #456`), fetch the issue context:
      ```bash
      gh issue view <issue_number> --json title,body
      ```
@@ -62,13 +79,18 @@ A disciplined, senior-grade code reviewer for GitHub Pull Requests and local Git
 
 ### Step 2: Grounding & Local Code Inspection
 
-Never review diff hunks in isolation. A finding without surrounding context is a guess.
+Never review diff hunks in isolation. A finding without surrounding context is a
+guess.
 
 1. **Caller & Interface Tracing**:
-   * Inspect the complete modified files in the local worktree (`view_file` or `grep_search`).
-   * When public methods, parameters, or types are modified, search for call sites across the repository to verify that all consumers are updated.
+   - Inspect the complete modified files in the local worktree (`view_file` or
+     `grep_search`).
+   - When public methods, parameters, or types are modified, search for call
+     sites across the repository to verify that all consumers are updated.
 2. **Dependency & SDK Verification**:
-   * If a finding contemplates suggesting an alternative function or class, verify that the symbol exists in the language SDK or `pubspec.yaml` / `go.mod` / `requirements.txt` / `package.json`.
+   - If a finding contemplates suggesting an alternative function or class,
+     verify that the symbol exists in the language SDK or `pubspec.yaml` /
+     `go.mod` / `requirements.txt` / `package.json`.
 
 ---
 
@@ -77,43 +99,51 @@ Never review diff hunks in isolation. A finding without surrounding context is a
 Evaluate the diff against [`RUBRIC.md`](RUBRIC.md):
 
 1. **Sweep the 13 Angles**:
-   * *1. Line Scan* (null safety, off-by-one, type casts, boolean logic).
-   * *2. Removed Behavior* (broken silent contracts, deleted invariants).
-   * *3. Cross-File Tracer* (interface drift, mock parity, export lists).
-   * *4. Language Pitfalls* (unawaited futures, mutable defaults, goroutine leaks).
-   * *5. Invariants & Wrappers* (leaky abstractions, unvalidated constructors).
-   * *6. Testing Skeptic* (assertion-free tests, happy-path bias, missing regression tests).
-   * *7. Error Handling* (swallowed exceptions, missing rethrows, silent nulls).
-   * *8. Reuse* (reinventing existing standard library or dependency helpers).
-   * *9. Simplification* (premature abstractions, speculative knobs, YAGNI).
-   * *10. Efficiency* (allocations in loops, unindexed lookups, N+1 queries).
-   * *11. Altitude* (high-level architectural coherence and layering).
-   * *12. Readability & Conventions* (docstrings on public symbols, formatting).
-   * *13. Cyclomatic Complexity* (arrow anti-patterns, deeply nested branches).
+   - _1. Line Scan_ (null safety, off-by-one, type casts, boolean logic).
+   - _2. Removed Behavior_ (broken silent contracts, deleted invariants).
+   - _3. Cross-File Tracer_ (interface drift, mock parity, export lists).
+   - _4. Language Pitfalls_ (unawaited futures, mutable defaults, goroutine
+     leaks).
+   - _5. Invariants & Wrappers_ (leaky abstractions, unvalidated constructors).
+   - _6. Testing Skeptic_ (assertion-free tests, happy-path bias, missing
+     regression tests).
+   - _7. Error Handling_ (swallowed exceptions, missing rethrows, silent nulls).
+   - _8. Reuse_ (reinventing existing standard library or dependency helpers).
+   - _9. Simplification_ (premature abstractions, speculative knobs, YAGNI).
+   - _10. Efficiency_ (allocations in loops, unindexed lookups, N+1 queries).
+   - _11. Altitude_ (high-level architectural coherence and layering).
+   - _12. Readability & Conventions_ (docstrings on public symbols, formatting).
+   - _13. Cyclomatic Complexity_ (arrow anti-patterns, deeply nested branches).
 
-2. **Execute Inquisitor Filters ("Presumption of Theater")**:
-   Cross-examine every candidate finding. Summarily discard any finding that falls into:
-   * `[DISMISSED: INVENTED_ARCHITECTURE]` — Imaginary contracts not in code.
-   * `[DISMISSED: PARANOIA]` — Concurrency/lifetime warnings in synchronous paths.
-   * `[DISMISSED: PEDANTIC_ESCALATION]` — Elevating minor preferences to architectural flaws.
-   * `[DISMISSED: HARMLESS]` — Defensive null-checks or harmless cleanup.
-   * `[DISMISSED: HALLUCINATED_API]` — Recommending non-existent symbols/packages.
+2. **Execute Inquisitor Filters ("Presumption of Theater")**: Cross-examine
+   every candidate finding. Summarily discard any finding that falls into:
+   - `[DISMISSED: INVENTED_ARCHITECTURE]` — Imaginary contracts not in code.
+   - `[DISMISSED: PARANOIA]` — Concurrency/lifetime warnings in synchronous
+     paths.
+   - `[DISMISSED: PEDANTIC_ESCALATION]` — Elevating minor preferences to
+     architectural flaws.
+   - `[DISMISSED: HARMLESS]` — Defensive null-checks or harmless cleanup.
+   - `[DISMISSED: HALLUCINATED_API]` — Recommending non-existent
+     symbols/packages.
 
 3. **Assign Severity**:
-   * 🚨 **`[BLOCKING]`**: Runtime defects, data loss, race conditions, broken tests, security issues, public API breaks.
-   * 💡 **`[SUGGESTION]`**: Measurable performance wins, significant simplification, eliminating wheel reinvention.
-   * 🧹 **`[HYGIENE_NIT]`**: Typos, dead imports, docstring drift. (Suppress if zero blocking/suggestions exist to prevent comment noise on clean PRs).
+   - 🚨 **`[BLOCKING]`**: Runtime defects, data loss, race conditions, broken
+     tests, security issues, public API breaks.
+   - 💡 **`[SUGGESTION]`**: Measurable performance wins, significant
+     simplification, eliminating wheel reinvention.
+   - 🧹 **`[HYGIENE_NIT]`**: Typos, dead imports, docstring drift. (Suppress if
+     zero blocking/suggestions exist to prevent comment noise on clean PRs).
 
 ---
 
 ### Step 4: Report Formatting & Artifact Persistence
 
-1. **Write Review Report Artifact**:
-   Save the full review report to:
+1. **Write Review Report Artifact**: Save the full review report to:
    `<appDataDir>/brain/<conversation_id>/pr_review_<owner>_<repo>_<PR_NUMBER>.md`
 
 2. **Format Structure**:
-   ```markdown
+
+   ````markdown
    # Code Review: <Repo> PR #<Number> — <PR Title>
 
    **PR**: [<owner>/<repo>#<number>](https://github.com/<owner>/<repo>/pull/<number>) | **Base**: `<baseRef>` | **Head**: `<headRef>` (`<headSHA>`)
@@ -135,22 +165,26 @@ Evaluate the diff against [`RUBRIC.md`](RUBRIC.md):
      **Suggested Fix**:
      ```dart
      // Exact replacement code
-     ```
+   ````
 
    ### 💡 Suggestions
    - [ ] [**path/to/file.dart#L105**](https://github.com/<owner>/<repo>/blob/<sha>/path/to/file.dart#L105)
-     **Improvement**: <Concrete simplification or reuse opportunity.>
+         **Improvement**: <Concrete simplification or reuse opportunity.>
 
    ### 🧹 Hygiene Nits
    - [ ] [**path/to/file.dart#L12**](https://github.com/<owner>/<repo>/blob/<sha>/path/to/file.dart#L12)
-     **Nit**: <Dead import or typo.>
+         **Nit**: <Dead import or typo.>
+
+   ```
+
    ```
 
 ---
 
 ### Step 5: Interactive Action Gate (`ask_question`)
 
-Immediately after presenting the review summary in chat and linking the report artifact, invoke `ask_question` to present a 3-way decision gate:
+Immediately after presenting the review summary in chat and linking the report
+artifact, invoke `ask_question` to present a 3-way decision gate:
 
 ```text
 Question: "PR #<number> review complete (<N> blocking, <M> suggestions, <K> nits). What action would you like to take?"
@@ -161,6 +195,10 @@ Options:
 ```
 
 #### Action Execution Details:
-* **Option 1 (Report Only)**: Yield cleanly. No files or remote state touched.
-* **Option 2 (Local Fixes)**: Apply the verified fixes directly to the local worktree files, run formatters (`dart format`, `black`, `gofmt`), run project tests (`dart test`, `go test`), and prompt to commit/push.
-* **Option 3 (Post to GitHub)**: Format findings as inline review comments and post to GitHub using `gh api` or `gh pr review --comment --body "<summary>"`.
+
+- **Option 1 (Report Only)**: Yield cleanly. No files or remote state touched.
+- **Option 2 (Local Fixes)**: Apply the verified fixes directly to the local
+  worktree files, run formatters (`dart format`, `black`, `gofmt`), run project
+  tests (`dart test`, `go test`), and prompt to commit/push.
+- **Option 3 (Post to GitHub)**: Format findings as inline review comments and
+  post to GitHub using `gh api` or `gh pr review --comment --body "<summary>"`.

--- a/skills/sem-cli/SKILL.md
+++ b/skills/sem-cli/SKILL.md
@@ -12,28 +12,54 @@ key_features:
 
 # `sem-cli` Skill (`sem v0.24+`)
 
-This skill provides instructions on how to use `sem` (`sem-cli`), an AST entity indexer, call-graph navigator, and semantic version control tool that tracks functions, classes, methods, and types across 39 languages and data formats.
+This skill provides instructions on how to use `sem` (`sem-cli`), an AST entity
+indexer, call-graph navigator, and semantic version control tool that tracks
+functions, classes, methods, and types across 39 languages and data formats.
 
 ## Capabilities & Limitations (What `sem` Does Well and Does Not Do)
 
 ### What `sem` Does Well
-- **Instant Cold-Start Code Exploration:** Builds an on-disk mmap query index (`index.sem`) that answers definition lookups (`sem find`), direct callers (`sem callers`), direct callees (`sem refs`), and trigram regex searches (`sem grep`) in **~7ms warm** without running an LSP daemon.
-- **Signature-Only Context Packing:** Fits **5–10x wider call-graph maps** into LLM context windows using `sem context --headers`.
-- **Entity-Addressed Substring Search:** Searches entity bodies (`sem entities --text`) and returns the **enclosing AST entity ID** (`file::kind::name`) rather than raw `grep` line numbers.
-- **Hotspot & Co-Change Discovery:** Identifies most-modified entities and co-change pairs ("if you touch X, don't forget Y") via `sem log`.
-- **Structural Diffs & History:** Shows added, modified, renamed, or deleted entities across commits without formatting or whitespace noise (`structuralChange: false` or `--no-cosmetics`).
+
+- **Instant Cold-Start Code Exploration:** Builds an on-disk mmap query index
+  (`index.sem`) that answers definition lookups (`sem find`), direct callers
+  (`sem callers`), direct callees (`sem refs`), and trigram regex searches
+  (`sem grep`) in **~7ms warm** without running an LSP daemon.
+- **Signature-Only Context Packing:** Fits **5–10x wider call-graph maps** into
+  LLM context windows using `sem context --headers`.
+- **Entity-Addressed Substring Search:** Searches entity bodies
+  (`sem entities --text`) and returns the **enclosing AST entity ID**
+  (`file::kind::name`) rather than raw `grep` line numbers.
+- **Hotspot & Co-Change Discovery:** Identifies most-modified entities and
+  co-change pairs ("if you touch X, don't forget Y") via `sem log`.
+- **Structural Diffs & History:** Shows added, modified, renamed, or deleted
+  entities across commits without formatting or whitespace noise
+  (`structuralChange: false` or `--no-cosmetics`).
 
 ### What `sem` Does Not Do (Important Limitations)
-- **External Dependencies:** `sem` only indexes entities defined within the local repository's source files. It **does not** parse or track external packages or transitive library dependencies (e.g., from `pubspec.yaml`, `node_modules`, `Cargo.toml`, etc.).
-- **External Impact Analysis:** Running `sem impact` on an external type or class (e.g., `DartType` or `ClassElement` from an external package) will fail with `error: Entity '...' not found`.
-- **Workflow for External Packages:** If tasked with evaluating how an external package is used across a codebase, **do not start with `sem`**. Use standard `grep` or `ripgrep` (`sem grep` or `rg`) to find `import` statements and locate local wrapper classes or helper functions. Once local wrapper entities are identified, use `sem impact` on those local entities to trace their usage across the codebase.
+
+- **External Dependencies:** `sem` only indexes entities defined within the
+  local repository's source files. It **does not** parse or track external
+  packages or transitive library dependencies (e.g., from `pubspec.yaml`,
+  `node_modules`, `Cargo.toml`, etc.).
+- **External Impact Analysis:** Running `sem impact` on an external type or
+  class (e.g., `DartType` or `ClassElement` from an external package) will fail
+  with `error: Entity '...' not found`.
+- **Workflow for External Packages:** If tasked with evaluating how an external
+  package is used across a codebase, **do not start with `sem`**. Use standard
+  `grep` or `ripgrep` (`sem grep` or `rg`) to find `import` statements and
+  locate local wrapper classes or helper functions. Once local wrapper entities
+  are identified, use `sem impact` on those local entities to trace their usage
+  across the codebase.
 
 ## Finding Entities (`<entity_name>`)
 
-Many `sem` commands require an `<entity_name>`. Discover exact names or IDs using:
+Many `sem` commands require an `<entity_name>`. Discover exact names or IDs
+using:
 
 1. **Instant Cold-Start Lookups (`sem find` / `sem callers` / `sem refs`):**
-   Backed by an on-disk mmap-able query index (`index.sem`), warm lookups take ~7ms without a daemon:
+   Backed by an on-disk mmap-able query index (`index.sem`), warm lookups take
+   ~7ms without a daemon:
+
    ```bash
    # Find where an entity is defined
    sem find "function diff_command" --json
@@ -45,8 +71,10 @@ Many `sem` commands require an `<entity_name>`. Discover exact names or IDs usin
    sem refs diff_command --json
    ```
 
-2. **Entity-Addressed Substring Search (`sem entities --text`):**
-   Search entity bodies for an exact substring and get back the **enclosing AST entity ID** (`file::kind::name`), avoiding manual line-to-function mapping:
+2. **Entity-Addressed Substring Search (`sem entities --text`):** Search entity
+   bodies for an exact substring and get back the **enclosing AST entity ID**
+   (`file::kind::name`), avoiding manual line-to-function mapping:
+
    ```bash
    # Search for a string inside entity bodies and return enclosing entity IDs
    sem entities src/ --text "PERMISSION_DENIED" --json
@@ -55,17 +83,25 @@ Many `sem` commands require an `<entity_name>`. Discover exact names or IDs usin
    sem entities src/ --only function --only class --json
    ```
 
-3. **Entity IDs for Disambiguation:**
-   If a name is ambiguous (e.g., multiple files define a `setup()` function), pass `--file <path>` or use the fully qualified `entity_id` returned by `--json` output (e.g., `--entity-id "src/utils.ts::function::setup"`).
+3. **Entity IDs for Disambiguation:** If a name is ambiguous (e.g., multiple
+   files define a `setup()` function), pass `--file <path>` or use the fully
+   qualified `entity_id` returned by `--json` output (e.g.,
+   `--entity-id "src/utils.ts::function::setup"`).
 
 ## Core Commands & Flag Reference (`sem v0.24+`)
 
 > **Important Flag Distinction (`--format` vs. `--json`):**
+>
 > - Only `sem diff` uses `--format <json|markdown|plain>`.
-> - **All other subcommands** (`sem impact`, `sem blame`, `sem log`, `sem entities`, `sem context`, `sem find`, `sem callers`, `sem refs`, `sem grep`, `sem graph`) use `--json` directly. Do **not** pass `--format json` to `sem impact` or `sem log`.
+> - **All other subcommands** (`sem impact`, `sem blame`, `sem log`,
+>   `sem entities`, `sem context`, `sem find`, `sem callers`, `sem refs`,
+>   `sem grep`, `sem graph`) use `--json` directly. Do **not** pass
+>   `--format json` to `sem impact` or `sem log`.
 
 ### 1. Semantic Diff (`sem diff`)
-Show added, modified, deleted, renamed, or moved entities in the working tree, between commits, between any two files, or piped from unified diffs.
+
+Show added, modified, deleted, renamed, or moved entities in the working tree,
+between commits, between any two files, or piped from unified diffs.
 
 ```bash
 # View semantic changes in working directory
@@ -94,9 +130,12 @@ jj diff --git | sem diff --patch --no-cosmetics --format json
 # Compare any two files directly (no git repo required)
 sem diff file1.dart file2.dart
 ```
-*Additional options:* `--file-exts <EXTS>...` (Filter by extensions, e.g., `--file-exts .dart`).
+
+_Additional options:_ `--file-exts <EXTS>...` (Filter by extensions, e.g.,
+`--file-exts .dart`).
 
 ### 2. Impact Analysis (`sem impact`)
+
 Analyze the transitive impact of changing an entity (BFS traversal).
 
 ```bash
@@ -119,7 +158,9 @@ sem impact <entity_name> --no-default-excludes --json
 ```
 
 ### 3. Repository Hotspots & Entity History (`sem log`)
-Show the evolution of an entity through git history, or analyze repository-wide churn and co-change pairs.
+
+Show the evolution of an entity through git history, or analyze repository-wide
+churn and co-change pairs.
 
 ```bash
 # Repository hotspots (most-modified entities + author counts) & co-change pairs
@@ -134,6 +175,7 @@ sem log <entity_name> -v
 ```
 
 ### 4. Instant Index Lookups (`sem find`, `sem callers`, `sem refs`, `sem grep`)
+
 Fast cold/warm lookups backed by `index.sem`:
 
 ```bash
@@ -151,7 +193,9 @@ sem grep "TODO"
 ```
 
 ### 5. Token-Budgeted Context (`sem context`)
-Fit an entity, its dependencies, and its dependents into a strict token budget for LLM consumption:
+
+Fit an entity, its dependencies, and its dependents into a strict token budget
+for LLM consumption:
 
 ```bash
 # Standard full-body context packing
@@ -176,7 +220,12 @@ sem blame <file_path> --json
 
 ## Troubleshooting & Environment Gotchas
 
-- **GNU Parallel Binary Collision (`/usr/bin/sem`):**
-  GNU Parallel installs `/usr/bin/sem` as a symlink to `parallel`. If `sem` hangs or rejects subcommands, verify the binary with `sem --version` or `which sem`. Ensure Homebrew (`$(brew --prefix)/bin/sem`) or Cargo (`~/.cargo/bin/sem`) precedes `/usr/bin` in `PATH`.
-- **Asynchronous Execution for Large Graphs:**
-  On very large repositories, the initial index/graph build can take several seconds. Run `sem impact` or `sem graph` with a background timeout (`WaitMsBeforeAsync`) if cold-starting on a massive monorepo.
+- **GNU Parallel Binary Collision (`/usr/bin/sem`):** GNU Parallel installs
+  `/usr/bin/sem` as a symlink to `parallel`. If `sem` hangs or rejects
+  subcommands, verify the binary with `sem --version` or `which sem`. Ensure
+  Homebrew (`$(brew --prefix)/bin/sem`) or Cargo (`~/.cargo/bin/sem`) precedes
+  `/usr/bin` in `PATH`.
+- **Asynchronous Execution for Large Graphs:** On very large repositories, the
+  initial index/graph build can take several seconds. Run `sem impact` or
+  `sem graph` with a background timeout (`WaitMsBeforeAsync`) if cold-starting
+  on a massive monorepo.

--- a/skills/sidequest/SKILL.md
+++ b/skills/sidequest/SKILL.md
@@ -21,41 +21,59 @@ Synthesizes task hierarchies and context drift into a visual session map.
 
 ## ⚠️ Mandatory Execution Contract (5 Core Rules)
 
-1. **Tool-Driven State Updates:** Always update state via the CLI tool (`sidequest`). Never edit `sidequest.json` manually.
-2. **Tool-Driven Map Compilation:** Always generate/compile `sidequest.md` via `sidequest`. Never format the markdown map by hand.
-3. **Strict Internal Privacy:** **NEVER** mention or reference `sidequest.json` in user-facing conversation. Treat JSON state as a private implementation detail.
-4. **Markdown User Interface:** Always reference `sidequest.md` or provide concise inline markdown summaries when communicating progress to the human.
-5. **Subagent History Ingestion:** Never read `transcript.jsonl` directly in the main conversation; delegate deep history rebuilds exclusively via `/sidequest rebuild`.
+1. **Tool-Driven State Updates:** Always update state via the CLI tool
+   (`sidequest`). Never edit `sidequest.json` manually.
+2. **Tool-Driven Map Compilation:** Always generate/compile `sidequest.md` via
+   `sidequest`. Never format the markdown map by hand.
+3. **Strict Internal Privacy:** **NEVER** mention or reference `sidequest.json`
+   in user-facing conversation. Treat JSON state as a private implementation
+   detail.
+4. **Markdown User Interface:** Always reference `sidequest.md` or provide
+   concise inline markdown summaries when communicating progress to the human.
+5. **Subagent History Ingestion:** Never read `transcript.jsonl` directly in the
+   main conversation; delegate deep history rebuilds exclusively via
+   `/sidequest rebuild`.
 
 ---
 
 ## 🏗️ Storage & Architecture
 
-- **Session-Private Artifacts:** All state files (`sidequest.json`, `sidequest.md`) reside strictly in the session artifact directory (auto-discovered via `ANTIGRAVITY_CONVERSATION_ID`, `CLAUDE_ARTIFACT_DIR`, `GEMINI_ARTIFACT_DIR`, or `--dir`). Never write to user repositories or dotfiles.
-- **Compaction Resilient:** `sidequest.json` maintains the deterministic state model (quests, completion orders, VCS state, step watermark) across context truncations.
+- **Session-Private Artifacts:** All state files (`sidequest.json`,
+  `sidequest.md`) reside strictly in the session artifact directory
+  (auto-discovered via `ANTIGRAVITY_CONVERSATION_ID`, `CLAUDE_ARTIFACT_DIR`,
+  `GEMINI_ARTIFACT_DIR`, or `--dir`). Never write to user repositories or
+  dotfiles.
+- **Compaction Resilient:** `sidequest.json` maintains the deterministic state
+  model (quests, completion orders, VCS state, step watermark) across context
+  truncations.
 
 ---
 
 ## 🧭 Hierarchy & Syntax Specification
 
-| Level | Syntax / Prefix | Description | Status Indicators |
-| :--- | :--- | :--- | :--- |
-| **Main Quest** | `Main Quest N:` | High-level initiatives / chapters | `⚔️ [ACTIVE]`, `🏆 [COMPLETED]`, `⏸️ [PAUSED]` |
-| **Sub-Quest** | `Sub-Quest N.M:` | Planned milestones | `🛡️` |
-| **Blocker** | `Blocker N.M.K:` | Critical-path unplanned blocker | `👾 Active`, `💀 ~~Resolved~~` |
-| **Step** | `Step N.M.K:` | Planned action item | `👣 Active`, `👣 ~~Done~~` |
-| **Side Quest** | `[Active]` / `🎒 [Parked]` | Tangents / rabbit holes (`G1`, `S1`) | `🌿` |
+| Level          | Syntax / Prefix            | Description                          | Status Indicators                              |
+| :------------- | :------------------------- | :----------------------------------- | :--------------------------------------------- |
+| **Main Quest** | `Main Quest N:`            | High-level initiatives / chapters    | `⚔️ [ACTIVE]`, `🏆 [COMPLETED]`, `⏸️ [PAUSED]` |
+| **Sub-Quest**  | `Sub-Quest N.M:`           | Planned milestones                   | `🛡️`                                           |
+| **Blocker**    | `Blocker N.M.K:`           | Critical-path unplanned blocker      | `👾 Active`, `💀 ~~Resolved~~`                 |
+| **Step**       | `Step N.M.K:`              | Planned action item                  | `👣 Active`, `👣 ~~Done~~`                     |
+| **Side Quest** | `[Active]` / `🎒 [Parked]` | Tangents / rabbit holes (`G1`, `S1`) | `🌿`                                           |
 
-- **Completion Order (`[#N ⭐]`):** Completed items receive sequential tags (`[#1]`, `[#2]`). The most recently completed item receives the star (`[#N ⭐]`).
-- **VCS Lifecycle:** Track working copy state per quest: `📝 Dirty` -> `📦 Local Commit` -> `🚀 Uploaded` -> `🎉 Merged` -> `🧹 Clean`.
+- **Completion Order (`[#N ⭐]`):** Completed items receive sequential tags
+  (`[#1]`, `[#2]`). The most recently completed item receives the star
+  (`[#N ⭐]`).
+- **VCS Lifecycle:** Track working copy state per quest: `📝 Dirty` ->
+  `📦 Local Commit` -> `🚀 Uploaded` -> `🎉 Merged` -> `🧹 Clean`.
 
 ---
 
 ## 🚀 Execution Workflow
 
-When `/sidequest` triggers (via `/sidequest`, "where are we?", or context drift):
+When `/sidequest` triggers (via `/sidequest`, "where are we?", or context
+drift):
 
 ### Mode A: In-Session CLI Mutation (Default `O(1)`)
+
 Execute `sidequest` (or `dart run <path-to-skill>/bin/sidequest.dart`):
 
 ```bash
@@ -83,18 +101,34 @@ sidequest reopen 1.1
 sidequest remove 1.1.2
 ```
 
-**User Output:** Output a brief, punchy chat summary covering active `⚔️ Main Quest`, current `🛡️ Sub-Quest`, VCS status, and recommended next step. Always place the clickable link to the generated artifact at the very **BOTTOM** of the chat reply with an emoji anchor so it is easy to find and click:
+**User Output:** Output a brief, punchy chat summary covering active
+`⚔️ Main Quest`, current `🛡️ Sub-Quest`, VCS status, and recommended next step.
+Always place the clickable link to the generated artifact at the very **BOTTOM**
+of the chat reply with an emoji anchor so it is easy to find and click:
+
 > `🗺️ Full Session Map: [sidequest.md](file:///path/to/sidequest.md)`
 
 ### Mode B: Subagent Transcript Rebuild (`/sidequest rebuild`)
-Use **only** when initializing from long unmapped history or explicitly requested via `/sidequest rebuild`:
-1. **Spawn Auditor Subagent:** `TypeName: "research"`, `Role: "Sidequest Log Auditor"`, passing baseline `sidequest.json` and [auditor_prompt.txt](resources/auditor_prompt.txt).
-2. **Delta Audit:** Subagent inspects `transcript.jsonl` from `watermark.stepIndex` onwards and returns audited JSON payload in `send_message`.
-3. **Merge & Emit:** Parent runs `sidequest merge-audit --input=<payload_file>` to update JSON and compile `sidequest.md`.
+
+Use **only** when initializing from long unmapped history or explicitly
+requested via `/sidequest rebuild`:
+
+1. **Spawn Auditor Subagent:** `TypeName: "research"`,
+   `Role: "Sidequest Log Auditor"`, passing baseline `sidequest.json` and
+   [auditor_prompt.txt](resources/auditor_prompt.txt).
+2. **Delta Audit:** Subagent inspects `transcript.jsonl` from
+   `watermark.stepIndex` onwards and returns audited JSON payload in
+   `send_message`.
+3. **Merge & Emit:** Parent runs `sidequest merge-audit --input=<payload_file>`
+   to update JSON and compile `sidequest.md`.
 
 ---
 
 ## 🤝 Parked Item Escalation
 
-When parking side quests (`🎒 [Parked / Tracked for Later]`), check available issue trackers and offer:
-> *"Would you like me to file an issue in your project tracker (`gh issue create` / local tracker) so this parked item survives across sessions?"*
+When parking side quests (`🎒 [Parked / Tracked for Later]`), check available
+issue trackers and offer:
+
+> _"Would you like me to file an issue in your project tracker
+> (`gh issue create` / local tracker) so this parked item survives across
+> sessions?"_

--- a/skills/sidequest/resources/sidequest_template.md
+++ b/skills/sidequest/resources/sidequest_template.md
@@ -1,33 +1,46 @@
 # 🧭 Conversation Map & Sidequests
 
-> [!CAUTION]
-> **Uncommitted & Unpushed Changes:**
-> * **Main Quest 2 (`fix-leak`):** `lib/worker.dart`
-> * **Active Side-Quest S1:** `test/debug_test.dart`
+> [!CAUTION] **Uncommitted & Unpushed Changes:**
+>
+> - **Main Quest 2 (`fix-leak`):** `lib/worker.dart`
+> - **Active Side-Quest S1:** `test/debug_test.dart`
 
 ## 🏆 [COMPLETED] Main Quest 1: Migrate `UserService` to `v2` API
+
 > **VCS State:** `🧹 Clean` -> PR #142 (Merged upstream, local workspace synced)
-* [x] [#1] 🛡️ **Sub-Quest 1.1:** Identify callers across repository -> *Done*
-* [x] [#4] 🛡️ **Sub-Quest 1.2:** Update client stub bindings -> *Done*
-  * [x] [#2] 💀 ~~*Blocker 1.2.1:* Fix build missing `proto/public` dep~~ -> *Resolved*
-  * [x] [#3] 👣 ~~*Step 1.2.2:* Merge in PR #142~~ -> *Done*
+
+- [x] [#1] 🛡️ **Sub-Quest 1.1:** Identify callers across repository -> _Done_
+- [x] [#4] 🛡️ **Sub-Quest 1.2:** Update client stub bindings -> _Done_
+  - [x] [#2] 💀 ~~_Blocker 1.2.1:_ Fix build missing `proto/public` dep~~ ->
+        _Resolved_
+  - [x] [#3] 👣 ~~_Step 1.2.2:_ Merge in PR #142~~ -> _Done_
 
 ---
 
 ## ⚔️ [ACTIVE HEAD] Main Quest 2: Investigate Thread Leak Issue
+
 > **VCS State:** `📝 Dirty` | Branch: `fix-leak` | Modified: `lib/worker.dart`
-* [x] [#5] 🛡️ **Sub-Quest 2.1:** Check config and run the reproduction test case -> *Done*
-* [ ] 🛡️ **Sub-Quest 2.2:** Profile thread spawning across workers *(IN PROGRESS)*
-  * [x] [#6 ⭐] 💀 ~~*Blocker 2.2.1:* Resolve local Docker network timeout~~ -> *Resolved*
-  * [ ] 👣 *Step 2.2.2:* Run worker profiling script
+
+- [x] [#5] 🛡️ **Sub-Quest 2.1:** Check config and run the reproduction test case
+      -> _Done_
+- [ ] 🛡️ **Sub-Quest 2.2:** Profile thread spawning across workers _(IN
+      PROGRESS)_
+  - [x] [#6 ⭐] 💀 ~~_Blocker 2.2.1:_ Resolve local Docker network timeout~~ ->
+        _Resolved_
+  - [ ] 👣 _Step 2.2.2:_ Run worker profiling script
 
 ### 🌿 Active & Parked Side Quests (For Main Quest 2)
-* [ ] **[Active]** Check why debug flag behaves differently on local vs remote machine.
-  * 📝 *VCS:* `test/debug_test.dart` (Uncommitted)
-* [ ] **🎒 [Parked / Tracked for Later]** Refactor `LegacyThreadMonitor` -> *Filed Issue #215 in project tracker*
+
+- [ ] **[Active]** Check why debug flag behaves differently on local vs remote
+      machine.
+  - 📝 _VCS:_ `test/debug_test.dart` (Uncommitted)
+- [ ] **🎒 [Parked / Tracked for Later]** Refactor `LegacyThreadMonitor` ->
+      _Filed Issue #215 in project tracker_
 
 ---
 
 ## ⏸️ [PAUSED] Main Quest 3: Code Review for PR #27
+
 > **VCS State:** `🚀 Uploaded` -> PR #27 (Awaiting Review)
-* [ ] **Status:** Waiting on author reply to our comment on line 142.
+
+- [ ] **Status:** Waiting on author reply to our comment on line 142.

--- a/tool/TESTING.md
+++ b/tool/TESTING.md
@@ -1,17 +1,24 @@
 # Testing in this Repository
 
-This repository follows automated testing and linting standards for skills to ensure every skill is robust and self-contained.
+This repository follows automated testing and linting standards for skills to
+ensure every skill is robust and self-contained.
 
 ## Implemented Layers
 
 ### Layer 1: SKILL.md (Contract)
-Every skill in this repository has a `SKILL.md` file defining its contract, triggers, and rules.
+
+Every skill in this repository has a `SKILL.md` file defining its contract,
+triggers, and rules.
 
 ### Layer 3: Unit Tests
-We have automated tests to validate skill standards and run unit tests for any deterministic scripts associated with skills.
+
+We have automated tests to validate skill standards and run unit tests for any
+deterministic scripts associated with skills.
 
 ### Layer 8: Skill Linting & Validation
-We use `dart_skills_lint` to verify path hygiene (relative vs. absolute paths) and formatting compliance.
+
+We use `dart_skills_lint` to verify path hygiene (relative vs. absolute paths)
+and formatting compliance.
 
 ## How to Run Tests
 

--- a/tool/bin/generate_cleanup_catalog.dart
+++ b/tool/bin/generate_cleanup_catalog.dart
@@ -164,7 +164,7 @@ int _run(List<String> arguments) {
   final updatedContent = skillContent.replaceRange(
     startIndex,
     endIndex + endTag.length,
-    '$startTag\n$generatedMarkdown\n$endTag',
+    '$startTag\n\n<!-- prettier-ignore-start -->\n\n$generatedMarkdown\n\n<!-- prettier-ignore-end -->\n\n$endTag',
   );
 
   if (validateMode) {

--- a/tool/bin/readme.dart
+++ b/tool/bin/readme.dart
@@ -52,11 +52,12 @@ void main(List<String> arguments) async {
         ..sort((a, b) => p.basename(a.path).compareTo(p.basename(b.path)));
 
   final listBuffer = StringBuffer();
-  listBuffer.writeln('<!-- SKILLS_LIST_START -->');
-  listBuffer.writeln('To install any skill individually:');
+  listBuffer.writeln('<!-- SKILLS_LIST_START -->\n');
+  listBuffer.writeln('To install any skill individually:\n');
   listBuffer.writeln('```bash');
   listBuffer.writeln('npx skills add $repoSlug --skill <skill-name>');
   listBuffer.writeln('```\n');
+  listBuffer.writeln('<!-- prettier-ignore -->');
   listBuffer.writeln('| Skill | Description | Key Features |');
   listBuffer.writeln('|-------|-------------|--------------|');
   for (final dir in skillDirs) {
@@ -94,7 +95,7 @@ void main(List<String> arguments) async {
       '| **[$title](skills/$skillName/SKILL.md)** | $cleanDescription | $cleanFeatures |',
     );
   }
-  listBuffer.write('<!-- SKILLS_LIST_END -->');
+  listBuffer.write('\n<!-- SKILLS_LIST_END -->');
 
   final generatedTable = listBuffer.toString();
 

--- a/tool/data/dart_cleanup_catalog.json
+++ b/tool/data/dart_cleanup_catalog.json
@@ -9,14 +9,14 @@
     "dash_skills": {
       "path": "~/github/kevmoo/dash_skills",
       "cloneUrl": "https://github.com/kevmoo/dash_skills.git",
-      "commitSha": "949bd00b69fc8449c535aeb4f4970c7ec5e21b49",
-      "commitDate": "2026-09-07T18:31:46-07:00"
+      "commitSha": "6c3900555225a113d4dbd89b4cda4b41c72130ae",
+      "commitDate": "2026-09-12T17:38:23-07:00"
     },
     "analytica.dart": {
       "path": "~/github/kevmoo/analytica.dart",
       "cloneUrl": "https://github.com/kevmoo/analytica.dart.git",
-      "commitSha": "1bba4de81a526b3805561227fb1adeed4e3feb45",
-      "commitDate": "2026-08-29T00:10:54-07:00"
+      "commitSha": "0114d16b76df87f7bea27f9b11888518fb787357",
+      "commitDate": "2026-09-12T15:57:20-07:00"
     }
   },
   "categories": [


### PR DESCRIPTION
- Add .prettierrc.json with 80-column prose wrapping.
- Add .github/workflows/markdown.yml check workflow.
- Update tool/bin/readme.dart to emit prettier-ignore for skills table.
- Wrap dart-cleanup catalog in prettier-ignore markers.
- Format all markdown files with prettier.
